### PR TITLE
Add link to QuickBooks site

### DIFF
--- a/_saas-integrations/quickbooks.md
+++ b/_saas-integrations/quickbooks.md
@@ -842,7 +842,7 @@ tables:
 
 
 {% contentfor setup %}
-Connecting your QuickBooks data to Stitch is a four-step process:
+Connecting your [QuickBooks data](https://quickbooks.intuit.com/cloud-accounting-software/){:target="new"} to Stitch is a four-step process:
 
 1. [Add QuickBooks as a Stitch data source](#add-stitch-data-source)
 2. [Define the Historical Sync](#define-historical-sync)


### PR DESCRIPTION
This PR adds a link to the QuickBooks site to the QB docs, as per a support request from QuickBooks’s marketing team.