### PR TITLE
Remove Zuora non-sandbox prerequisite

### DIFF
--- a/_saas-integrations/zuora.md
+++ b/_saas-integrations/zuora.md
@@ -1245,8 +1245,7 @@ Connecting your Zuora data to Stitch is a five-step process:
 
 ### Prerequisites
 
-1. **Verify that your Zuora account is a Production account.** At this time, Stitch can't connect to [Sandbox accounts](https://knowledgecenter.zuora.com/BB_Introducing_Z_Business/D_Zuora_Environments).
-2. **Verify that you have Administrator permissions in Zuora.** This is required to create a Zuora user for Stitch.
+- **Verify that you have Administrator permissions in Zuora.** This is required to create a Zuora user for Stitch.
 
 ### Creating a Stitch Zuora User {#create-stitch-zuora-user}
 


### PR DESCRIPTION
Zuora now supports sandbox accounts.

Steps for selecting the account level during setup still need to be added.