### PR TITLE
Add AUTO_SUSPEND to Snowflake setup

### DIFF
--- a/_destinations/snowflake.md
+++ b/_destinations/snowflake.md
@@ -99,9 +99,9 @@ To help you select the warehouse size that fits your needs and budget, check out
 
 ### Automated Warehouse Management {#automated-warehouse-management}
 
-To reduce usage, you can elect to automate the management of your Snowflake warehouse. This means that you can elect to suspend the warehouse when there's no activity after a specified period of time, and then automatically resume when there is. Note that these settings apply to the entire warehouse and not individual clusters.
+To reduce usage, you can elect to automate the management of your Snowflake warehouse. This means that you can elect to suspend the warehouse when there's no activity after a specified period of time, and then automatically resume when there is. **Note**: These settings apply to the entire warehouse and not individual clusters.
 
-Enabling these settings depends on your workload and availability needs. [Learn more about the Auto Suspend and Auto Resume features here](https://docs.snowflake.net/manuals/user-guide/warehouses-considerations.html#automating-warehouse-management){:target="_blank"}.
+Enabling these settings depends on your workload and availability needs. [Learn more about the Auto Suspend and Auto Resume features here](https://docs.snowflake.net/manuals/user-guide/warehouses-considerations.html#automating-warehouse-management){:target="_blank"}. If you use [our instructions]({{ link.destinations.setup.snowflake | prepend: site.baseurl }}) for creating and setting up a Snowflake warehouse, we strongly recommend enabling the Auto Suspend feature to prevent unanticipated credit usage.
 
 Additionally, note that Stitch will only ever impact your Snowflake usage when loading data.
 {% endcontentfor %}

--- a/_destinations/snowflake/setup/connecting-snowflake.md
+++ b/_destinations/snowflake/setup/connecting-snowflake.md
@@ -99,9 +99,9 @@ setup-steps:
 
              ```sql
              GRANT ALL ON WAREHOUSE [warehouse] TO ROLE [stitch_role];
-
-             // Grants all privileges except ownership
              ```
+
+             **Note**: This will grant all privileges **except** ownership.
 
           4. [Grant database privileges to the Stitch role](https://docs.snowflake.net/manuals/user-guide/security-access-control.html#database-privileges){:target="_blank"}, using the name of the database you created for Stitch:
 
@@ -109,7 +109,7 @@ setup-steps:
              GRANT ALL ON DATABASE [stitch_database] TO ROLE [stitch_role];
              ```
 
-             Note that the privileges granted in steps 3 and 4 of this section will only apply to the warehouse and database you specify in the above queries. The Stitch user will not be granted privileges to any other warehouse or database unless you elect to do so.
+             **Note**: The privileges granted in steps 3 and 4 of this section will only apply to the warehouse and database you specify in the above queries. The Stitch user will not be granted privileges to any other warehouse or database unless you elect to do so.
 
           5. Create the Stitch user and grant the Stitch role to the user:
 

--- a/_destinations/snowflake/setup/connecting-snowflake.md
+++ b/_destinations/snowflake/setup/connecting-snowflake.md
@@ -39,15 +39,32 @@ setup-steps:
 
       1. Log into your Snowflake account using a web browser or a SQL client.
       2. If you log in via a web browser, click the **Worksheet** icon at the top of the page.
-      3. Create the warehouse:
+      3. Create the warehouse by running this command, changing the`[square_brackets]` to the values you want:
 
          ```sql
          CREATE WAREHOUSE [stitch_warehouse]
-          WITH
-          WAREHOUSE_SIZE = '[size]' // xsmall, small, medium, large, xlarge, xxlarge, xxxlarge
+         WITH
+         AUTO_SUSPEND = [time_in_seconds]
+         AUTO_RESUME = TRUE|FALSE
+         WAREHOUSE_SIZE = [size];
          ```
 
-      Additional warehouse parameters are available, including settings for Auto Suspend and Auto Resume. [Check out Snowflake's documentation for detailed explanations.](https://docs.snowflake.net/manuals/sql-reference/sql/create-warehouse.html)
+         The parameters in this command define the following:
+
+            - **AUTO_SUSPEND**: Specifies the number of seconds of inactivity after which a warehouse is automatically suspended.
+
+               {% capture auto-suspend-notice %}
+               Make sure the `auto_suspend` parameter is included in the warehouse creation command. This parameter determines how many seconds of inactivity must pass before a warehouse is automatically suspended.<br><br>
+
+               If this parameter isn't included, the default will be `NULL`, meaning that the warehouse will never automatically suspend. As a result, Snowflake credits will continue to be consumed even if the warehouse is inactive.
+               {% endcapture %}
+               {% include important.html content=auto-suspend-notice %}
+            - **AUTO_RESUME**: If `TRUE`, the warehouse will be automatically resumed when accessed by a SQL statement. If `FALSE`, the warehouse will only start again when explicitly resumed through the Snowflake web interface or using `ALTER WAREHOUSE`.
+            - **WAREHOUSE_SIZE**: Specifies the size of the warehouse to create. Accepted values are `XSMALL`, `SMALL`, `MEDIUM`, `LARGE`, `XLARGE`, `XXLARGE`, `XXXXLARGE`, and `XXXXLARGE`.
+
+               The default is `XSMALL`.
+
+         Additional warehouse parameters are available. [Check out Snowflake's documentation for detailed explanations.](https://docs.snowflake.net/manuals/sql-reference/sql/create-warehouse.html)
 
   - title: "Create a Stitch Database & Database User"
     anchor: "create-database-and-user"


### PR DESCRIPTION
This PR adds the `AUTO_SUSPEND` parameter to the creation command section of the Snowflake setup doc. If left undefined, the value will default to `NULL`, meaning the warehouse will **never** suspend (even when inactive) and credits will be rapidly consumed.