### PR TITLE
Added zendesk (v15-10-2015) deprecation date

### DIFF
--- a/_data/taps/versions/zendesk.yml
+++ b/_data/taps/versions/zendesk.yml
@@ -15,4 +15,4 @@ released-versions:
     date-released: "October 15, 2015"
     date-last-connection: "July 31, 2018"
     deprecated: true
-    deprecation-date: "n/a"
+    deprecation-date: "November 5, 2018"


### PR DESCRIPTION
Added a deprecation date of Nov 5 for older Zendesk integration.