### PR TITLE
Append-Only example: Rep Key inclusivity with updated_at

### DIFF
--- a/_includes/destinations/overviews/replication-process.html
+++ b/_includes/destinations/overviews/replication-process.html
@@ -16,7 +16,11 @@ This means that there can be many different rows in a {{ destination.display_nam
         </div>
         <div id="collapseOne" class="panel-collapse collapse noCrossRef">
             <div class="panel-body">
+                {% capture append-only-content %}
                 {% include replication/append-only-replication-example.html %}
+                {% endcapture %}
+
+                {{ append-only-content | flatify | markdownify }}
             </div>
         </div>
     </div>

--- a/_includes/replication/append-only-replication-example.html
+++ b/_includes/replication/append-only-replication-example.html
@@ -19,7 +19,7 @@ These rows are replicated during the initial sync of the table. Some time later,
 
 {% endhighlight %}
 
-During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated total row count to 5:
+During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated bringing the total row count to 5:
 
 
 {% highlight markdown %}

--- a/_includes/replication/append-only-replication-example.html
+++ b/_includes/replication/append-only-replication-example.html
@@ -1,40 +1,50 @@
 Our example table contains the following rows to start with: 
 
 {% highlight markdown %}
-| Name | Age | Type  | Magic   | {{ system-column.sequence }} |
-|------+-----+-------+---------+---------------|
-| Finn | 14  | Human | False   | 1473773877524 |
-| Jake | 6   | Dog   | True    | 1473773877524 |
+| Name | Age | Type  | Magic   | updated_at              |{{ system-column.sequence }} |
+|------+-----+-------+---------+-------------------------+---------------|
+| Finn | 14  | Human | False   | 2017-12-22 12:34:23     | 1473773877524 |
+| Jake | 6   | Dog   | True    | 2018-07-17 16:28:23     | 1473773877524 |
 {% endhighlight %}
 
-These rows are replicated during the initial sync of the table. Some time later, new rows are added to the table:
+These rows are replicated during the initial sync of the table. Some time later, new rows are added to the (source) table:
 
 {% highlight markdown %}
-| Name      | Age | Type     | Magic  | {{ system-column.sequence }} |
-|-----------+-----+----------+--------+---------------|
-| Bubblegum | 16  | Princess | True   | 1473776585195 |
-| Beamo     | 1   | Game Bot | False  | 1473776585195 |
+| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
+|-----------+-----+----------+--------+-------------------------+---------------|
+| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
+| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 | //current bookmark
+| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 | // new rows
+| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 | // new rows
+
 {% endhighlight %}
 
-During the next replication job, the new rows are appended to the table, bringing the total row count to 4:
+During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated total row count to 5:
+
 
 {% highlight markdown %}
-| Name      | Age | Type     | Magic  | {{ system-column.sequence }} |
-|-----------+-----+----------+--------+---------------|
-| Finn      | 14  | Human    | False  | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 1473773877524 |
-| Bubblegum | 16  | Princess | True   | 1473776585195 |  // new rows are appended
-| Beamo     | 1   | Game Bot | False  | 1473776585195 |
+| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
+|-----------+-----+----------+--------+-------------------------+---------------|
+| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
+| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |
+| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |  // record with previous bookmark value is appended
+| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 |  // new rows
+| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 |  // new rows
+
 {% endhighlight %}
 
-But what happens when an existing row is updated? If Finn's age were updated to 15, the <strong>existing</strong> row wouldn't be updated - instead, an entirely new row would be appended to the end of the table:
+What happens when an existing row is updated? If Finn's age were updated to 15, the <strong>existing</strong> row wouldn't be updated - instead, an entirely new row would be appended to the end of the table:
+
 
 {% highlight markdown %}
-| Name      | Age | Type     | Magic  | {{ system-column.sequence }} |
-|-----------+-----+----------+--------+---------------|
-| Finn      | 14  | Human    | False  | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 1473773877524 |
-| Bubblegum | 16  | Princess | True   | 1473776585195 |
-| Beamo     | 1   | Game Bot | False  | 1473776585195 |
-| Finn      | 15  | Human    | False  | 1473827984228 |  // updated data as new row
+| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
+|-----------+-----+----------+--------+-------------------------+---------------|
+| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
+| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |
+| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |  
+| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 | 
+| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 | 
+| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 |  // record with previous bookmark value is appended
+| Finn      | 15  | Human    | False  | 2018-07-17 20:34:23     | 1473776585195 |  // updated data appended as new row
+
 {% endhighlight %}

--- a/_includes/replication/append-only-replication-example.html
+++ b/_includes/replication/append-only-replication-example.html
@@ -19,7 +19,7 @@ These rows are replicated during the initial sync of the table. Some time later,
 
 {% endhighlight %}
 
-During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated bringing the total row count to 5:
+During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated, bringing the total row count to 5:
 
 
 {% highlight markdown %}

--- a/_includes/replication/append-only-replication-example.html
+++ b/_includes/replication/append-only-replication-example.html
@@ -1,50 +1,91 @@
-Our example table contains the following rows to start with: 
 
-{% highlight markdown %}
-| Name | Age | Type  | Magic   | updated_at              |{{ system-column.sequence }} |
-|------+-----+-------+---------+-------------------------+---------------|
-| Finn | 14  | Human | False   | 2017-12-22 12:34:23     | 1473773877524 |
-| Jake | 6   | Dog   | True    | 2018-07-17 16:28:23     | 1473773877524 |
-{% endhighlight %}
+#### Initial replication job
 
-These rows are replicated during the initial sync of the table. Some time later, new rows are added to the (source) table:
+**Source table**
 
-{% highlight markdown %}
-| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
-|-----------+-----+----------+--------+-------------------------+---------------|
-| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 | //current bookmark
-| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 | // new rows
-| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 | // new rows
+In the source, the initial table looks like this:
 
-{% endhighlight %}
+| id | name | type  | magic   | updated_at              |
+|----+------+-------+---------+-------------------------|
+| 1  | Finn | human | false   | 2017-12-22 12:34:23     |
+| 2  | Jake | dog   | true    | 2018-07-17 16:28:14     |
 
-During the next replication job, any record where updated_at >= 2018-07-17 16:28:23 is replicated, bringing the total row count to 5:
+<br>
+Stitch saves the maximum value from the Replication Key column (`updated_at: 2018-07-17 16:28:14`) to as a 'bookmark', which is where replication will pick up on the next replication job.
 
+**Destination table**
 
-{% highlight markdown %}
-| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
-|-----------+-----+----------+--------+-------------------------+---------------|
-| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |  // record with previous bookmark value is appended
-| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 |  // new rows
-| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 |  // new rows
+The entire table is replicated in full to the destination:
 
-{% endhighlight %}
+| id | name | type  | magic   | updated_at              |
+|----+------+-------+---------+-------------------------|
+| 1  | Finn | human | false   | 2017-12-22 12:34:23     |
+| 2  | Jake | dog   | true    | 2018-07-17 16:28:14     |
 
-What happens when an existing row is updated? If Finn's age were updated to 15, the <strong>existing</strong> row wouldn't be updated - instead, an entirely new row would be appended to the end of the table:
+---
 
+#### Second replication job
 
-{% highlight markdown %}
-| Name      | Age | Type     | Magic  | updated_at              |{{ system-column.sequence }} |
-|-----------+-----+----------+--------+-------------------------+---------------|
-| Finn      | 14  | Human    | False  | 2017-12-22 12:34:23     | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |
-| Jake      | 6   | Dog      | True   | 2018-04-09 16:28:23     | 1473773877524 |  
-| Bubblegum | 16  | Princess | True   | 2018-07-12 18:34:23     | 1473776585195 | 
-| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 | 
-| Beamo     | 1   | Game Bot | False  | 2018-07-17 18:34:23     | 1473776585195 |  // record with previous bookmark value is appended
-| Finn      | 15  | Human    | False  | 2018-07-17 20:34:23     | 1473776585195 |  // updated data appended as new row
+**Source table**
 
-{% endhighlight %}
+Some time later, new rows (`id: 3, 4`) are added to the source table:
+
+| id | name      | type     | magic  | updated_at              |
+|----+-----------+----------+--------+-------------------------|
+| 1  | Finn      | human    | false  | 2017-12-22 12:34:23     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 3  | Bubblegum | princess | true   | 2018-07-17 18:37:56     |
+| 4  | Beamo     | game bot | false  | 2018-07-17 18:34:49     |
+
+<br>
+**Destination table**
+
+Stitch replicates all records where `updated_at >= 2018-07-17 16:28:14`, in this case `id: 2, 3, 4`, and appends them to the end of the table in the destination:
+
+| id | name      | type     | magic  | updated_at              |
+|----+-----------+----------+--------+-------------------------|
+| 1  | Finn      | human    | false  | 2017-12-22 12:34:23     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 3  | Bubblegum | princess | true   | 2018-07-17 18:37:56     |
+| 4  | Beamo     | game bot | false  | 2018-07-17 18:34:49     |
+
+<br>
+Note that:
+
+- `id: 2` is in the table twice. This is because of the inclusive nature of Replication Keys, where records that are greater than or equal to the last saved maximum value are replicated.
+- Rows for records `id: 3, 4` are appended to the end of the table
+- The maximum Replication Key value is updated to `updated_at: 2018-07-17 18:37:56`
+
+---
+
+#### Third replication job
+
+**Source table**
+
+What happens when an existing row is updated? In the source, `id: 1` is now `magic: true`, which changes the record's `updated_at` to `2018-07-20 09:18:32`:
+
+| id | name      | type     | magic  | updated_at              |
+|----+-----------+----------+--------+-------------------------|
+| 1  | Finn      | human    | true   | 2018-07-20 09:18:32     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 3  | Bubblegum | princess | true   | 2018-07-17 18:37:56     |
+| 4  | Beamo     | game bot | false  | 2018-07-17 18:34:49     |
+
+<br>
+**Destination table**
+
+Stitch replicates all records where `updated_at: 2018-07-17 18:37:56`. In this case, that's records `id: 1, 3`, which will be appended to the end of the table in the destination:
+
+| id | name      | type     | magic  | updated_at              |
+|----+-----------+----------+--------+-------------------------|
+| 1  | Finn      | human    | false  | 2017-12-22 12:34:23     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 2  | Jake      | dog      | true   | 2018-07-17 16:28:14     |
+| 3  | Bubblegum | princess | true   | 2018-07-17 18:37:56     |
+| 4  | Beamo     | game bot | false  | 2018-07-17 18:34:49     |
+| 1  | Finn      | human    | true   | 2018-07-20 09:18:32     |
+| 3  | Bubblegum | princess | true   | 2018-07-17 18:37:56     |
+
+<br>
+Because existing rows aren't updated in the destination, records `id: 1, 3` are now in the table twice. For `id: 1`, note that the `magic` values are different.


### PR DESCRIPTION
The original does not take into account the fact that during append-only replication, records which have a replication key value greater than or equal to the previous bookmark will also be replicated.