### PR TITLE
Mixpanel: Export and Engage have nested data

### DIFF
--- a/_saas-integrations/mixpanel.md
+++ b/_saas-integrations/mixpanel.md
@@ -81,10 +81,10 @@ tables:
       Because of how Mixpanel's API is designed, this table can only be queried by day. This means that every time Stitch runs a replication job for a Mixpanel integration, **the past day's worth of data will be replicated for this table.**
     replication-method: "Incremental"
     primary-key: "event:time:distinct_id:_sdc_record_hash"
-    nested-structures: false
+    nested-structures: true
     attributes:
       - name: distinct_id
-      - name: event
+      - name: event *
       - name: mp_country_code
       - name: mp_lib
       - name: mp_reserved_browser

--- a/_saas-integrations/mixpanel.md
+++ b/_saas-integrations/mixpanel.md
@@ -63,7 +63,7 @@ tables:
     notes: 
     replication-method: "Full Table"
     primary-key: "distinct_id"
-    nested-structures: false
+    nested-structures: true
     attributes:
       - name: distinct_id
       - name: created

--- a/_saas-integrations/mixpanel.md
+++ b/_saas-integrations/mixpanel.md
@@ -84,7 +84,7 @@ tables:
     nested-structures: true
     attributes:
       - name: distinct_id
-      - name: event *
+      - name: event
       - name: mp_country_code
       - name: mp_lib
       - name: mp_reserved_browser


### PR DESCRIPTION
The response from [Mixpanel API](https://mixpanel.com/help/reference/exporting-raw-data#export-api-reference) includes an object that includes all of the attributes of the given event. This results in flattening of records.

See:

"One event per line, sorted by increasing timestamp. *Each line is a valid JSON object* although the return itself is valid JSON but instead JSONL."