### PR TITLE
Shopify: Update order_refunds Replication Method

### DIFF
--- a/_saas-integrations/shopify.md
+++ b/_saas-integrations/shopify.md
@@ -235,7 +235,7 @@ tables:
     doc-link: https://help.shopify.com/api/reference/refund/
     description: "info about refunds applied to transactions."
     notes: 
-    replication-method: "Key-based Incremental"
+    replication-method: "Full Table"
     primary-key: "id"
     nested-structures: true
     attributes:


### PR DESCRIPTION
This PR corrects the Replication Method for Shopify's `order_refunds` table.