### PR TITLE
Use setup-name

### DIFF
--- a/_database-integrations/magento.md
+++ b/_database-integrations/magento.md
@@ -11,6 +11,7 @@ summary: "Connect and replicate data from your Magento database using Stitch's M
 
 name: "magento"
 display_name: "Magento"
+setup-name: "MySQL"
 singer: true
 author: "Stitch"
 author-url: https://www.stitchdata.com

--- a/_includes/integrations/databases/setup/database-integration-settings.html
+++ b/_includes/integrations/databases/setup/database-integration-settings.html
@@ -1,5 +1,16 @@
 {% assign integration = page %}
 
+<!-- Some integrations don't have a branded UI. Ex: Magento is MySQL, but doesn't
+currently have its own UI. Capture the name that's in the UI and display it
+in the instructions. -->
+{% if integration.setup-name %}
+    {% assign integration-name = integration.setup-name %}
+{% else %}
+    {% assign integration-name = integration.display_name %}
+{% endif %}
+
+<!-- Assign the correct page field names & descriptions based on
+database type -->
 {% case integration.db-type %}
   {% when 'rds' %}
     {% assign database-settings = site.data.ui.database-integration-settings-page.rds %}
@@ -21,6 +32,7 @@
     {% assign database-settings = site.data.ui.database-integration-settings-page.default %}
   {% endcase %}
 
+<!-- Assign values to the default fields -->
 {% assign default-field = site.data.ui.database-integration-settings-page.default-fields %}
 {% assign default-copy = site.data.ui.database-integration-settings-page.default-copy %}
 
@@ -28,10 +40,8 @@
 2. {{ app.menu-paths.add-integration | flatify }}
 {% if integration.name == "rds" %}
 3. Click the icon (ex: MySQL) for the type of database you're connecting.
-{% elsif integration.name == "magento" %}
-3. Click the **MySQL** icon. As Magento is based on MySQL, you can use Stitch's MySQL integration to connect your Magento database.
 {% else %}
-3. Click the **{{ integration.display_name }}** icon.
+3. Click the **{{ integration-name }}** icon.
 {% endif %}
 4. Fill in the fields as follows:
    {% for field in database-settings %}

--- a/_includes/notifications/support-beta-singer-notice.html
+++ b/_includes/notifications/support-beta-singer-notice.html
@@ -1,3 +1,9 @@
+{% if integration.setup-name %}
+    {% assign integration-name = integration.setup-name %}
+{% else %}
+    {% assign integration-name = integration.display_name %}
+{% endif %}
+
 <div class="alert alert-info" role="alert">
     <i class="fa fa-life-ring"></i>
 
@@ -7,7 +13,7 @@
             </strong><br>
 
             {% if integration.singer == true %}
-                This integration is powered by <a href="{{ site.singer }}">Singer's</a> {{ integration.display_name }} tap and certified by Stitch. {% if integration.repo-url %}<a href="{{ integration.repo-url }}">Check out and contribute to the repo on GitHub</a>.{% endif %}<br><br>
+                This integration is powered by <a href="{{ site.singer }}">Singer's</a> {{ integration-name }} tap and certified by Stitch. {% if integration.repo-url %}<a href="{{ integration.repo-url }}">Check out and contribute to the repo on GitHub</a>.{% endif %}<br><br>
 
             {% else %}
                 This integration is certified by Stitch. 
@@ -21,7 +27,7 @@
                 {{ integration.display_name }} is supported by the Singer community
             </strong><br>
 
-            This integration is powered by <a href="{{ site.singer }}">Singer's</a> {{ integration.display_name }} tap. For support, <a href="{{ integration.repo-url }}">visit the GitHub repo</a> or <a href="{{ site.singer-slack }}">join the Singer Slack</a>.
+            This integration is powered by <a href="{{ site.singer }}">Singer's</a> {{ integration-name }} tap. For support, <a href="{{ integration.repo-url }}">visit the GitHub repo</a> or <a href="{{ site.singer-slack }}">join the Singer Slack</a>.
 
         {% endif %}
 


### PR DESCRIPTION
This PR adds a parameter named `setup-name` to integrations that don’t have a dedicated UI in Stitch, but are still supported.

Notifications and instructions will use the name of the dedicated integration to reduce confusion. Ex: Magento databases can be connected using the MySQL integration.