### PR TITLE
Add deleted data option to FB Ads

### DIFF
--- a/_integration-schemas/facebook-ads/adcreative.md
+++ b/_integration-schemas/facebook-ads/adcreative.md
@@ -8,6 +8,8 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `adcreative` table contains info about the creatives used in ads in your Facebook Ads account.
 
+  **This is a Core Object table**.
+
 replication-method: "Full Table"
 attribution-window: true
 api-method:

--- a/_integration-schemas/facebook-ads/ads.md
+++ b/_integration-schemas/facebook-ads/ads.md
@@ -8,10 +8,15 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `ads` table contains info about the ads in your Facebook Ads account.
 
+  **This is a Core Object table**.
+
   #### updated_time & Querying
   Because this table uses `updated_time` as part of the Primary Key, query results might return various versions of the same adgroup.
 
   To reflect the latest state of the adgroup, use the latest `updated_time` timestamp.
+
+  #### Deleted Ads
+  If the **Include data from deleted campaigns, ads, and adsets** box in the integration's settings is checked, this table will include data for deleted ads.
   
 replication-method: "Incremental"
 attribution-window: true

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -8,6 +8,8 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `ads_insights` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics.
 
+  **Note**: Data for deleted ads, adsets, and campaigns will not appear in this table even if the option in the integration's settings is enabled.
+
   #### Segmented ads_insights Data
 
   To analyze data that's been segmented by various characteristics, consider tracking some of the other `ads_insights` tables in this integration. The following tables contain the same fields as this one (`ads_insights`), but include additional dimensions to segment the data:

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -8,7 +8,9 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `ads_insights_age_and_gender` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics, segmented by age and gender.
 
-  **Note:** This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of `age` and `gender`.
+  This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of `age` and `gender`.
+  
+  Data for deleted ads, adsets, and campaigns will not appear in this table even if the option in the integration's settings is enabled.
 
 replication-method: "Incremental"
 attribution-window: true

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -8,7 +8,9 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `ads_insights_country` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics, segmented by country.
 
-  **Note:** This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of `country`.
+  This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of `country`.
+
+  Data for deleted ads, adsets, and campaigns will not appear in this table even if the option in the integration's settings is enabled.
 
 replication-method: "Incremental"
 attribution-window: true

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -7,12 +7,14 @@ doc-link: https://developers.facebook.com/docs/marketing-api/insights/fields/
 singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_facebook/schemas/ads_insights_platform_and_device.json
 description: |
   The `ads_insights_country` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics, segmented by publisher platform, platform position, and device.
+  
+  This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of the following fields:
 
-  **Note:** This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of the following fields:
-
-  - `publisher_platform`
-  - `platform_position`
-  - `impression_device`
+     - `publisher_platform`
+     - `platform_position`
+     - `impression_device`
+  
+  Data for deleted ads, adsets, and campaigns will not appear in this table even if the option in the integration's settings is enabled.
 
 replication-method: "Incremental"
 attribution-window: true

--- a/_integration-schemas/facebook-ads/adsets.md
+++ b/_integration-schemas/facebook-ads/adsets.md
@@ -8,11 +8,16 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `adsets` table contains info about the Ad Sets in your Facebook Ads account.
 
+  **This is a Core Object table**.
+
   #### updated_time & Querying
 
   Because this table uses `updated_time` as part of the Primary Key, query results might return various versions of the same adgroup. 
 
   To reflect the latest state of the adgroup, use the latest `updated_time` timestamp.
+
+  #### Deleted Adsets
+  If the **Include data from deleted campaigns, ads, and adsets** box in the integration's settings is checked, this table will include data for deleted adsets.
   
 replication-method: "Incremental"
 attribution-window: true

--- a/_integration-schemas/facebook-ads/campaigns.md
+++ b/_integration-schemas/facebook-ads/campaigns.md
@@ -8,7 +8,12 @@ singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_faceboo
 description: |
   The `campaigns` table contains info about the campaigns in your Facebook Ads account.
 
-  Facebook defines campaigns as _"a grouping of ad sets organized by the same business objective."_ 
+  **This is a Core Object table**.
+
+  Facebook defines campaigns as _"a grouping of ad sets organized by the same business objective."_
+
+  #### Deleted Campaigns
+  If the **Include data from deleted campaigns, ads, and adsets** box in the integration's settings is checked, this table will include data for deleted campaigns.
 
 replication-method: "Incremental"
 attribution-window: true

--- a/_saas-integrations/facebook-ads/facebook-ads-latest.md
+++ b/_saas-integrations/facebook-ads/facebook-ads-latest.md
@@ -62,6 +62,8 @@ requirements-list:
 
 setup-steps:
   - title: "add integration"
+    content: |
+      4. Check the **Include data from deleted campaigns, ads, and adsets** box to have Stitch replicate data for these deleted objects. **Note**: Data for deleted campaigns, ads, and adsets will be included only in [**Core Object**](#core-objects-and-insights-tables) tables.
   - title: "historical sync"
   - title: "replication frequency"
   - title: "Authorize Stitch to Access Facebook Ads"

--- a/_saas-integrations/facebook-ads/facebook-ads-latest.md
+++ b/_saas-integrations/facebook-ads/facebook-ads-latest.md
@@ -100,6 +100,13 @@ schema-sections:
       Facebook Ads' campaign structure contains three levels: **campaigns, ad sets, and ads**. There is also a fourth level for developers called **creatives**.
 
       To learn more about how Facebook Ads data is structured, we recommend checking out their [API guide](https://developers.facebook.com/docs/marketing-api/buying-api).
+  - title: "Core Objects and Insights"
+    anchor: "core-objects-and-insights-tables"
+    content: |
+      There are two types of tables in Stitch’s {{ integration.display_name }} integration: Core Object and Report.
+
+      - **Core Object** tables contain foundational data that's useful for analysis. These are the [`adcreative`](#adcreative), [`ads`](#ads), [`adsets`](#adsets), and [`campaigns`](#campaigns) tables.
+      - **Insights** tables contain performance data for every campaign/adset/ad combination, segmented by day and demographics specific to each table. For example: The [`ads_insights_age_and_gender`](#ads_insights_age_and_gender) table is segmented by day, age, and gender.
 
 ---
 {% assign integration = page %}


### PR DESCRIPTION
This PR:

- Adds the new `include deleted data for campaigns, adsets, and ads` field to the Facebook Ads setup instructions
- Adds Core Object and Insight terms to differentiate between the table types in the integration