### PR TITLE
Correct FHDL start behavior

### DIFF
--- a/_account-security/billing-faq.md
+++ b/_account-security/billing-faq.md
@@ -150,7 +150,7 @@ frequently-asked-questions:
       - question: "What is a free historical data load?"
         anchor: "free-historical-data-load"
         answer: |
-          During the first seven days that follow the creation of a new integration, replication is free. This is a free historical data load, and means that rows replicated from the new integration during this time won't count towards your quota.
+          During the first seven days after a new integration begins to replicate data, replication is free. This is a free historical data load, and means that rows replicated from the new integration during this time won't count towards your quota.
 
           After the seven days are over, Stitch will continue to replicate data from the integration. Be sure to **pause** or **delete** the integration if you are no longer interested in replicating its data.
 
@@ -161,7 +161,16 @@ frequently-asked-questions:
       - question: "Do free historical data loads apply to integration or table resets?"
         anchor: "free-historical-loads-resets"
         answer: |
-          No. Free historical data loads are only applicable to new integrations for the first seven days after they are created. [Resetting replication]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) for an integration or a table will count towards your quota.
+          No. Free historical data loads are only applicable to new integrations for the first seven days after they begin to replicate data. [Resetting replication]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) for an integration or a table will count towards your quota.
+
+      - question: "When do the seven days of historical data loading begin?"
+        anchor: "free-historical-data-load-begin"
+        answer: |
+          The free historical data load period for new integrations begins after the integration first replicates data.
+
+          For example: You create an integration on January 1 but don't fully configure it until January 2. In this case, the free historical data load will begin on January 2 and end January 9.
+
+          **Note**: This is applicable only to integrations created on or after May 21, 2018. 
 
 
 # -------------------------- #

--- a/_account-security/billing-faq.md
+++ b/_account-security/billing-faq.md
@@ -144,6 +144,10 @@ frequently-asked-questions:
 
           For more info, refer to [our pricing page]({{ site.pricing }}).
 
+# -------------------------- #
+#   HISTORICAL DATA LOADS    #
+# -------------------------- #
+
   - topic: "Historical data loads"
     anchor: "historical-data-loads"
     items:
@@ -161,16 +165,20 @@ frequently-asked-questions:
       - question: "Do free historical data loads apply to integration or table resets?"
         anchor: "free-historical-loads-resets"
         answer: |
-          No. Free historical data loads are only applicable to new integrations for the first seven days after they begin to replicate data. [Resetting replication]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) for an integration or a table will count towards your quota.
+          If the reset occurs during the free historical data load period, yes.
+
+          If the reset occurs after the free historical data load period has ended, no.
+
+          Free historical data loads are only applicable to new integrations for the first seven days after they begin to replicate data. [Resetting replication]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) for an integration or a table will count towards your quota.
 
       - question: "When do the seven days of historical data loading begin?"
         anchor: "free-historical-data-load-begin"
         answer: |
           The free historical data load period for new integrations begins after the integration first replicates data.
 
-          For example: You create an integration on January 1 but don't fully configure it until January 2. In this case, the free historical data load will begin on January 2 and end January 9.
+          For example: You create an integration on June 1 but don't fully configure it until June 2. In this case, the free historical data load will begin on June 2 and end June 9.
 
-          **Note**: This is applicable only to integrations created on or after May 21, 2018. 
+          **Note**: This is applicable only to integrations created on or after May 22, 2018. 
 
 
 # -------------------------- #

--- a/_includes/integrations/shared-setup/initial-syncs.html
+++ b/_includes/integrations/shared-setup/initial-syncs.html
@@ -6,6 +6,6 @@ A **Pending** status indicates that Stitch is in the process of scheduling the i
 
 #### Free historical data loads
 
-The first seven days of replication for a new integration are free. Rows replicated from the new integration during this time won't count towards your quota. Stitch offers this as a way of testing new integrations, measuring usage, and ensuring historical data volumes don't quickly consume your quota.
+The first seven days of replication, beginning when data is first replicated, are free. Rows replicated from the new integration during this time won't count towards your quota. Stitch offers this as a way of testing new integrations, measuring usage, and ensuring historical data volumes don't quickly consume your quota.
 
 {% include note.html content="**Replication will continue after the seven days are over**. If you're no longer interested in this source, be sure to **pause** or **delete** the integration to prevent unwanted usage." %}


### PR DESCRIPTION
This PR updates the documentation to reflect that FHDL (free historical data loads) begin **after** an integration begins to replicate data. 

This behavior is the same way trials begin: the 14 days for a trial begin only when a destination has been connected and data starts to replicate.