### PR TITLE
Improve Redshift view dependency doc

### DIFF
--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -114,24 +114,6 @@ If you chose this option to resolve an error after a column was split and rename
 
 ### Option 2: Manually Locate & Temporarily Drop Dependent Views {#locate-drop-dependent-views}
 
-1. Using a SQL or command line tool, login to your Redshift database as an administrator. 
-2. The query below is run against tables in the `information_schema` and will find all first-order dependency for the schema noted in the error notification.
-
-   Run the query below, replacing what’s in the `[square brackets]` with the table name:
-
-   ```sql
-   SELECT DISTINCT c_p.oid AS tbloid
-     ,n_p.nspname AS schemaname
-     ,c_p.relname AS NAME
-     ,n_c.nspname AS refbyschemaname
-     ,c_c.relname AS refbyname
-     ,c_c.oid AS viewoid
-   FROM pg_class c_p
-   JOIN pg_depend d_p ON c_p.relfilenode = d_p.refobjid
-   JOIN pg_depend d_c ON d_p.objid = d_c.objid
-   JOIN pg_class c_c ON d_c.refobjid = c_c.relfilenode
-   LEFT JOIN pg_namespace n_p ON c_p.relnamespace = n_p.oid
-   LEFT JOIN pg_namespace n_c ON c_c.relnamespace = n_c.oid
 #### Step 1: Create a View of Tables and Dependencies
 
 {% include note.html content ="You need to have access to the `pg_catalog` schema and its tables and be able to run the `CREATE VIEW` command to complete this step." %}

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -106,7 +106,7 @@ CREATE VIEW sales_orders_view AS
 	WITH NO SCHEMA BINDING;
 ```
 
-Note that you can't update, insert into, or delete from a view. This means that if you want to add or remove columns, you would need to re-create the view.
+**Note**: You can't update, insert into, or delete from a view. This means that if you want to add or remove columns, you need to re-create the view.
 
 If you chose this option to resolve an error after a column was split and renamed, remember to include all the subsequent split columns when you re-create the view. For example: if `sales_order` 'split' into `sales_order__int` and `sales_order__st`, you'd want to include both columns to ensure all values are captured in the view.
 

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -31,7 +31,9 @@ solutions-pros-cons:
 ---
 {% include misc/data-files.html %}
 
-> We were unable to recreate the [view] in your data warehouse with fresh data from the underlying table.
+> ERROR: cannot drop table [schema_name].[table_name] column [column_name] because other objects depend on it
+>
+> Hint: Use DROP ... CASCADE to drop the dependent objects too.
 
 Typically, this error - along with missing views and incorrect data in views - are a result of how Stitch handles altered table structures and views with dependencies in Redshift.
 

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -43,9 +43,9 @@ Typically, this error - along with missing views and incorrect data in views - a
 
 A table's structure can change for a few reasons:
 
-- A new column has been added to the source table.
-- A new column has been added to the table as a result of [column/data type splitting]({{ link.destinations.storage.column-splitting | prepend: site.baseurl }}).
-- A new column has been added to the table as a result of [`VARCHAR` widening]({{ link.destinations.storage.varchar-widening | prepend: site.baseurl }}).
+- A new column has been added to the source table
+- A new column has been added to the table as a result of [column/data type splitting]({{ link.destinations.storage.column-splitting | prepend: site.baseurl }})
+- A new column has been added to the table as a result of [`VARCHAR` widening]({{ link.destinations.storage.varchar-widening | prepend: site.baseurl }})
 
 When a table's structure is changed, dependent views must be ['dropped'](http://docs.aws.amazon.com/redshift/latest/dg/r_DROP_VIEW.html) so Stitch can re-create the underlying table.
 

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -149,7 +149,7 @@ The above command only selects [dependencies with a type](https://www.postgresql
 
 #### Step 2: Query the View to Locate Dependencies
 
-Next, you'll query the `view_dependencies` view to locate the objects you need to drop. If the notification referenced the `closeio.closeio_leads` table, the query would look like this:
+Next, you'll query the `view_dependencies` view you created in Step 1 to locate the objects you need to drop. If the notification referenced the `closeio.closeio_leads` table, the query would look like this:
 
 ```sql
 SELECT source_table_schema,
@@ -161,7 +161,7 @@ SELECT source_table_schema,
    AND source_table_name = 'closeio_leads'
 ```
 
-And in the results, we see:
+And in the results:
 
 | source_table_schema | source_table_name | dependent_view_schema | dependent_view_name   |
 |---------------------|-------------------|-----------------------|-----------------------|

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -47,7 +47,7 @@ A table's structure can change for a few reasons:
 - A new column has been added to the table as a result of [column/data type splitting]({{ link.destinations.storage.column-splitting | prepend: site.baseurl }})
 - A new column has been added to the table as a result of [`VARCHAR` widening]({{ link.destinations.storage.varchar-widening | prepend: site.baseurl }})
 
-When a table's structure is changed, dependent views must be ['dropped'](http://docs.aws.amazon.com/redshift/latest/dg/r_DROP_VIEW.html) so Stitch can re-create the underlying table.
+When a table's structure changes, dependent views must be temporarily [dropped](http://docs.aws.amazon.com/redshift/latest/dg/r_DROP_VIEW.html) so Stitch can re-create the underlying table.
 
 Because we don’t want to affect your work without your say-so, Stitch will not automatically drop views with dependencies.
 


### PR DESCRIPTION
This PR improves the documentation for troubleshooting Redshift view dependency errors:

- Added a more straightforward and user-friendly dependent view query
- Added instructions for querying the view to locate dependencies