### PR TITLE
Install include-cache gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gem 'jekyll'
 gem 'jekyll-redirect-from'  # https://github.com/jekyll/jekyll-redirect-from
 gem 'jekyll-contentblocks'
+gem 'jekyll-include-cache'

--- a/_config.yml
+++ b/_config.yml
@@ -63,6 +63,7 @@ kramdown:
 ## Plugins used by the site
 plugins:
   - jekyll-redirect-from
+  - jekyll-include-cache
 
 # -------------------------- #
 #        Collections         #

--- a/_includes/layout/head.html
+++ b/_includes/layout/head.html
@@ -10,7 +10,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
-<title>{{ page.title }} | {{ site.site_title }}</title>
+<title>{{ include.title }} | {{ site.site_title }}</title>
 
 <meta property="og:title" content="{{ page.title }} | {{ site.site_title }}" />
 <meta property="og:description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,12 +62,12 @@
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PXBN5GK"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-{% include layout/topnav.html %}
+{% include_cached layout/topnav.html %}
 
 <!-- Page Content -->
 <div id="main">
     <div class="sidebar-column">
-        {% include layout/sidebar.html %}
+        {% include_cached layout/sidebar.html %}
     </div>
     <div class="content-column">
         

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-    {% include layout/head.html %}
+    {% include_cached layout/head.html title=page.title %}
 
     // <script>
     //     $(document).ready(function() {

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -47,4 +47,4 @@ layout: default
 
 </div>
 
-{% include layout/footer.html %}
+{% include_cached layout/footer.html %}


### PR DESCRIPTION
This PR adds the `install-cache` gem to the site. This plugin caches include files during builds to reduce the overall build time.

Repo is here: https://github.com/benbalter/jekyll-include-cache