### PR TITLE
Update Zuora v15-10-2015 deprecation date

### DIFF
--- a/_data/taps/versions/zuora.yml
+++ b/_data/taps/versions/zuora.yml
@@ -13,4 +13,4 @@ released-versions:
   - number: "15-10-2015"
     date-released: "October 15, 2015"
     deprecated: true
-    deprecation-date: "July 16, 2018"
+    deprecation-date: "September 1, 2018"


### PR DESCRIPTION
Pushing the Zuora deprecation date to September 1 to provide 90 days from formal communication.