### PR TITLE
BigQuery: Add EU support

### DIFF
--- a/_data/sidebars/stitchnav.yml
+++ b/_data/sidebars/stitchnav.yml
@@ -97,6 +97,9 @@ all-docs:
         - title: "Connect to Stitch"
           url: "{{ link.destinations.setup.bigquery }}"
 
+        - title: "Change BigQuery Location"
+          url: "{{ link.destinations.overviews.switch-bigquery-destination }}"
+
     - title: Panoply
       subsections:
         - title: "Overview"

--- a/_data/ui/change-destinations-page.yml
+++ b/_data/ui/change-destinations-page.yml
@@ -6,9 +6,27 @@
 #   Historical Data Fields   #
 # -------------------------- #
 
-historical-data:
-  - field: "Replicate new data only"
-    copy: "Stitch will pick up where it left off and only replicate **new** data to your new destination."
+default-fields:
+  new-data-only: &new-data-only "**Replicate new data only**"
+  historical-data: &historical-data "**Replicate historical data**"
 
-  - field: "Replicate historical data"
-    copy: "Stitch will clear all Replication Key values, queue a **full re-sync** of your integrations' data, and replicate all historical data to your new destination. For SaaS integrations, Stitch will replicate data beginning with the start date currently listed in the integration's settings."
+default-copy:
+  new-data-only: &new-data-only-copy |
+    Stitch will pick up where it left off and only replicate **new** data to your new destination.
+  historical-data-copy: &historical-data-copy |
+    Stitch will clear all Replication Key values, queue a **full re-replication** of your integrations' data, and replicate all historical data to your new destination. For SaaS integrations, Stitch will replicate data beginning with the **Start Date** currently listed in the integration's settings.
+
+default-historical-data:
+  - field: *new-data-only
+    copy: *new-data-only-copy
+
+  - field: *historical-data
+    copy: *historical-data-copy
+
+bigquery-historical-data:
+  - field: *new-data-only
+    copy: |
+      Select this option if you manually transferred your historical data or you don't need to re-replicate historical data. Stitch will pick up where it left off and only replicate **new** data to the new {{ destination.display_name }} destination.
+
+  - field: *historical-data
+    copy: *historical-data-copy

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -46,6 +46,8 @@ destinations:
   overviews:
     choose-destination: /destinations/choosing-a-stitch-destination
     compatibility: /destinations/destination-integration-compatibility
+    switch-destination: /destinations/switching-destinations
+    switch-bigquery-destination: /destinations/bigquery/changing-google-bigquery-destination-data-locations
 
     amazon-s3: /destinations/amazon-s3/
     bigquery: /destinations/bigquery/

--- a/_destinations/bigquery.md
+++ b/_destinations/bigquery.md
@@ -94,7 +94,7 @@ sections:
     content: |
       To set up {{ destination.display_name }}, Stitch requires:
 
-      1. **A user with access to an existing [Google Cloud Platform project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**. Stitch won't be able to create one for you.
+      1. **A user with full access to an existing [Google Cloud Platform project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**. Stitch won't be able to create one for you.
       2. **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions.
       2. **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
 

--- a/_destinations/bigquery.md
+++ b/_destinations/bigquery.md
@@ -94,13 +94,9 @@ sections:
     content: |
       To set up {{ destination.display_name }}, Stitch requires:
 
-      1. **A user that:**
-         - Has access to a [Google Cloud Platform project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}
-         - Has access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"}
-         - Has Google Cloud Storage (GCS) privileges
-      2. **A United States (US)-based BigQuery instance.** Currently, Stitch can only create US-based GCS buckets, which are required for the replication process. US-based buckets are only compatible with US-based BigQuery instances.
-
-         This means that instances based in other regions - for example, the EU - will not currently work with Stitch's {{ destination.display_name }} destination. If you're interested in Stitch supporting this feature, [please let us know](mailto:{{ site.support }}).
+      1. **A user with access to an existing [Google Cloud Platform project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**. Stitch won't be able to create one for you.
+      2. **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions.
+      2. **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
 
       **[Spin up a {{ destination.display_name }} data warehouse]({{ link.destinations.setup.bigquery | prepend: site.baseurl }})**
 

--- a/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
+++ b/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
@@ -79,11 +79,13 @@ setup-steps:
          - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
          - **Offline Access** - To continuously load data, Stitch requires offline access. This is so the authorization token generated during setup process can be used for more than an hour after the initial auth.
       6. To grant access, click the **Authorize** button.
-      7. After you sign into Google and grant Stitch access, you'll be prompted to select a Project.
-      8. Select the Project you created in step 2 from the drop-down menu.
-      9. Click **Finish Setup**.
-
-      If the connection is successful, a *Success!* message will display at the top of the screen.
+      7. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
+         Fill in the fields that display: 
+            - **Google Cloud Project**: From the dropdown, select the project you created in [Step 2](#create-gcp-project-enable-billing).
+            - **Google Cloud Storage Location**: From the dropdown, select the location where data should be stored:
+                - **US**: Data will be stored in the United States
+                - **EU**: Data will be stored in Europe
+      8. Click **Finish Setup**.
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type","bigquery" | first %}

--- a/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
+++ b/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
@@ -15,39 +15,33 @@ type: "bigquery"
 
 requirements-list:
   - item: |
-      **To have full access to a GCP project.** Stitch requires this permission to create datasets and load data into BigQuery.
+      **A user with full access to an existing [Google Cloud Platform (GCP) project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**. Stitch won't be able to create one for you.
   - item: |
-      **Admin permissions to a BigQuery instance that:**
-
-      - **Is based in the United States (US).** Currently, Stitch can only create US-based Google Cloud Storage (GCS) buckets, which are required for the replication process. US-based buckets are only compatible with US-based BigQuery instances.
-
-        This means that instances based in other regions - for example, the EU - will not currently work with Stitch's {{ destination.display_name }} destination. If you're interested in Stitch supporting this feature, [please let us know](mailto:{{ site.support }}).
-
-      - **Has billing info (a credit card) attached to it.** Note that even if you're using BigQuery's free trial option, billing must still be enabled or Stitch will encounter issues with loading data into your data warehouse. [Instructions for setting up and connecting a billing account to a BigQuery instance can be found here.]({{ destination.enable-billing }}){:target="_blank"}
+      **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions. Stitch requires these permissions to [create and use a GCS bucket](https://cloud.google.com/storage/docs/access-control/bucket-level-iam){:target="_blank"} to load replicated data into BigQuery.
   - item: |
-      **Storage Admin permissions for GCS**. Stitch requires these permissions to [create and use a GCS bucket](https://cloud.google.com/storage/docs/access-control/bucket-level-iam){:target="_blank"} to load replicated data into BigQuery.
+      **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
 
 # -------------------------- #
 #     Setup Instructions     #
 # -------------------------- #
 
 setup-steps:
-  - title: "Create a GCP Account"
+  - title: "Create a GCP account"
     anchor: "create-gcp-account"
     content: |
       This one's easy. Simply [sign up here]({{ destination.sign-up }}) and you'll receive a $300 credit.
 
-  - title: "Create a GCP Project & Enable Billing"
+  - title: "Create a GCP project and enable billing"
     anchor: "create-gcp-project-enable-billing"
     content: |
-      Next, create a new Project to house your BigQuery data warehouse by following [these instructions]({{ destination.setup-project }}).
+      Next, create a new GCP project to house your BigQuery data warehouse by following [these instructions]({{ destination.setup-project }}).
 
-      **Be sure to enable billing for the account, even if you're using the free trial option.** If billing isn't enabled, Stitch will encounter issues when loading data into your data warehouse.
+      **Be sure to enable billing for the account and attach a credit card, even if you're using the free trial option.** If billing isn't enabled, Stitch will encounter issues when loading data into your data warehouse.
 
-  - title: "Grant User Permissions"
+  - title: "Grant user permissions"
     anchor: "grant-user-permissions"
     content: |
-      {% include layout/inline_image.html type="right" file="destinations/bigquery-dashboard-project-info.png" alt="The Project Info box on the GCP Platform Dashboard page." max-width="250px" %}After the Project has been created, **open the Project in the GCP console**. You can do this by either:
+      {% include layout/inline_image.html type="right" file="destinations/bigquery-dashboard-project-info.png" alt="The project Info box on the GCP Platform Dashboard page." max-width="250px" %}After the project has been created, pen the project in the GCP console. You can do this by either:
 
       - Clicking **Manage Project Settings** in the **Project Info** box on the dashboard page, as seen to the right.
 
@@ -55,13 +49,15 @@ setup-steps:
 
       {% include layout/inline_image.html type="right" file="destinations/bigquery-user-permissions.gif" alt="Assigning BigQuery Admin & Storage Admin permissions to a GCP user." max-width="425px" %}
 
-      In the page that displays, click the **IAM** option in the menu on the left side of the page. This will display a page of all the members that have access to the Project.
+      In the page that displays, click the **IAM** option in the menu on the left side of the page. This will display a page of all the members that have access to the project.
 
       1. In the list, locate the user you want to use to connect BigQuery to Stitch.
       2. Click the **Role(s)** drop-down in the row for that user.
       3. Select the **BigQuery** option and click **BigQuery Admin**.
       4. Next, select the **Storage** option and click **Storage Admin**.
       5. Click **Save.**
+
+      {% include note.html content="Even if the user has Owner permissions, you must still grant the BigQuery Admin and Storage Admin permissions to the user. Stitch will encounter loading errors otherwise." %}
 
   - title: "Authenticate with Google"
     anchor: "authenticate-with-google"
@@ -77,7 +73,7 @@ setup-steps:
          - **Full Access to BigQuery** - Stitch requires full access to be able to create datasets and load data into BigQuery.
          - **Read-Only Access to Projects** - Stitch requires read-only access to projects to allow you to select a project to use during the BigQuery setup process.
          - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
-         - **Offline Access** - To continuously load data, Stitch requires offline access. This is so the authorization token generated during setup process can be used for more than an hour after the initial auth.
+         - **Offline Access** - To continuously load data, Stitch requires offline access. This allows the authorization token generated during setup process to be used for more than an hour after the initial authentication takes place.
       6. To grant access, click the **Authorize** button.
       7. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
          Fill in the fields that display: 

--- a/_destinations/bigquery/switching-location-of-google-bigquery.md
+++ b/_destinations/bigquery/switching-location-of-google-bigquery.md
@@ -1,0 +1,102 @@
+---
+title: Change the Location of a Google BigQuery Destination
+permalink: /destinations/bigquery/changing-google-bigquery-destination-data-locations
+tags: [bigquery_destination]
+keywords: bigquery, google bigquery data warehouse, bigquery data warehouse, bigquery etl, etl to bigquery, bigquery destination
+summary: "Change the location of your Google BigQuery destination."
+toc: true
+layout: destination
+display_name: "BigQuery"
+type: "bigquery"
+---
+{% assign destination = site.destinations | where:"type","bigquery" | first %}
+{% assign page-settings = site.data.ui.change-destinations-page %}
+{% include misc/data-files.html %}
+
+Need to change the location in which {{ destination.display_name }} stores your data? Using Stitch's Destination Change feature, you can delete the current destination and connect a new one with the desired data storage location.
+
+---
+
+## Considerations
+
+Here's what you need to know to ensure a smooth switch:
+
+- **Your integrations will be paused.** After the switch is complete, you'll need to manually unpause the integrations you'd like to resume.
+
+- **Some webhook data may be lost during this process**. Due to their continuous, real-time nature, some webhook data may be lost during the switch.
+
+- **Historical data from webhook-based integrations must be either manually backfilled or replayed**. Some webhook providers - such as Segment - allow customers on certain plans to ‘replay’ their historical data. This feature varies from provider to provider and may not always be available.
+
+   If you don’t have the ability to replay historical webhook data, then it must be manually backfilled after the switch is complete.
+
+- **We won’t delete or transfer any data from your current {{ destination.display_name }} destination**. Depending on your needs, how historical data is imported into the new instance may vary. See the next section for details.
+
+---
+
+## Step 1: Select a historical data setting {#select-historical-data-setting}
+
+If you need historical data in the new destination, you’ll need to either manually transfer your historical data or queue a historical replication job.
+
+- **Manually transfer historical data**: To accomplish this, you can use Google's UI to import the existing datasets into the new {{ destination.display_name }} instance. Ensure that all dataset names remain the same during the transfer, or loading errors may occur.
+
+   **Complete the historical transfer before continuing.**
+
+- **Queue a historical replication job**: Initializing a historical replication will re-replicate all historical data from your integrations. For SaaS integrations, Stitch will replicate data beginning with the **Start Date** currently in the integration's settings.
+
+### Define the setting
+
+1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
+2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
+3. In the **Historical Data** section, select how you want data to be replicated to the new destination: 
+   {% for field in page-settings.bigquery-historical-data %}
+   - {{ field.field }}: {{ field.copy | flatify }}
+   {% endfor %}
+
+---
+
+## Step 2: Delete the current destination {#delete-current-bigquery-destination}
+
+1. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
+2. To complete the switch, Stitch must delete your current destination configuration. **Note**: This will not delete data in the destination itself - it only clears this destination's settings from Stitch.
+
+   To continue with the switch, click **OK** to delete the current destination settings.
+
+---
+
+## Step 3: Connect the new {{ destination.display_name }} destination {#connect-new-bigquery-destination}
+
+{% capture permissions %}
+**Requirements for connecting {{ destination.display_name }}**<br><br>
+
+1. **A user with full access to an existing [Google Cloud Platform (GCP) project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**.<br>
+
+2. **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions. Stitch requires these permissions to [create and use a GCS bucket](https://cloud.google.com/storage/docs/access-control/bucket-level-iam){:target="_blank"} to load replicated data into BigQuery.<br>
+
+3. **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
+{% endcapture %}
+
+{% include important.html content=permissions %}
+
+1. On the next page, click the **{{ destination.display_name }}** icon.
+2. Click **Sign in with Google**.
+3. If you aren't already signed into your Google account, you'll be prompted for your credentials.
+4. After you sign in, you'll see a list of the permissions requested by Stitch:
+     - **Read/Write Access to Google Cloud Storage** - Stitch requires Read/Write access to create and use a GCS bucket to load replicated data into BigQuery.
+     - **Full Access to BigQuery** - Stitch requires full access to be able to create datasets and load data into BigQuery.
+     - **Read-Only Access to Projects** - Stitch requires read-only access to projects to allow you to select a project to use during the BigQuery setup process.
+     - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
+     - **Offline Access** - To continuously load data, Stitch requires offline access. This allows the authorization token generated during setup process to be used for more than an hour after the initial authentication takes place.
+5. To grant access, click the **Authorize** button.
+6. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
+   Fill in the fields that display:
+      - **Google Cloud Project**: From the dropdown, select the project you want to connect to Stitch.
+      - **Google Cloud Storage Location**: From the dropdown, select the new location you want to use.
+7. Click **Finish Setup**.
+
+---
+
+## Step 4: Unpause integrations {#unpause-integrations}
+
+After you've successfully connected the new {{ destination.display_name }} destination, un-pause your integrations.
+
+Your data will begin replicating according to the historical data option selected in Step 1.

--- a/_destinations/switching-stitch-destinations.md
+++ b/_destinations/switching-stitch-destinations.md
@@ -51,8 +51,8 @@ Here's what you need to know to ensure a smooth switch:
 1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
 2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
 3. In the **Historical Data** section, select how you want data to be replicated to the new destination:
-   {% for field in page-settings.historical-data %}
-   - **{{ field.field }}**: {{ field.copy }}
+   {% for field in page-settings.default-historical-data %}
+   - {{ field.field }}: {{ field.copy | flatify }}
    {% endfor %}
 4. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
 5. To complete the switch, Stitch must delete your current destination configuration. **Note that this will not delete data in the destination itself** - it only clears this destination's settings from Stitch.


### PR DESCRIPTION
This PR adds documentation for BigQuery EU support.

- Setup instructions now include info about selecting a GCS location during setup
- Lists of required BQ permissions no longer list the US requirement
- New guide for deleting/adding BQ destinations in order to change location