### PR TITLE
Make Pipedrive a community integration

### DIFF
--- a/_saas-integrations/pipedrive.md
+++ b/_saas-integrations/pipedrive.md
@@ -25,10 +25,11 @@ status-url: "http://status.pipedrive.com/"
 # -------------------------- #
 
 status: "Closed Beta"
+certified: false
 
 historical: "1 year"
 frequency: "30 minutes"
-tier: "Premium"
+tier: "Free"
 icon: /images/integrations/icons/pipedrive.svg
 whitelist:
   tables: false


### PR DESCRIPTION
This PR fixes an issue where the Pipedrive integration wasn’t display in the sidenav or on any of the integration category pages.

To display in the sidenav/on category pages, the following Frontmatter parameters must be present:

```yaml
input: true  # must be true

certified: true/false
```

`certified` may be `true` or `false` - the variable just has to be present and not null.