### PR TITLE
Marketo 1.0 deprecation

### DIFF
--- a/_data/taps/versions/marketo.yml
+++ b/_data/taps/versions/marketo.yml
@@ -6,11 +6,11 @@ latest-version: "2.0"
 
 released-versions:
   - number: "2.0"
-    date-released: "TBD"
+    date-released: "June 26, 2018"
     deprecated: false
     # deprecation-date: "n/a"
 
   - number: "1.0"
     date-released: "March 1, 2017"
-    deprecated: false
-    # deprecation-date: "n/a"
+    deprecated: true
+    deprecation-date: "September 24, 2018"


### PR DESCRIPTION
Adding Marketo 1.0 deprecation date to provide 90 days from formal communication.

