### PR TITLE
Binlog instructions for MariaDB

### DIFF
--- a/_database-integrations/mariadb.md
+++ b/_database-integrations/mariadb.md
@@ -61,23 +61,7 @@ setup-steps:
   - title: "Configure database server settings"
     anchor: "server-settings"
     content: |
-      Next, you'll configure your server to use binlog replication.
-
-      Binlog replication is a method of replication that reads a database's binary log files. These files contain information about modifications made to data in a {{ integration.display_name }} instance. Binlog replication captures all inserts, updates, and deletes made to records, and is the most accurate and efficient method of replication.
-
-      While Stitch recommends using binlog to replicate data, it isn't mandatory. Stitch offers additional [Replication Methods]({{ link.replication.rep-methods | prepend: site.baseurl }}) for {{ integration.display_name }} databases that don't require defining these settings.
-
-      {% capture section-name %}
-      mysqld
-      {% endcapture %}
-
-      {% capture server-instructions %}
-      Log into your database server and locate the `my.cnf` file. This is usually located at `/etc/my.cnf`.
-
-      Ensure the `my.cnf` file has the following lines in the `{{ section-name | strip }}` section.
-      {% endcapture %}
-
-      {% include integrations/templates/configure-server-settings.html %}
+      {% include integrations/databases/setup/binlog/vanilla-mysql.html %}
 
   - title: "Create a Stitch database user"
     anchor: "db-user"

--- a/_includes/integrations/databases/setup/binlog/vanilla-mysql.html
+++ b/_includes/integrations/databases/setup/binlog/vanilla-mysql.html
@@ -1,4 +1,11 @@
 {% assign database-setup = site.data.taps.extraction.database-setup.server-settings[integration.db-type] %}
+
+<!-- Different flavors of databases may not be on the same version as the DB
+that powers their backend, or their settings may be slightly different.
+
+Use the database's display name to pull the correct settings, versus just
+using the type. -->
+
 {% assign database-name = integration.display_name | downcase | replace: " ","-" %}
 
 {% capture section-name %}


### PR DESCRIPTION
This PR adds binlog setup instructions for MySQL-backed MariaDB.