### PR TITLE
Connect: Remove 1 and 10 as frequency options

### DIFF
--- a/_data/connect/general.yml
+++ b/_data/connect/general.yml
@@ -77,8 +77,6 @@ common:
     frequency: |
       Defines how often, in minutes, Stitch should attempt to replicate data from [INTEGRATION]. Accepted values are:
 
-      - `1`
-      - `10`
       - `30`
       - `60`
       - `360`


### PR DESCRIPTION
10 is not a valid frequency option, and 1 is only supported for database integrations.