### PR TITLE
HubSpot: Correct `workflows` version

### DIFF
--- a/_integration-schemas/hubspot/v01-03-2017/workflows.md
+++ b/_integration-schemas/hubspot/v01-03-2017/workflows.md
@@ -1,6 +1,6 @@
 ---
 tap: "hubspot"
-version: "1.0"
+version: "01-03-2017"
 
 name: "workflows"
 doc-link: https://developers.hubspot.com/docs/methods/workflows/workflows_overview


### PR DESCRIPTION
This PR corrects the `version` value of the HubSpot `workflows` table in release `01-03-2017`.