### PR TITLE
Update Schema of mixpanel_export

### DIFF
--- a/_saas-integrations/mixpanel.md
+++ b/_saas-integrations/mixpanel.md
@@ -80,7 +80,7 @@ tables:
       ### Replication
       Because of how Mixpanel's API is designed, this table can only be queried by day. This means that every time Stitch runs a replication job for a Mixpanel integration, **the past day's worth of data will be replicated for this table.**
     replication-method: "Incremental"
-    primary-key: "event:time:distinct_id:_sdc_record_hash"
+    primary-key: "event:time:distinct_id:_rjm_record_hash"
     nested-structures: false
     attributes:
       - name: distinct_id
@@ -99,7 +99,7 @@ tables:
       - name: mp_reserved_screen_height
       - name: mp_reserved_screen_width
       - name: time
-      - name: _sdc_record_hash
+      - name: _rjm_record_hash
 
 ## Funnels
   - name: "mixpanel_funnels"

--- a/_saas-integrations/mixpanel.md
+++ b/_saas-integrations/mixpanel.md
@@ -94,7 +94,7 @@ tables:
       - name: mp_reserved_initial_referrer
       - name: mp_reserved_initial_referring_domain
       - name: mp_reserved_lib_version
-      - name: mp_reserved_reserved_os
+      - name: mp_reserved_os
       - name: mp_reserved_region
       - name: mp_reserved_screen_height
       - name: mp_reserved_screen_width


### PR DESCRIPTION
We listed the field as _sdc_record_hash, though this field is loaded as _rjm_record_hash.