### PR TITLE
HubSpot: Add `deal_pipelines` table

### DIFF
--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -1,0 +1,63 @@
+---
+tap: "hubspot"
+version: "1.0"
+
+name: "deal_pipelines"
+doc-link: https://developers.hubspot.com/docs/methods/deal-pipelines/overview
+singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/schemas/deal_pipelines.json
+description: |
+  The `deal_pipelines` table contains info about the 'deal stage' and 'pipeline' properties.
+
+notes:
+
+replication-method: "Full Table"
+api-method:
+  name: getAllDealPipelines
+  doc-link: https://developers.hubspot.com/docs/methods/deal-pipelines/get-all-deal-pipelines
+
+attributes:
+## Primary Key
+  - name: "pipelineId"
+    type: "string"
+    primary-key: true
+    description: "The internal ID of the pipeline"
+
+  - name: "stages"
+    type: "array"
+    description: "A list of stages for this specific pipeline."
+    array-attributes:
+      - name: "stageID"
+        type: "string"
+        description: "The internal ID of the stage."
+
+      - name: "label"
+        type: "string"
+        description: "The human-readable label for the stage."
+
+      - name: "probability"
+        type: "number"
+        description: "The probability that the deal will close."
+        
+      - name: "active"
+        type: "boolean"
+        description: "Indicates if the stage is currently in use."
+        
+      - name: "displayOrder"
+        type: "integer"
+        description: "The order in which the stage appears in HubSpot."
+        
+      - name: "closedWon"
+        type: "boolean"
+        description: "Indicates if this stage marks a deal as closed won."        
+        
+  - name: “label”
+    type: “string”
+    description: “The human-readable label for the pipeline”
+
+   - name: “active”
+    type: “boolean”
+    description: “Indicates if the pipeline is currently in use”
+    
+   - name: “displayOrder”
+    type: “integer”
+    description: “The order in which the pipeline appears in HubSpot”    

--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -6,9 +6,7 @@ name: "deal_pipelines"
 doc-link: https://developers.hubspot.com/docs/methods/deal-pipelines/overview
 singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/schemas/deal_pipelines.json
 description: |
-  The `deal_pipelines` table contains info about the 'deal stage' and 'pipeline' properties.
-
-notes:
+  The `deal_pipelines` table contains info about the `deal stage` and `pipeline` properties.
 
 replication-method: "Full Table"
 api-method:
@@ -26,7 +24,7 @@ attributes:
     type: "array"
     description: "A list of stages for this specific pipeline."
     array-attributes:
-      - name: "stageID"
+      - name: "stageId"
         type: "string"
         description: "The internal ID of the stage."
 
@@ -37,15 +35,15 @@ attributes:
       - name: "probability"
         type: "number"
         description: "The probability that the deal will close."
-        
+
       - name: "active"
         type: "boolean"
         description: "Indicates if the stage is currently in use."
-        
+
       - name: "displayOrder"
         type: "integer"
         description: "The order in which the stage appears in HubSpot."
-        
+
       - name: "closedWon"
         type: "boolean"
         description: "Indicates if this stage marks a deal as closed won."        

--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -58,4 +58,4 @@ attributes:
     
    - name: “displayOrder”
     type: “integer”
-    description: “The order in which the pipeline appears in HubSpot”    
+    description: “The order in which the pipeline appears in HubSpot”    ---

--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -47,15 +47,16 @@ attributes:
       - name: "closedWon"
         type: "boolean"
         description: "Indicates if this stage marks a deal as closed won."        
-        
-  - name: “label”
-    type: “string”
-    description: “The human-readable label for the pipeline”
 
-   - name: “active”
-    type: “boolean”
-    description: “Indicates if the pipeline is currently in use”
-    
-   - name: “displayOrder”
-    type: “integer”
-    description: “The order in which the pipeline appears in HubSpot”    ---
+  - name: "label"
+    type: "string"
+    description: "The human-readable label for the pipeline."
+
+  - name: "active"
+    type: "boolean"
+    description: "Indicates if the pipeline is currently in use."
+
+  - name: "displayOrder"
+    type: "integer"
+    description: "The order in which the pipeline appears in HubSpot."
+---

--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -20,7 +20,7 @@ attributes:
   - name: "pipelineId"
     type: "string"
     primary-key: true
-    description: "The internal ID of the pipeline"
+    description: "The internal ID of the pipeline."
 
   - name: "stages"
     type: "array"


### PR DESCRIPTION
This will add the deal_pipelines table to the schema documention for HubSpot.

https://github.com/singer-io/tap-hubspot/commit/da1b444de55186ddd030f73c5a6b31e7204900fc

This list excludes the undocumented `staticDefault` field: https://github.com/singer-io/tap-hubspot/pull/54/commits/804c6ec4171b298e064a6c9690f270243d4f4130

   - name: “staticDefault”
    type: “Boolean”
    description: “This field is not listed in HubSpot's API documentation, but is returned in results from the `/deals/v1/pipelines`
endpoint.”