### PR TITLE
Ref SaaSquatch: Add accountId as PK to users table

### DIFF
--- a/_integration-schemas/referral-saasquatch/users.md
+++ b/_integration-schemas/referral-saasquatch/users.md
@@ -18,13 +18,14 @@ attributes:
     type: "string"
     primary-key: true
     description: "The user ID."
+   
+  - name: "accountId"
+    type: "string"
+    primary-key: true
+    description: "The ID of the account the user belongs to."
 
   - name: "n/a"
     replication-key: true
-
-  - name: "accountId"
-    type: "string"
-    description: "The ID of the account the user belongs to."
 
   - name: "email"
     type: "string"


### PR DESCRIPTION
This PR adds the `accountId` field as a primary key to the Referral SaaSquatch`users` stream due to [#4](https://github.com/singer-io/tap-referral-saasquatch/pull/4)