### PR TITLE
Connect: Correct start_date format and POST account example

### DIFF
--- a/_connect-files/api/objects/accounts/create-an-account.md
+++ b/_connect-files/api/objects/accounts/create-an-account.md
@@ -57,7 +57,6 @@ examples:
     language: "curl"
     code: |
       curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | strip_newlines }}
-           -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{
                 "email": "stitch-api-test@stitchdata.com",

--- a/_data/connect/general.yml
+++ b/_data/connect/general.yml
@@ -88,4 +88,4 @@ common:
     start-date: |
       The date from which Stitch should begin replicating data from [INTEGRATION]. Data from this date forward will be replicated.
 
-      This field must contain an [ISO 8601-compliant](https://en.wikipedia.org/wiki/ISO_8601) date. For example: `2018-01-01T11:59:59Z`
+      This field must contain an [ISO 8601-compliant](https://en.wikipedia.org/wiki/ISO_8601) date, and the timestamp must be midnight. For example: `2018-01-01T00:00:00Z`


### PR DESCRIPTION
This PR does the following in the Connect docs:

- Updates the `start_date` example to use midnight as the time since that's what the regex validation requires
- Removed the access token from the header on the account `POST` example since it's not required to post an account