### PR TITLE
Freshdesk: Hide unsupported `contacts` table

### DIFF
--- a/_integration-schemas/freshdesk/contacts.md
+++ b/_integration-schemas/freshdesk/contacts.md
@@ -1,5 +1,5 @@
 ---
-tap: "freshdesk"
+# tap: "freshdesk"
 # version:
 
 name: "contacts"


### PR DESCRIPTION
This PR comments out the Freshdesk `contacts` table.

As per [this PR](https://github.com/singer-io/tap-freshdesk/pull/12), we aren't currently supporting replication of this table.