### PR TITLE
AdWords/v1 new report tables

### DIFF
--- a/_integration-schemas/google-adwords/account_performance_report.md
+++ b/_integration-schemas/google-adwords/account_performance_report.md
@@ -1,0 +1,37 @@
+---
+tap: "google-adwords"
+version: "1.0"
+
+name: "account_performance_report"
+doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/account-performance-report
+description: |
+  The `account_performance_report` table contains all statistics aggregated by default at the account level.
+
+  [This is a **Report** table](#replication). See the **Replication** section for information on how data is replicated and loaded for this table.
+
+replication-method: "Append-Only (Incremental)"
+attribution-window: true
+
+attributes:
+  - name: "{{ system-column.primary-key }}"
+    type: "string"
+    primary-key: true
+    description: "{{ system-column.primary-key-description }}"
+
+  - name: "day"
+    type: "date-time"
+    replication-key: true
+    description: "The day the record pertains to."
+
+  - name: "{{ system-column.customer-id }}"
+    type: "integer"
+    description: "The ID of the AdWords account that the record belongs to."
+
+  - name: "{{ system-column.report-date-time }}"
+    type: "date-time"
+    description: "The start time of the Stitch replication job that replicated this record."
+
+  - name: "Custom Fields"
+    description: |
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+---

--- a/_integration-schemas/google-adwords/call_metrics_call_details_report.md
+++ b/_integration-schemas/google-adwords/call_metrics_call_details_report.md
@@ -1,0 +1,37 @@
+---
+tap: "google-adwords"
+version: "1.0"
+
+name: "call_metrics_call_details_report"
+doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/call-metrics-call-details-report
+description: |
+  The `{{ table.name }}` table contains data for call tracking of call-only ads or call extensions.
+
+  [This is a **Report** table](#replication). See the **Replication** section for information on how data is replicated and loaded for this table.
+
+replication-method: "Append-Only (Incremental)"
+attribution-window: true
+
+attributes:
+  - name: "{{ system-column.primary-key }}"
+    type: "string"
+    primary-key: true
+    description: "{{ system-column.primary-key-description }}"
+
+  - name: "day"
+    type: "date-time"
+    replication-key: true
+    description: "The day the record pertains to."
+
+  - name: "{{ system-column.customer-id }}"
+    type: "integer"
+    description: "The ID of the AdWords account that the record belongs to."
+
+  - name: "{{ system-column.report-date-time }}"
+    type: "date-time"
+    description: "The start time of the Stitch replication job that replicated this record."
+
+  - name: "Custom Fields"
+    description: |
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+---

--- a/_integration-schemas/google-adwords/display_keyword_performance_report.md
+++ b/_integration-schemas/google-adwords/display_keyword_performance_report.md
@@ -1,0 +1,37 @@
+---
+tap: "google-adwords"
+version: "1.0"
+
+name: "display_keyword_performance_report"
+doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/display-keyword-performance-report
+description: |
+  The `{{ table.name }}` table contains all Display Network and YouTube Network statistics aggregated at the keyword level.
+
+  [This is a **Report** table](#replication). See the **Replication** section for information on how data is replicated and loaded for this table.
+
+replication-method: "Append-Only (Incremental)"
+attribution-window: true
+
+attributes:
+  - name: "{{ system-column.primary-key }}"
+    type: "string"
+    primary-key: true
+    description: "{{ system-column.primary-key-description }}"
+
+  - name: "day"
+    type: "date-time"
+    replication-key: true
+    description: "The day the record pertains to."
+
+  - name: "{{ system-column.customer-id }}"
+    type: "integer"
+    description: "The ID of the AdWords account that the record belongs to."
+
+  - name: "{{ system-column.report-date-time }}"
+    type: "date-time"
+    description: "The start time of the Stitch replication job that replicated this record."
+
+  - name: "Custom Fields"
+    description: |
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+---

--- a/_integration-schemas/google-adwords/display_topics_performance_report.md
+++ b/_integration-schemas/google-adwords/display_topics_performance_report.md
@@ -1,0 +1,37 @@
+---
+tap: "google-adwords"
+version: "1.0"
+
+name: "display_topics_performance_report"
+doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/display-topics-performance-report
+description: |
+  The `{{ table.name }}` table contains all Display Network and YouTube Network statistics aggregated at the topic level.
+
+  [This is a **Report** table](#replication). See the **Replication** section for information on how data is replicated and loaded for this table.
+
+replication-method: "Append-Only (Incremental)"
+attribution-window: true
+
+attributes:
+  - name: "{{ system-column.primary-key }}"
+    type: "string"
+    primary-key: true
+    description: "{{ system-column.primary-key-description }}"
+
+  - name: "day"
+    type: "date-time"
+    replication-key: true
+    description: "The day the record pertains to."
+
+  - name: "{{ system-column.customer-id }}"
+    type: "integer"
+    description: "The ID of the AdWords account that the record belongs to."
+
+  - name: "{{ system-column.report-date-time }}"
+    type: "date-time"
+    description: "The start time of the Stitch replication job that replicated this record."
+
+  - name: "Custom Fields"
+    description: |
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+---

--- a/_integration-schemas/google-adwords/video_performance_report.md
+++ b/_integration-schemas/google-adwords/video_performance_report.md
@@ -1,0 +1,37 @@
+---
+tap: "google-adwords"
+version: "1.0"
+
+name: "video_performance_report"
+doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/video-performance-report
+description: |
+  The `video_performance_report` table contains statistics for your account's upgraded [AdWords for Video campaigns](https://adwords.googleblog.com/2015/09/trueview-campaigns-now-in-adwords.html){:target="new"}.
+
+  [This is a **Report** table](#replication). See the **Replication** section for information on how data is replicated and loaded for this table.
+
+replication-method: "Append-Only (Incremental)"
+attribution-window: true
+
+attributes:
+  - name: "{{ system-column.primary-key }}"
+    type: "string"
+    primary-key: true
+    description: "{{ system-column.primary-key-description }}"
+
+  - name: "day"
+    type: "date-time"
+    replication-key: true
+    description: "The day the record pertains to."
+
+  - name: "{{ system-column.customer-id }}"
+    type: "integer"
+    description: "The ID of the AdWords account that the record belongs to."
+
+  - name: "{{ system-column.report-date-time }}"
+    type: "date-time"
+    description: "The start time of the Stitch replication job that replicated this record."
+
+  - name: "Custom Fields"
+    description: |
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+---


### PR DESCRIPTION
This PR adds documentation for some new tables to Google AdWords v1:

- `account_performance_report`
- `call_metrics_call_details_report`
- `display_keywords_performance_report`
- `display_topics_performance_report`
- `video_performance_report`

Singer PR: https://github.com/singer-io/tap-adwords/pull/34