### PR TITLE
Update Harvest status

### DIFF
--- a/_saas-integrations/harvest/harvest-latest.md
+++ b/_saas-integrations/harvest/harvest-latest.md
@@ -28,7 +28,7 @@ certified: false # Community-supported integration
 
 historical: "1 year"
 frequency: "30 minutes"
-tier: "Premium"
+tier: "Free"
 status-url: http://harveststatus.com/
 icon: /images/integrations/icons/harvest.svg
 whitelist:


### PR DESCRIPTION
This PR corrects the Harvest integration's status from `premium` to `free`.