### PR TITLE
Connect: Add more details about the ephemeral token and session token expiration

### DIFF
--- a/_connect-files/api/objects/sessions/create-a-session.md
+++ b/_connect-files/api/objects/sessions/create-a-session.md
@@ -12,8 +12,9 @@ short-url: |
   /v{{ object.version }}{{ object.endpoint-url }}/ephemeral
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
-short: "{{ api.core-objects.sessions.create.description }}"
-description: "{{ api.core-objects.sessions.create.description }}"
+short: "{{ api.core-objects.sessions.create.short }}"
+description: |
+  {{ api.core-objects.sessions.create.description | flatify }}
 
 returns: |
   If successful, the API will return a status of <code class="api success">200 OK</code> and a [Session object]({{ api.core-objects.sessions.object }}).

--- a/_connect-files/api/objects/sessions/sessions-object.md
+++ b/_connect-files/api/objects/sessions/sessions-object.md
@@ -4,12 +4,13 @@ endpoint: "sessions"
 order: 2
 
 title: "Session"
-description: "{{ api.core-objects.sessions.description }}"
+description: "{{ api.core-objects.sessions.description | flatify }}"
 endpoint-url: "/sessions"
 version: "3"
 
 object-attributes:
   - name: "ephemeral_token"
     type: "string"
-    description: "{{ connect.common.attributes.ephemeral-token | flatify }}"
+    description: |
+      {{ connect.common.attributes.ephemeral-token | flatify }}
 ---

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -61,7 +61,7 @@ core-objects:
       title: "Create a session"
       method: *post
       anchor: "#create-a-session"
-      description: "Creates a session in the Stitch web application. The session will be for the user for whom the API access token was created."
+      description: "Generate an ephemeral token to create a session in the Stitch web application. The ephemeral token expires after one hour. Use the ephemeral token to [create a session](https://www.stitchdata.com/docs/stitch-connect/javascript-client) with the Connect JavaScript client. The session will be for the user for whom the API access token was created. After the ephemeral token is used to create a session, the session created will expire once terminated or after 12 hours."
 
 # -------------------------- #
 #        Destinations        #

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -61,7 +61,13 @@ core-objects:
       title: "Create a session"
       method: *post
       anchor: "#create-a-session"
-      description: "Generate an ephemeral token to create a session in the Stitch web application. The ephemeral token expires after one hour. Use the ephemeral token to [create a session](https://www.stitchdata.com/docs/stitch-connect/javascript-client) with the Connect JavaScript client. The session will be for the user for whom the API access token was created. After the ephemeral token is used to create a session, the session created will expire once terminated or after 12 hours."
+      short: "Generates an ephemeral token to create a session in the Stitch web application. Ephemeral tokens expire after one hour."
+      description: |
+         {{ site.data.connect.api.core-objects.sessions.create.short }}
+
+         Ephemeral tokens are used to [create a session](https://www.stitchdata.com/docs/stitch-connect/javascript-client) with the Connect JavaScript client. The session will be for the user for whom the API access token was created.
+
+         After the ephemeral token is used to create a session, the created session will expire once terminated or after 12 hours.
 
 # -------------------------- #
 #        Destinations        #

--- a/_data/connect/general.yml
+++ b/_data/connect/general.yml
@@ -28,6 +28,8 @@ common:
 
       If the token is not provided, the user may be prompted to sign into their Stitch account.
 
+      The ephemeral token expires one hour after it's generated. When specified as an argument in a Connect JavaScript function, the ephemeral token is exchanged for a session token, creating a temporary Stitch session for the user. The session expires once terminated or 12 hours after its creation.
+
   ## Databases & Destinations
 
     host: "The IP address or hostname of the database server."

--- a/_data/connect/general.yml
+++ b/_data/connect/general.yml
@@ -28,7 +28,7 @@ common:
 
       If the token is not provided, the user may be prompted to sign into their Stitch account.
 
-      The ephemeral token expires one hour after it's generated. When specified as an argument in a Connect JavaScript function, the ephemeral token is exchanged for a session token, creating a temporary Stitch session for the user. The session expires once terminated or 12 hours after its creation.
+      The ephemeral token expires one hour after generation. When specified as an argument in a Connect JavaScript function, the ephemeral token is exchanged for a session token, creating a temporary Stitch session for the user. The session expires once terminated or 12 hours after its creation.
 
   ## Databases & Destinations
 


### PR DESCRIPTION
This PR:

* Updates the Connect API `/sessions/ephemeral` documentation to clarify when ephemeral tokens expire
* Updates the Connect API `/sessions/ephemeral` documentation to clarify how long sessions are valid after the ephemeral token is used to create a session
* Updates the Connect JS documentation to clarify when ephemeral tokens expire
* Updates the Connect JS documentation to clarify how long sessions are valid after the ephemeral token is used to create a session