### PR TITLE
Facebook Ads: Update schemas for deprecated fields

### DIFF
--- a/_data/taps/versions/facebook-ads.yml
+++ b/_data/taps/versions/facebook-ads.yml
@@ -1,0 +1,104 @@
+# -------------------------- #
+#   FACEBOOK ADS VERSIONS    #
+# -------------------------- #
+
+latest-version: "1.0"
+
+released-versions:
+  - number: "1.0"
+    date-released: "September 11, 2017"
+    deprecated: false
+    deprecation-date: "n/a"
+
+
+# -------------------------- #
+#   FACEBOOK ADS CHANGELOG   #
+# -------------------------- #
+
+# Changelog entry types:
+# - new-release
+# - version-deprecation
+# - schema-change
+# - maintenance
+# - new-data
+# - feature-support
+# - provider-deprecation
+
+# Depending on the entry type, some initial copy and a pre-defined
+# Summary heading might display. See:
+# _includes/integrations/templates/versioning/integration-changelog.html
+
+changelog-entries:
+  - date: "July 26, 2018"
+    version: "1.0"
+    type: "provider-deprecation"
+    summary: "Deprecated ad insights fields"
+    content: |
+      [Facebook has deprecated the following fields](https://developers.facebook.com/docs/graph-api/changelog/breaking-changes#feb2018){:target="new"}, meaning they are no longer available for selection or retrieval via Facebook's API:
+
+      - `call_to_action_clicks`
+      - `cost_per_total_action`
+      - `social_reach`
+      - `social_impressions`
+      - `social_clicks`
+      - `unique_social_clicks`
+      - `today_spend`
+      - `total_actions`
+      - `total_unique_actions`
+
+      In addition, several types of metrics have been deprecated. **Note**: The fields are still available, but the types listed below are not.
+
+      - `actions` field: `mention`, `tab_view`
+      - `action_values` field: `app_custom_event`
+      - `cost_per_action_type` field: `mention`, `tab_view`
+      - `canvas_avg_view_percentage_per_component` field: `canvas_view`
+
+  - date: "April 10, 2018"
+    version: "1.0"
+    type: "provider-deprecation"
+    summary: "Deprecated field: `video_15_sec_watched_actions"
+    content: |
+      With the upgrade to the 2.11 version of Facebook's Marketing API, Facebook has deprecated the `video_15_sec_watched_actions` field. This field is no longer available for selection or retrieval via the API.
+
+  - date: "April 10, 2018"
+    version: "1.0"
+    type: "new-data"
+    summary: "New table availability: `ads_insights_region`"
+    content: |
+      A new table is now available for Facebook Ads integrations. The `ads_insights_region` table contains data by region (such as state or province) where people live or were located when viewing your ads, depending on how you set your location targeting.
+
+  - date: "April 10, 2018"
+    version: "1.0"
+    type: "feature-support"
+    summary: "Configurable attribution windows"
+    content: |
+      Attribution windows are now configurable in Stitch for Facebook Ads integrations. You can choose between 1, 7, or 28 days to ensure Stitch replicates historical data in alignment with the attribution window of your Facebook Ads account.
+
+  - date: "April 10, 2018"
+    version: "1.0"
+    type: "maintenance"
+    summary: "Upgrade to Facebook Marketing API 2.11"
+    content: |
+      The Facebook Ads integration has been updated to use the newest version of Facebook's Marketing API (2.11).
+
+  - date: "February 15, 2018"
+    version: "1.0"
+    type: "feature-support"
+    summary: "Loading Reports now available"
+    content: |
+      Loading Reports are now available for all Facebook Ads integrations.
+
+  - date: "November 16, 2017"
+    version: "1.0"
+    type: "feature-support"
+    summary: "Extraction Logs now available"
+    content: |
+      Extraction Logs are now available for all Facebook Ads integrations.
+
+  - date: "September 11, 2017"
+    version: "1.0"
+    type: "new-version"
+    content: |
+      Highlights include:
+
+      - Field selection support

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -106,10 +106,6 @@ attributes:
     type: "number"
     description: "The average number of times each person saw your ad."
 
-  - name: "total_actions"
-    type: "integer"
-    description: "The total number of actions people took that are attributed to the ad. Actions may include engagement, clicks, or conversions."
-
   - name: "account_id"
     type: "string"
     description: "The ID number of your ad account."

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -83,6 +83,11 @@ attributes:
 
           Action types include Page likes, app installs, conversions, event responses, and more.
 
+          **Note**: As of July 2018, Facebook has deprecated the following `action` types:
+
+          - `mention`
+          - `tab_view`
+
       - name: "value"
         type: "number"
         description: &action-type-value-description |

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -217,7 +217,13 @@ attributes:
 
   - name: "cost_per_action_type"
     type: "array"
-    description: "Details about the average cost of a relevant action."
+    description: |
+      Details about the average cost of a relevant action.
+
+      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
+
+      - `mention`
+      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -139,10 +139,6 @@ attributes:
         type: "string"
         description: *action-type-description
 
-  - name: "social_reach"
-    type: "integer"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_post_engagement"
     type: "integer"
     description: "The total number of actions that people take involving the ad. Inline post engagements use a fixed 1-day-click attribution window."
@@ -227,10 +223,6 @@ attributes:
   - name: "unique_link_clicks_ctr"
     type: "number"
     description: "The percentage of people who saw the ad and performed a link click."
-
-  - name: "social_reach"
-    type: "number"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
 
   - name: "spend"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -258,8 +258,4 @@ attributes:
   - name: "ctr"
     type: "number"
     description: "The percentage of times people saw your ad and performed a click (all)."
-
-  - name: "total_unique_actions"
-    type: "integer"
-    description: "The number of people who took an action that was attributed to the ad."
 ---

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -267,10 +267,6 @@ attributes:
     type: "number"
     description: "The average percentage of the Facebook Canvas that people saw."
 
-  - name: "social_impressions"
-    type: "integer"
-    description: "The number of times the ad was viewed when displayed with social information, which shows Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "objective"
     type: "string"
     description: "The objective selected for the campaign. This reflects the goal you want to achieve with your advertising."

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -161,25 +161,13 @@ attributes:
 
           Facebook's documentation states that: _"10 means we (Facebook) estimate the ad is highly relevant and 1 means we (Facebook) estimate it’s not very relevant."_
 
-  - name: "social_clicks"
-    type: "integer"
-    description: "The number of clicks (all) when the ad was displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_link_clicks"
-    type: "integer"
-    description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
-
-  - name: "unique_social_clicks"
     type: "integer"
     description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
 
   - name: "cpc"
     type: "number"
     description: "The average cost for each click (all)."
-
-  - name: "unique_social_clicks"
-    type: "integer"
-    description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -85,6 +85,7 @@ attributes:
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
+          - `app_custom_event`
           - `mention`
           - `tab_view`
 
@@ -191,14 +192,6 @@ attributes:
   - name: "unique_social_clicks"
     type: "integer"
     description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
-
-  - name: "call_to_action_clicks"
-    type: "integer"
-    description: "The number of times people clicked the call-to-action button on the ad."
-
-  - name: "cost_per_total_action"
-    type: "number"
-    description: "The average cost for a relevant action."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -158,14 +158,6 @@ attributes:
 
           **Note:** Relevance scores are shown after ads receive more than 500 impressions. In addition, relevance scores are only applicable to ads and will not appear for ad sets and campaigns.
 
-      - name: "negative_feedback"
-        type: "string"
-        description: "A string that indicates the level of negative feedback received about the ad. Ex: `LOW`"
-
-      - name: "positive_feedback"
-        type: "string"
-        description: "A string that indicates the level of positive feedback received about the ad. Ex: `HIGH`"
-
       - name: "score"
         type: "number"
         description: |

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -86,6 +86,11 @@ attributes:
 
           Action types include Page likes, app installs, conversions, event responses, and more.
 
+          **Note**: As of July 2018, Facebook has deprecated the following `action` types:
+
+          - `mention`
+          - `tab_view`
+
       - name: "value"
         type: "number"
         description: &action-type-value-description |

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -196,14 +196,6 @@ attributes:
     type: "integer"
     description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
-  - name: "call_to_action_clicks"
-    type: "integer"
-    description: "The number of times people clicked the call-to-action button on the ad."
-
-  - name: "cost_per_total_action"
-    type: "number"
-    description: "The average cost for a relevant action."
-
   - name: "cost_per_unique_inline_link_click"
     type: "number"
     description: "The average cost of each unique inline link click."

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -261,8 +261,4 @@ attributes:
   - name: "ctr"
     type: "number"
     description: "The percentage of times people saw your ad and performed a click (all)."
-
-  - name: "total_unique_actions"
-    type: "integer"
-    description: "The number of people who took an action that was attributed to the ad."
 ---

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -88,6 +88,7 @@ attributes:
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
+          - `app_custom_event`
           - `mention`
           - `tab_view`
 

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -270,10 +270,6 @@ attributes:
     type: "number"
     description: "The average percentage of the Facebook Canvas that people saw."
 
-  - name: "social_impressions"
-    type: "integer"
-    description: "The number of times the ad was viewed when displayed with social information, which shows Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "objective"
     type: "string"
     description: "The objective selected for the campaign. This reflects the goal you want to achieve with your advertising."

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -220,7 +220,13 @@ attributes:
 
   - name: "cost_per_action_type"
     type: "array"
-    description: "Details about the average cost of a relevant action."
+    description: |
+      Details about the average cost of a relevant action.
+
+      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
+
+      - `mention`
+      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -142,10 +142,6 @@ attributes:
         type: "string"
         description: *action-type-description
 
-  - name: "social_reach"
-    type: "integer"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_post_engagement"
     type: "integer"
     description: "The total number of actions that people take involving the ad. Inline post engagements use a fixed 1-day-click attribution window."
@@ -230,10 +226,6 @@ attributes:
   - name: "unique_link_clicks_ctr"
     type: "number"
     description: "The percentage of people who saw the ad and performed a link click."
-
-  - name: "social_reach"
-    type: "number"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
 
   - name: "spend"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -164,25 +164,13 @@ attributes:
 
           Facebook's documentation states that: _"10 means we (Facebook) estimate the ad is highly relevant and 1 means we (Facebook) estimate it’s not very relevant."_
 
-  - name: "social_clicks"
-    type: "integer"
-    description: "The number of clicks (all) when the ad was displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_link_clicks"
-    type: "integer"
-    description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
-
-  - name: "unique_social_clicks"
     type: "integer"
     description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
 
   - name: "cpc"
     type: "number"
     description: "The average cost for each click (all)."
-
-  - name: "unique_social_clicks"
-    type: "integer"
-    description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -109,10 +109,6 @@ attributes:
     type: "number"
     description: "The average number of times each person saw your ad."
 
-  - name: "total_actions"
-    type: "integer"
-    description: "The total number of actions people took that are attributed to the ad. Actions may include engagement, clicks, or conversions."
-
   - name: "account_id"
     type: "string"
     description: "The ID number of your ad account."

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -161,14 +161,6 @@ attributes:
 
           **Note:** Relevance scores are shown after ads receive more than 500 impressions. In addition, relevance scores are only applicable to ads and will not appear for ad sets and campaigns.
 
-      - name: "negative_feedback"
-        type: "string"
-        description: "A string that indicates the level of negative feedback received about the ad. Ex: `LOW`"
-
-      - name: "positive_feedback"
-        type: "string"
-        description: "A string that indicates the level of positive feedback received about the ad. Ex: `HIGH`"
-
       - name: "score"
         type: "number"
         description: |

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -215,7 +215,13 @@ attributes:
 
   - name: "cost_per_action_type"
     type: "array"
-    description: "Details about the average cost of a relevant action."
+    description: |
+      Details about the average cost of a relevant action.
+
+      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
+
+      - `mention`
+      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -256,8 +256,4 @@ attributes:
   - name: "ctr"
     type: "number"
     description: "The percentage of times people saw your ad and performed a click (all)."
-
-  - name: "total_unique_actions"
-    type: "integer"
-    description: "The number of people who took an action that was attributed to the ad."
 ---

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -159,25 +159,13 @@ attributes:
 
           Facebook's documentation states that: _"10 means we (Facebook) estimate the ad is highly relevant and 1 means we (Facebook) estimate it’s not very relevant."_
 
-  - name: "social_clicks"
-    type: "integer"
-    description: "The number of clicks (all) when the ad was displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_link_clicks"
-    type: "integer"
-    description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
-
-  - name: "unique_social_clicks"
     type: "integer"
     description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
 
   - name: "cpc"
     type: "number"
     description: "The average cost for each click (all)."
-
-  - name: "unique_social_clicks"
-    type: "integer"
-    description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -81,6 +81,11 @@ attributes:
 
           Action types include Page likes, app installs, conversions, event responses, and more.
 
+          **Note**: As of July 2018, Facebook has deprecated the following `action` types:
+
+          - `mention`
+          - `tab_view`
+
       - name: "value"
         type: "number"
         description: &action-type-value-description |

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -137,10 +137,6 @@ attributes:
         type: "string"
         description: *action-type-description
 
-  - name: "social_reach"
-    type: "integer"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_post_engagement"
     type: "integer"
     description: "The total number of actions that people take involving the ad. Inline post engagements use a fixed 1-day-click attribution window."
@@ -225,10 +221,6 @@ attributes:
   - name: "unique_link_clicks_ctr"
     type: "number"
     description: "The percentage of people who saw the ad and performed a link click."
-
-  - name: "social_reach"
-    type: "number"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
 
   - name: "spend"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -83,6 +83,7 @@ attributes:
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
+          - `app_custom_event`
           - `mention`
           - `tab_view`
 

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -191,14 +191,6 @@ attributes:
     type: "integer"
     description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
-  - name: "call_to_action_clicks"
-    type: "integer"
-    description: "The number of times people clicked the call-to-action button on the ad."
-
-  - name: "cost_per_total_action"
-    type: "number"
-    description: "The average cost for a relevant action."
-
   - name: "cost_per_unique_inline_link_click"
     type: "number"
     description: "The average cost of each unique inline link click."

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -265,10 +265,6 @@ attributes:
     type: "number"
     description: "The average percentage of the Facebook Canvas that people saw."
 
-  - name: "social_impressions"
-    type: "integer"
-    description: "The number of times the ad was viewed when displayed with social information, which shows Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "objective"
     type: "string"
     description: "The objective selected for the campaign. This reflects the goal you want to achieve with your advertising."

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -104,10 +104,6 @@ attributes:
     type: "number"
     description: "The average number of times each person saw your ad."
 
-  - name: "total_actions"
-    type: "integer"
-    description: "The total number of actions people took that are attributed to the ad. Actions may include engagement, clicks, or conversions."
-
   - name: "account_id"
     type: "string"
     description: "The ID number of your ad account."

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -156,14 +156,6 @@ attributes:
 
           **Note:** Relevance scores are shown after ads receive more than 500 impressions. In addition, relevance scores are only applicable to ads and will not appear for ad sets and campaigns.
 
-      - name: "negative_feedback"
-        type: "string"
-        description: "A string that indicates the level of negative feedback received about the ad. Ex: `LOW`"
-
-      - name: "positive_feedback"
-        type: "string"
-        description: "A string that indicates the level of positive feedback received about the ad. Ex: `HIGH`"
-
       - name: "score"
         type: "number"
         description: |

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -270,8 +270,4 @@ attributes:
   - name: "ctr"
     type: "number"
     description: "The percentage of times people saw your ad and performed a click (all)."
-
-  - name: "total_unique_actions"
-    type: "integer"
-    description: "The number of people who took an action that was attributed to the ad."
 ---

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -229,7 +229,13 @@ attributes:
 
   - name: "cost_per_action_type"
     type: "array"
-    description: "Details about the average cost of a relevant action."
+    description: |
+      Details about the average cost of a relevant action.
+
+      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
+
+      - `mention`
+      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -97,6 +97,7 @@ attributes:
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
+          - `app_custom_event`
           - `mention`
           - `tab_view`
 

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -95,6 +95,11 @@ attributes:
 
           Action types include Page likes, app installs, conversions, event responses, and more.
 
+          **Note**: As of July 2018, Facebook has deprecated the following `action` types:
+
+          - `mention`
+          - `tab_view`
+
       - name: "value"
         type: "number"
         description: &action-type-value-description |

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -279,10 +279,6 @@ attributes:
     type: "number"
     description: "The average percentage of the Facebook Canvas that people saw."
 
-  - name: "social_impressions"
-    type: "integer"
-    description: "The number of times the ad was viewed when displayed with social information, which shows Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "objective"
     type: "string"
     description: "The objective selected for the campaign. This reflects the goal you want to achieve with your advertising."

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -118,10 +118,6 @@ attributes:
     type: "number"
     description: "The average number of times each person saw your ad."
 
-  - name: "total_actions"
-    type: "integer"
-    description: "The total number of actions people took that are attributed to the ad. Actions may include engagement, clicks, or conversions."
-
   - name: "account_id"
     type: "string"
     description: "The ID number of your ad account."

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -170,14 +170,6 @@ attributes:
 
           **Note:** Relevance scores are shown after ads receive more than 500 impressions. In addition, relevance scores are only applicable to ads and will not appear for ad sets and campaigns.
 
-      - name: "negative_feedback"
-        type: "string"
-        description: "A string that indicates the level of negative feedback received about the ad. Ex: `LOW`"
-
-      - name: "positive_feedback"
-        type: "string"
-        description: "A string that indicates the level of positive feedback received about the ad. Ex: `HIGH`"
-
       - name: "score"
         type: "number"
         description: |

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -151,10 +151,6 @@ attributes:
         type: "string"
         description: *action-type-description
 
-  - name: "social_reach"
-    type: "integer"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_post_engagement"
     type: "integer"
     description: "The total number of actions that people take involving the ad. Inline post engagements use a fixed 1-day-click attribution window."
@@ -239,10 +235,6 @@ attributes:
   - name: "unique_link_clicks_ctr"
     type: "number"
     description: "The percentage of people who saw the ad and performed a link click."
-
-  - name: "social_reach"
-    type: "number"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
 
   - name: "spend"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -205,14 +205,6 @@ attributes:
     type: "integer"
     description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
-  - name: "call_to_action_clicks"
-    type: "integer"
-    description: "The number of times people clicked the call-to-action button on the ad."
-
-  - name: "cost_per_total_action"
-    type: "number"
-    description: "The average cost for a relevant action."
-
   - name: "cost_per_unique_inline_link_click"
     type: "number"
     description: "The average cost of each unique inline link click."

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -173,25 +173,13 @@ attributes:
 
           Facebook's documentation states that: _"10 means we (Facebook) estimate the ad is highly relevant and 1 means we (Facebook) estimate it’s not very relevant."_
 
-  - name: "social_clicks"
-    type: "integer"
-    description: "The number of clicks (all) when the ad was displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_link_clicks"
-    type: "integer"
-    description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
-
-  - name: "unique_social_clicks"
     type: "integer"
     description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
 
   - name: "cpc"
     type: "number"
     description: "The average cost for each click (all)."
-
-  - name: "unique_social_clicks"
-    type: "integer"
-    description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -215,7 +215,13 @@ attributes:
 
   - name: "cost_per_action_type"
     type: "array"
-    description: "Details about the average cost of a relevant action."
+    description: |
+      Details about the average cost of a relevant action.
+
+      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
+
+      - `mention`
+      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -256,8 +256,4 @@ attributes:
   - name: "ctr"
     type: "number"
     description: "The percentage of times people saw your ad and performed a click (all)."
-
-  - name: "total_unique_actions"
-    type: "integer"
-    description: "The number of people who took an action that was attributed to the ad."
 ---

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -159,25 +159,13 @@ attributes:
 
           Facebook's documentation states that: _"10 means we (Facebook) estimate the ad is highly relevant and 1 means we (Facebook) estimate it’s not very relevant."_
 
-  - name: "social_clicks"
-    type: "integer"
-    description: "The number of clicks (all) when the ad was displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_link_clicks"
-    type: "integer"
-    description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
-
-  - name: "unique_social_clicks"
     type: "integer"
     description: "The number of clicks on links to select destinations or experiences, on or off Facebook-owned properties. Inline link clicks use a fixed 1-day-click attribution window."
 
   - name: "cpc"
     type: "number"
     description: "The average cost for each click (all)."
-
-  - name: "unique_social_clicks"
-    type: "integer"
-    description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
   - name: "cost_per_unique_inline_link_click"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -81,6 +81,11 @@ attributes:
 
           Action types include Page likes, app installs, conversions, event responses, and more.
 
+          **Note**: As of July 2018, Facebook has deprecated the following `action` types:
+
+          - `mention`
+          - `tab_view`
+
       - name: "value"
         type: "number"
         description: &action-type-value-description |

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -137,10 +137,6 @@ attributes:
         type: "string"
         description: *action-type-description
 
-  - name: "social_reach"
-    type: "integer"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "inline_post_engagement"
     type: "integer"
     description: "The total number of actions that people take involving the ad. Inline post engagements use a fixed 1-day-click attribution window."
@@ -225,10 +221,6 @@ attributes:
   - name: "unique_link_clicks_ctr"
     type: "number"
     description: "The percentage of people who saw the ad and performed a link click."
-
-  - name: "social_reach"
-    type: "number"
-    description: "The number of people who saw the ad when displayed with social information, which shows other Facebook friends who engaged with the Facebook Page or ad."
 
   - name: "spend"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -83,6 +83,7 @@ attributes:
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
+          - `app_custom_event`
           - `mention`
           - `tab_view`
 

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -191,14 +191,6 @@ attributes:
     type: "integer"
     description: "The number of people who performed a click (all) on the ad when it was displayed with social information, which shows other Facebook friends who engaged with the Page or ad."
 
-  - name: "call_to_action_clicks"
-    type: "integer"
-    description: "The number of times people clicked the call-to-action button on the ad."
-
-  - name: "cost_per_total_action"
-    type: "number"
-    description: "The average cost for a relevant action."
-
   - name: "cost_per_unique_inline_link_click"
     type: "number"
     description: "The average cost of each unique inline link click."

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -265,10 +265,6 @@ attributes:
     type: "number"
     description: "The average percentage of the Facebook Canvas that people saw."
 
-  - name: "social_impressions"
-    type: "integer"
-    description: "The number of times the ad was viewed when displayed with social information, which shows Facebook friends who engaged with the Facebook Page or ad."
-
   - name: "objective"
     type: "string"
     description: "The objective selected for the campaign. This reflects the goal you want to achieve with your advertising."

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -104,10 +104,6 @@ attributes:
     type: "number"
     description: "The average number of times each person saw your ad."
 
-  - name: "total_actions"
-    type: "integer"
-    description: "The total number of actions people took that are attributed to the ad. Actions may include engagement, clicks, or conversions."
-
   - name: "account_id"
     type: "string"
     description: "The ID number of your ad account."

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -156,14 +156,6 @@ attributes:
 
           **Note:** Relevance scores are shown after ads receive more than 500 impressions. In addition, relevance scores are only applicable to ads and will not appear for ad sets and campaigns.
 
-      - name: "negative_feedback"
-        type: "string"
-        description: "A string that indicates the level of negative feedback received about the ad. Ex: `LOW`"
-
-      - name: "positive_feedback"
-        type: "string"
-        description: "A string that indicates the level of positive feedback received about the ad. Ex: `HIGH`"
-
       - name: "score"
         type: "number"
         description: |


### PR DESCRIPTION
This PR:

- Updates the schema files to reflect the [fields Facebook has deprecated](https://developers.facebook.com/docs/graph-api/changelog/breaking-changes#feb2018)
- Adds a version file for FB ads
- Adds a changelog for FB ads