### PR TITLE
Clarify Pausing Behavior re: loading

### DIFF
--- a/_account-security/understanding-stitch-billing-replicated-rows.md
+++ b/_account-security/understanding-stitch-billing-replicated-rows.md
@@ -92,3 +92,5 @@ Note that this is only applicable to database integrations and the SaaS [integra
 ### Pause Integrations
 
 If all else fails, you can temporarily pause the integration to keep from going over your row limit.
+
+Note that pausing an integration will prevent the extraction of additional records, while loading will continue for any records that have already been extracted.

--- a/_account-security/understanding-stitch-billing-replicated-rows.md
+++ b/_account-security/understanding-stitch-billing-replicated-rows.md
@@ -93,4 +93,4 @@ Note that this is only applicable to database integrations and the SaaS [integra
 
 If all else fails, you can temporarily pause the integration to keep from going over your row limit.
 
-Note that pausing an integration will prevent the extraction of additional records, while loading will continue for any records that have already been extracted.
+**Note**: Pausing an integration will only prevent the extraction of additional records. Loading will continue for records that have been extracted prior to the pause.


### PR DESCRIPTION
Pausing an integration does not pause the loading process, though it does pause the extraction process. This is a pretty significant caveat and the language added should clarify this behavior.

Added: Note that pausing an integration will prevent the extraction of additional records, while loading will continue for any records that have already been extracted.