### PR TITLE
Zendesk v1: Add ticket_forms stream

### DIFF
--- a/_integration-schemas/zendesk/ticket_forms.md
+++ b/_integration-schemas/zendesk/ticket_forms.md
@@ -88,8 +88,6 @@ attributes:
       - name: "value"
         type: "integer"
         description: "The ID of the brand."
-        foreign-key: true
-        table: "brands"
   
 
     

--- a/_integration-schemas/zendesk/ticket_forms.md
+++ b/_integration-schemas/zendesk/ticket_forms.md
@@ -88,9 +88,4 @@ attributes:
       - name: "value"
         type: "integer"
         description: "The ID of the brand."
-  
-
-    
-
-
-
+---

--- a/_integration-schemas/zendesk/ticket_forms.md
+++ b/_integration-schemas/zendesk/ticket_forms.md
@@ -1,0 +1,98 @@
+---
+tap: "zendesk"
+version: "1.0"
+
+name: "ticket_forms"
+doc-link: https://developer.zendesk.com/rest_api/docs/core/ticket_forms
+singer-schema: https://github.com/singer-io/tap-zendesk/blob/master/tap_zendesk/schemas/ticket_forms.json
+description: |
+  The `ticket_forms` table contains info about the ticket forms in your Zendesk account.
+
+  **Note**: Retrieving ticket form data requires Zendesk Agent or Admin permissions.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: List ticket forms
+  doc-link: https://developer.zendesk.com/rest_api/docs/core/ticket_forms#list-ticket-forms
+
+attributes:
+  - name: "id"
+    type: "integer"
+    primary-key: true
+    description: "The ticket form ID."
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the ticket form was last updated."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time the ticket form was created."
+
+  - name: "name"
+    type: "string"
+    description: "The name of the ticket form."
+
+  - name: "raw_name"
+    type: "string"
+    description: "The dynamic content placeholder, if present. If not, the `name` value."
+
+  - name: "display_name"
+    type: "string"
+    description: "The name of the ticket form that is displayed to the end user."
+
+  - name: "raw_display_name"
+    type: "string"
+    description: "The dynamic content placeholder, if present. If not, the `display_name` value."
+
+  - name: "url"
+    type: "string"
+    description: "The url of the ticket form."
+
+  - name: "position"
+    type: "integer"
+    description: "The relative position of the ticket form."
+
+  - name: "active"
+    type: "boolean"
+    description: "If `true`, the ticket form is set to active."
+
+  - name: "default"
+    type: "boolean"
+    description: "If `true`, the ticket form is the default form for the account."
+
+  - name: "end_user_available"
+    type: "boolean"
+    description: "If `true`, the ticket form is visible to the end user"
+
+  - name: "in_all_brands"
+    type: "boolean"
+    description: "If `true`, the ticket form is available for use in all brands on the account"
+
+  - name: "ticket_field_ids"
+    type: "array"
+    description: "IDs of all ticket fields which are in this ticket form."
+    array-attributes:
+      - name: "value"
+        type: "integer"
+        description: "The ID of the ticket field."
+        foreign-key: true
+        table: "ticket_fields"
+
+  - name: "restricted_brand_ids"
+    type: "array"
+    description: "IDs of all brands that this ticket form is restricted to."
+    array-attributes:
+      - name: "value"
+        type: "integer"
+        description: "The ID of the brand."
+        foreign-key: true
+        table: "brands"
+  
+
+    
+
+
+


### PR DESCRIPTION
I recently added the `ticket_forms` stream to tap-zendesk.  This is the corresponding documentation PR for it.  

A few questions:  

- Do we include foreign key distinctions for streams that the tap doesn't currently support?  (e.g. the `restricted_brand_ids` attribute)
- When I added the `ticket_forms` stream, I bumped the version to 1.1.0.  Should this be reflected in the `version` in this stream's doc or does that refer to a different version?

Singer PR: https://github.com/singer-io/tap-zendesk/pull/15