### PR TITLE
Miscellaneous fixes

### DIFF
--- a/_data-structure/nested-data-structures-row-count-impact.md
+++ b/_data-structure/nested-data-structures-row-count-impact.md
@@ -10,10 +10,23 @@ weight: 4
 ---
 {% include misc/data-files.html %}
 
-{% capture callout %}
-his article is only applicable to Panoply, PostgreSQL, Redshift, Snowflake, and S3 (CSV) destinations.
+{% assign destinations-without-nesting = site.destinations | where:"nested-structure-support",false %}
 
-**Postgres `ARRAY` & `JSON` datatypes:** The info in this article is **not** applicable to Postgres `ARRAY` and `JSON` data types. These data types will be stored as `strings` in your data warehouse, whether it's Postgres, Panoply, or Redshift.{% endcapture %}
+{%- capture destinations-with-no-nested-support -%}
+{%- for destination in destinations-without-nesting -%}
+{%- case forloop.last -%}
+{% when true %}
+{{ destination.display_name | append: ", and S3 (CSV)" }}
+{% else %}
+{{ destination.display_name | append: ", " }}
+{%- endcase -%}
+{%- endfor -%}
+{%- endcapture -%}
+
+{% capture callout %}
+This article is applicable only to {{ destinations-with-no-nested-support }} destinations, as they do not natively support nested data structures.
+
+**PostgreSQL `ARRAY` & `JSON` datatypes:** The info in this article is not applicable to PostgreSQL `ARRAY` and `JSON` data types. These data types will be stored as `strings` in your data warehouse, whether it's PostgreSQL, Panoply, or Redshift.{% endcapture %}
 
 {% include important.html first-line="**Not applicable to all destinations**" content=callout %}
 

--- a/_data-structure/nested-data-structures-row-count-impact.md
+++ b/_data-structure/nested-data-structures-row-count-impact.md
@@ -24,11 +24,10 @@ weight: 4
 {%- endcapture -%}
 
 {% capture callout %}
-This article is applicable only to {{ destinations-with-no-nested-support }} destinations, as they do not natively support nested data structures.
+- **Destinations**: This article is applicable only to **{{ destinations-with-no-nested-support | strip }}** destinations, as they do not natively support nested data structures.
+- **PostgreSQL `ARRAY` & `JSON` datatypes:** The info in this article is not applicable to PostgreSQL `ARRAY` and `JSON` data types. These data types will be stored as strings in your data warehouse, whether it's PostgreSQL, Panoply, or Redshift.{% endcapture %}
 
-**PostgreSQL `ARRAY` & `JSON` datatypes:** The info in this article is not applicable to PostgreSQL `ARRAY` and `JSON` data types. These data types will be stored as `strings` in your data warehouse, whether it's PostgreSQL, Panoply, or Redshift.{% endcapture %}
-
-{% include important.html first-line="**Not applicable to all destinations**" content=callout %}
+{% include important.html first-line="**Not applicable to all destinations and data types**" content=callout %}
 
 To understand how Stitch interprets the data it receives, you need to know a little bit about JSON.
 

--- a/_data-structure/nested-data-structures-row-count-impact.md
+++ b/_data-structure/nested-data-structures-row-count-impact.md
@@ -49,7 +49,7 @@ When Stitch pulls data from an integration, it's pulling a series of JSON record
 ### Objects {#json-objects}
 An object is an unordered set of name and value pairs; each set is called a property. Objects begin with a left curly bracket ( `{` ) and end with a right curly bracket ( `}` ).
 
-{% highlight json %}
+```json
 {  
    "product_id":"5008798",
    "name":"Awesome Dino Shirt",
@@ -61,7 +61,7 @@ An object is an unordered set of name and value pairs; each set is called a prop
       "ounces":"5"
    }                           // object ends
 }
-{% endhighlight %}
+```
 
 When Stitch receives an object, the properties in the object are "flattened" into the table and columns are created. Columns created from object properties follow this naming convention: `[object_name]__[property_name]`
 
@@ -77,8 +77,8 @@ If a table were created for the object in the example above, the schema would lo
 An array is an ordered collection of values. Values are separated by commas and can be a string (contained in double quotes), numbers, boolean, an object, or another array. Arrays begin with a left square bracket ( `[` ) and end with a right square bracket ( `]` ).
 
 Here's an example:
-{% highlight json %}
 
+```json
 {
    "order_id":"1234",
    "customer_id":"100",
@@ -89,7 +89,7 @@ Here's an example:
       }
    ]                        // array ends
 }
-{% endhighlight %}
+```
 
 When Stitch receives a nested array - or an array that's inside a JSON record - like the one above, it will "denest" it from the parent structure and create a subtable.
 
@@ -105,7 +105,7 @@ To give you a better understanding of how Stitch denests arrays, we'll walk you 
 
 Here's what the JSON for the Shopify order looks like:
 
-{% highlight json %}
+```json
 {
    "order_id":"1234",
    "created_at":"2015-01-01 00:00:00",
@@ -125,7 +125,7 @@ Here's what the JSON for the Shopify order looks like:
       }
    ]                                    // line item record ends
 }
-{% endhighlight %}
+```
 
 This record contains three levels of data due to the nested arrays. Stitch will denest the arrays from the top level record - in this case, the core order info - and create subtables. **From this one order record, three tables will be created:**
 
@@ -167,11 +167,11 @@ Here's what the `orders__line_items` table would look like if another line item 
 
 If you wanted to return all line items for order number `1234`, you’d run the following query:
 
-{% highlight sql %}
-     SELECT *
-     FROM orders__line_items li
-     WHERE {{ system-column.source-key | append: "order_id" }} = 1234
-{% endhighlight %}
+```sql
+SELECT *
+  FROM orders__line_items li
+ WHERE {{ system-column.source-key | append: "order_id" }} = 1234
+```
 
 ### Third level: Tax Lines {#third-level}
 
@@ -192,14 +192,14 @@ Here's what the `orders__line_items__tax_lines` table would look like if we adde
 
 If we wanted to return all line items and tax lines for order number `1234`, we’d run the following query:
 
-{% highlight sql %}
-     SELECT *
-     FROM orders__line_items li
-     INNER JOIN orders__line_items__tax_lines tl
-     ON tl._{{ system-column.level-id | replace: '#', '0' }} = li._{{ system-column.level-id | replace: '#', '0' }}
-     AND tl._{{ system-column.source-key | append: "order_id" }} = li._{{ system-column.source-key | append: "order_id" }}
+```sql
+    SELECT *
+      FROM orders__line_items li
+INNER JOIN orders__line_items__tax_lines tl
+        ON tl._{{ system-column.level-id | replace: '#', '0' }} = li._{{ system-column.level-id | replace: '#', '0' }}
+       AND tl._{{ system-column.source-key | append: "order_id" }} = li._{{ system-column.source-key | append: "order_id" }}
      WHERE {{ system-column.source-key | append: "order_id" }} = 1234
-{% endhighlight %}
+```
 
 ---
 

--- a/_data/taps/versions/facebook-ads.yml
+++ b/_data/taps/versions/facebook-ads.yml
@@ -7,6 +7,7 @@ latest-version: "1.0"
 released-versions:
   - number: "1.0"
     date-released: "September 11, 2017"
+    # date-last-connection:
     deprecated: false
     deprecation-date: "n/a"
 

--- a/_data/taps/versions/google-adwords.yml
+++ b/_data/taps/versions/google-adwords.yml
@@ -7,6 +7,6 @@ latest-version: "1.0"
 released-versions:
   - number: "1.0"
     date-released: "December 5, 2017"
-    released: true
+    # date-last-connection:
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"

--- a/_data/taps/versions/google-analytics-adwords.yml
+++ b/_data/taps/versions/google-analytics-adwords.yml
@@ -7,12 +7,12 @@ latest-version: "05-12-2017"
 released-versions:
   - number: "05-12-2017"
     date-released: "December 5, 2017"
-    released: true
+    # date-last-connection: ""
     deprecated: false
     deprecation-date: "n/a"
 
   - number: "15-10-2015"
     date-released: "October 15, 2015"
-    released: true
+    date-last-connection: "December 4, 2017"
     deprecated: true
     deprecation-date: "n/a"

--- a/_data/taps/versions/hubspot.yml
+++ b/_data/taps/versions/hubspot.yml
@@ -7,15 +7,18 @@ latest-version: "2.0"
 released-versions:
   - number: "2.0"
     date-released: "May 30, 2018"
+    # date-last-connection:
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"
 
   - number: "1.0"
     date-released: "August 22, 2017"
+    date-last-connection: "May 29, 2018"
     deprecated: true
     deprecation-date: "September 1, 2018"
 
   - number: "01-03-2017"
     date-released: "March 1, 2017"
+    date-last-connection: "August 21, 2017"
     deprecated: true
     deprecation-date: "November 22, 2017"

--- a/_data/taps/versions/marketo.yml
+++ b/_data/taps/versions/marketo.yml
@@ -7,10 +7,12 @@ latest-version: "2.0"
 released-versions:
   - number: "2.0"
     date-released: "June 26, 2018"
+    # date-last-connection: ""
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"
 
   - number: "1.0"
     date-released: "March 1, 2017"
+    date-last-connection: "June 25, 2018"
     deprecated: true
     deprecation-date: "September 24, 2018"

--- a/_data/taps/versions/mysql.yml
+++ b/_data/taps/versions/mysql.yml
@@ -10,5 +10,6 @@ latest-version: "0.14"
 released-versions:
   - number: "0.14"
     date-released: "October 24, 2017"
+    # date-last-connection:
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"

--- a/_data/taps/versions/postgres.yml
+++ b/_data/taps/versions/postgres.yml
@@ -9,11 +9,13 @@ tap-name: "PostgreSQL"
 released-versions:
   - number: "1.0"
     date-released: "July 31, 2018"
+    # date-last-connection:
     deprecated: false
     deprecation-date: "n/a"
 
   - number: "15-10-2015"
     date-released: "October 15, 2015"
+    date-last-connection: "July 30, 2018"
     deprecated: true
     deprecation-date: "To be determined"
 

--- a/_data/taps/versions/salesforce.yml
+++ b/_data/taps/versions/salesforce.yml
@@ -7,10 +7,12 @@ latest-version: "1.0"
 released-versions:
   - number: "1.0"
     date-released: "November 16, 2017"
+    # date-last-connection:
     deprecated: false
     deprecation-date: "n/a"
 
   - number: "15-10-2015"
     date-released: "October 15, 2015"
+    date-last-connection: "November 15, 2017"
     deprecated: true
     deprecation-date: "n/a"

--- a/_data/taps/versions/version-template.yml
+++ b/_data/taps/versions/version-template.yml
@@ -7,10 +7,12 @@ latest-version: ""
 released-versions:
   - number: ""
     date-released: ""
+    # date-last-connection:
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"
 
   - number: ""
     date-released: ""
+    # date-last-connection:
     deprecated: true
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"

--- a/_data/taps/versions/zendesk.yml
+++ b/_data/taps/versions/zendesk.yml
@@ -6,11 +6,13 @@ latest-version: "1.0"
 
 released-versions:
   - number: "1.0"
-    date-released: "TBD"
+    date-released: "August 1, 2018"
+    # date-last-connection: ""
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"
 
   - number: "15-10-2015"
     date-released: "October 15, 2015"
+    date-last-connection: "July 31, 2018"
     deprecated: true
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"

--- a/_data/taps/versions/zuora.yml
+++ b/_data/taps/versions/zuora.yml
@@ -7,10 +7,12 @@ latest-version: "1.0"
 released-versions:
   - number: "1.0"
     date-released: "April 17, 2018"
+    # date-last-connection:
     deprecated: false
-    # deprecation-date: "n/a"
+    deprecation-date: "n/a"
 
   - number: "15-10-2015"
     date-released: "October 15, 2015"
+    date-last-connection: "April 16, 2018"
     deprecated: true
     deprecation-date: "September 1, 2018"

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -86,6 +86,7 @@ destinations:
 # -------------------------- #
 ## used as link.destinations.loading.[id]
   loading:
+    overview: /data-structure/loading-stitch-data-into-destinations
     bigquery: /data-structure/bigquery-data-loading-behavior
     panoply: /data-structure/panoply-data-loading-behavior
     postgres: /data-structure/postgresql-data-loading-behavior

--- a/_includes/integrations/templates/schemas/table-schemas.html
+++ b/_includes/integrations/templates/schemas/table-schemas.html
@@ -14,7 +14,13 @@
     {% assign schema = site.integration-schemas | where:"tap",integration.name %}
 {% endif %}
 
+{% capture schemas-and-destination-loading %}
+Depending on your destination, table and column names may not appear as they are outlined below.
 
+For example: Object names are lowercased in Redshift (`CusTomERs` > `customers`), while case is maintained in PostgreSQL destinations (`CusTomERs` > `CusTomERs`). Refer to the [Loading Guide]({{ link.destinations.loading.overview | prepend: site.baseurl }}) for your destination for more info.
+{% endcapture %}
+
+{% include note.html first-line="**Table and column names in your destination**" content=schemas-and-destination-loading %}
 
 {% for table in schema %}
 <!-- Some tables can have composite keys, or multiple columns that make up a PK. 

--- a/_includes/notifications/integration-deprecation-notice.html
+++ b/_includes/notifications/integration-deprecation-notice.html
@@ -11,12 +11,6 @@
 
 
 {% for version in released-versions %}
-    {% if version.number == latest-version %}
-        {% capture latest-version-release-date %}
-            {{ version.date-released }}
-        {% endcapture %}
-    {% endif %}
-
     {% if version.number == integration.this-version %}
         {% if version.deprecated == true %}
 
@@ -31,7 +25,7 @@
 {% capture deprecation %}
 This version of the {{ integration.display_name }} integration will be deprecated on **{{ version.deprecation-date }}** and no longer be formally supported by the Stitch Support Team.
 
-**Connections created from {{ version.date-released }} to {{ latest-version-release-date }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
+**Connections created from {{ version.date-released }} to {{ version.date-last-connection }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
     Upgrade to the latest version ({{ latest-version }}) to take advantage of the new enhancements.
 </a>
 {% endcapture %}
@@ -42,7 +36,7 @@ This version of the {{ integration.display_name }} integration will be deprecate
 {% capture deprecation %}
 A newer version of {{ integration.display_name }} is available in Stitch. This version will still continue to replicate data, but may be deprecated at a future date.
 
-**Connections created before {{ latest-version-release-date }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
+**Connections created before {{ version.date-last-connection }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
 Upgrade to the latest version ({{ latest-version }}) to take advantage of the new enhancements.
 </a>
 {% endcapture %}

--- a/_layouts/singer.html
+++ b/_layouts/singer.html
@@ -94,16 +94,16 @@ layout: page
 
 {% unless integration.no-schema == true %}
 <!-- SCHEMA DETAILS START -->
-<h2 id="schema">{{ integration.display_name }} Table Schemas</h2>
+<h2 id="schema">{{ integration.display_name }} table schemas</h2>
 
 <!-- Displays an info box if there are multiple versions of an integration currenly available -->
 
 {% if integration.this-version %}
 {% assign integration = page %}
 {% capture version-notice %}
-Schemas and naming conventions can change from version to version, so we recommend verifying your integration's version before continuing.<br><br>
+Schemas and naming conventions can change from version to version, so we recommend verifying your integration's version before continuing.
 
-The schema and info displayed below is for <strong>version {{ integration.this-version }}</strong> of this integration.
+The schema and info displayed below is for **version {{ integration.this-version }}** of this integration.
 
 {% if integration.this-version == latest-version %}
   This is the latest version of the {{ integration.display_name }} integraiton.


### PR DESCRIPTION
This PR fixes a few small, but annoying/confusing things:

- **Nested data flattening:** The info box in this article now uses a `forloop` to identify destinations that don't support nested structures (`nested-structure-support: false`) and only display the names of those destinations. This is in response to a support convo where a user noted that we incorrectly listed Snowflake, as nested data isn't flattened but stored as `VARIANT`.
- **Object naming in integration Table Schema sections**: A user pointed out that we display the Quickbooks schema as all lowercase, but in Postgres there are mixed-case object names. While this is expected behavior, not noting this in the docs lead to some confusion for the user.

   For the time being, I added a notice to this section that calls out object naming behavior and directs users to look at the loading guide for their destination.
- **Integration version deprecation notice:** Last week, some Stitches noticed some weird behavior around the integration version deprecation notice for Zendesk. This was because the `deprecation-date` value for the version was commented out, causing the logic to behave strangely.

   I added a new variable to integration version files (`version.date-last-connection`), which is used in the deprecation notice to display the `to` and `from` dates for connections. `date-last-connection` is the date in `MON DD,YYY` format that this version of the integration could be created in Stitch. Ex: `Connections created from [date-released] to [date-last-connection] use this version`.

   I also uncommented all the `deprecation-date` values for integrations with versions, so this won't be an issue going forward.

