### PR TITLE
Salesforce: Update IP whitelisting instructions

### DIFF
--- a/_saas-integrations/salesforce/salesforce-latest.md
+++ b/_saas-integrations/salesforce/salesforce-latest.md
@@ -58,7 +58,9 @@ setup-steps:
     content: |
       Depending on how your Salesforce instance is set up, you may need to whitelist Stitch's IP addresses. In Salesforce, this is referred to as "setting trusted IPs".
 
-      [The instructions in this Salesforce article](https://help.salesforce.com/articleView?id=security_networkaccess.htm&type=0) will walk you through how to do this in Salesforce; below are all the Stitch IP addresses that must be added to the trusted list:
+      [The instructions in this Salesforce article](https://help.salesforce.com/articleView?id=security_networkaccess.htm&type=0) will walk you through how to do this in Salesforce. **Note**: Because these are exact IP addresses and not ranges, the same IP address must be entered in the **Start IP Address** and **End IP Address** fields in Salesforce.
+
+      Add the following IP addresses to the trusted list:
 
       {% for ip-address in ip-addresses %}
       - {{ ip-address.ip }}


### PR DESCRIPTION
This PR adds clarification to the IP whitelisting section of the Salesforce documentation. In Salesforce, the UI asks for an IP range and not single IP addresses. 

To add exact IPs to the trusted list, users must enter the same IP in the Start and End fields. This changes adds that explicit instruction.