### PR TITLE
Fix link to github schema for contacts_by_company

### DIFF
--- a/_integration-schemas/hubspot/contacts_by_company.md
+++ b/_integration-schemas/hubspot/contacts_by_company.md
@@ -4,7 +4,7 @@ version: "2.0"
 
 name: "contacts_by_company"
 doc-link: 
-singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/schemas/hubspot_contacts_by_company.json
+singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/schemas/contacts_by_company.json
 description: |
   The `contacts_by_company` table contains contact and company ID pairs, allowing you to join contacts to relevant company data.
 


### PR DESCRIPTION
This PR corrects a link in the HubSpot 2.0 `contacts_by_company` table schema file.