### PR TITLE
Typo in Import API introduction

### DIFF
--- a/_connect-files/api/documentation/api-introduction.md
+++ b/_connect-files/api/documentation/api-introduction.md
@@ -5,7 +5,7 @@ order: 1
 
 sections:
   - content: |
-      The Stitch Connect API enables you to seamlessly integration Stitch’s data pipeline functionality into your own platform. This API is a RESTful, resource-oriented API that allows you to programmatically provision Stitch accounts, create and modify data sources, and configure destination connections.
+      The Stitch Connect API enables you to seamlessly integrate Stitch’s data pipeline functionality into your own platform. This API is a RESTful, resource-oriented API that allows you to programmatically provision Stitch accounts, create and modify data sources, and configure destination connections.
 
       Each endpoint uses standard HTTP verbs like GET and POST, and will return [standard HTTP response codes]({{ api.response-codes }}) to indicate request status or errors.
 


### PR DESCRIPTION
This PR fixes a typo in the Import API introduction.