### PR TITLE
PostgreSQL v1: Logical replication limitations

### DIFF
--- a/_database-integrations/postgres/amazon-rds/postgresql-amazon-rds-overview.md
+++ b/_database-integrations/postgres/amazon-rds/postgresql-amazon-rds-overview.md
@@ -27,19 +27,7 @@ sections:
   - title: "Version features"
     anchor: "version-features"
     content: |
-      {% capture logical-replication-limitations %}
-      On August 6, 2018, we discovered some limitations with {{ integration.display_name }} Log-based Replication. Currently, Log-based Replication requires:
-
-      - **PostgreSQL databases running PostgreSQL versions 9.4.x-9.9.x.** If your database is running PostgreSQL 10 or greater, Log-based Replication will not work. Some of the functions Stitch uses to replicate data were renamed in PostgreSQL 10.
-
-         We are working on adding support for logical replication - which is what Stitch uses to perform Log-based Replication - to the integration. In the meantime, use Key-based Incremental Replication.
-
-      - **A connection to the master instance.** Log-based Replication will not work on read replicas. When PostgreSQL initially released logical replication, support for replicating from read replicas wasn't implemented.
-
-         [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding this feature to a future version. Until this feature is released, you can connect Stitch to the master instance and use Log-based Replication, **or** connect to a read replica and use Key-based Incremental Replication.
-      {% endcapture %}
-
-      {% include important.html first-line="**Log-based Replication requirements**" content=logical-replication-limitations %}
+      {% include notifications/postgres-binlog-limitations.html %}
 
       In this section:
 

--- a/_database-integrations/postgres/amazon-rds/postgresql-amazon-rds-overview.md
+++ b/_database-integrations/postgres/amazon-rds/postgresql-amazon-rds-overview.md
@@ -27,6 +27,20 @@ sections:
   - title: "Version features"
     anchor: "version-features"
     content: |
+      {% capture logical-replication-limitations %}
+      On August 6, 2018, we discovered some limitations with {{ integration.display_name }} Log-based Replication. Currently, Log-based Replication requires:
+
+      - **PostgreSQL databases running PostgreSQL versions 9.4.x-9.9.x.** If your database is running PostgreSQL 10 or greater, Log-based Replication will not work. Some of the functions Stitch uses to replicate data were renamed in PostgreSQL 10.
+
+         We are working on adding support for logical replication - which is what Stitch uses to perform Log-based Replication - to the integration. In the meantime, use Key-based Incremental Replication.
+
+      - **A connection to the master instance.** Log-based Replication will not work on read replicas. When PostgreSQL initially released logical replication, support for replicating from read replicas wasn't implemented.
+
+         [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding this feature to a future version. Until this feature is released, you can connect Stitch to the master instance and use Log-based Replication, **or** connect to a read replica and use Key-based Incremental Replication.
+      {% endcapture %}
+
+      {% include important.html first-line="**Log-based Replication requirements**" content=logical-replication-limitations %}
+
       In this section:
 
       - [Supported features](#supported-features)

--- a/_database-integrations/postgres/amazon-rds/v1/postgresql-amazon-rds-v1.md
+++ b/_database-integrations/postgres/amazon-rds/v1/postgresql-amazon-rds-v1.md
@@ -67,19 +67,21 @@ requirements-list:
       **Permissions in Amazon Web Services (AWS) that allow you to**:
 
         - Create/manage Security Groups, which is required to whitelist Stitch's IP addresses.
-        - View database details, which is required for retrieving the database's connection details.
-  - item: |
-      **If you want to use Log-based Replication**, you need:
-
-      - **To be running PostgreSQL 9.4 or greater**. Earlier versions of PostgreSQL do not include logical replication functionality, which is required for Log-based Replication.
-      
-      - **The `rds_superuser` role in your {{ integration.display_name }} database, if you want to use Log-based Replication.** [This role](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Roles){:target="new"} is required to grant the `rds_replication` privilege to Stitch's database user.
-  - item: "**To be running PostgeSQL 9.3+ or greater**, or 9.4 or greater if you want to use Log-based Replication."
+        - View database details, which is required for retrieving the database's connection details
   - item: "**Permissions in PostgreSQL that allow you to create users.** This is required to create a database user for Stitch."
   - item: |
-      **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `standby` settings - before connecting it to Stitch.
+      **If using Log-based Replication**, you'll need:
 
-      Info about these settings can be found in the [Configure the database parameter group](#configure-database-parameter-group) section.
+      - **A database running PostgreSQL 9.4.x - 9.9.x.** Earlier versions of PostgreSQL do not include logical replication functionality, which is required for Log-based Replication.
+         We are working on adding support for logical replication in PostgreSQL 10 to this integration.
+      - **The `rds_superuser` role in your {{ integration.display_name }} database, if you want to use Log-based Replication.** [This role](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Roles){:target="new"} is required to grant the `rds_replication` privilege to Stitch's database user.
+      - **To connect to the master instance.** Log-based replication will only work on master instances due to a feature gap in PostgreSQL 10. [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding support for using logical replication on a read replica to a future version.
+  - item: |
+      **If you're not using Log-based Replication**, you'll need:
+
+      - **A database running PostgreSQL 9.3.x or greater.** PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations.
+      - **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `max_standby_streaming_delay` and `max_standby_archive_delay` settings - before connecting it to Stitch. We recommend setting these parameters to 8-12 hours for an initial replication job, and then decreasing them afterwards.
+
 
 # -------------------------- #
 #     Setup Instructions     #

--- a/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
+++ b/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
@@ -60,7 +60,7 @@ notice-copy: |
 
 requirements-list:
   - item: "**Permissions in PostgreSQL that allow you to create users.** This is required to create a database user for Stitch."
-  - item: "**To be running PostgeSQL 9.3+ or greater**."
+  - item: "**To be running PostgeSQL 9.3+ or greater**. PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations."
   - item: |
       **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `max_standby_streaming_delay` and `max_standby_archive_delay` settings - before connecting it to Stitch. We recommend setting these parameters to 8-12 hours for an initial replication job, and then decreasing them afterwards.
 

--- a/_database-integrations/postgres/vanilla/v1/postgres-v1.md
+++ b/_database-integrations/postgres/vanilla/v1/postgres-v1.md
@@ -74,16 +74,18 @@ notice-copy: |
 
 requirements-list:
   - item: "**The `CREATEROLE` or `SUPERUSER` privilege.** Either permission is required to create a database user for Stitch."
-  - item: "**The `SUPERUSER` privilege.** If using logical replication, this is required to define the appropriate server settings."
   - item: |
-      **A PostgreSQL that's running version:**
-         - **9.4 or greater to use Log-based Replication**. Earlier versions of PostgreSQL do not include logical replication functionality, which is required for Log-based Replication. 
-         - **9.3 or greater** if not using Log-based Replication.
+      **If using Log-based Replication**, you'll need:
 
+      - **A database running PostgreSQL 9.4.x - 9.9.x.** Earlier versions of PostgreSQL do not include logical replication functionality, which is required for Log-based Replication.
+         We are working on adding support for logical replication in PostgreSQL 10 to this integration.
+      - **The `SUPERUSER` privilege.** If using logical replication, this is required to define the appropriate server settings.
+      - **To connect to the master instance.** Log-based replication will only work on master instances due to a feature gap in PostgreSQL 10. [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding support for using logical replication on a read replica to a future version.
   - item: |
-      **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `standby` settings - before connecting it to Stitch.
+      **If you're not using Log-based Replication**, you'll need:
 
-      Info about these settings can be found in the [Configure database server settings](#server-settings) section.
+      - **A database running PostgreSQL 9.3.x or greater.** PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations.
+      - **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `max_standby_streaming_delay` and `max_standby_archive_delay` settings - before connecting it to Stitch. We recommend setting these parameters to 8-12 hours for an initial replication job, and then decreasing them afterwards.
 
 # -------------------------- #
 #     Setup Instructions     #

--- a/_database-integrations/postgres/vanilla/vanilla-postgres-overview.md
+++ b/_database-integrations/postgres/vanilla/vanilla-postgres-overview.md
@@ -32,6 +32,8 @@ sections:
   - title: "{{ integration.display_name }} version features"
     anchor: "version-features"
     content: |
+      {% include notifications/postgres-binlog-limitations.html %}
+
       In this section:
 
       - [Supported features](#supported-features)

--- a/_includes/integrations/databases/setup/binlog/configure-server-settings-intro.html
+++ b/_includes/integrations/databases/setup/binlog/configure-server-settings-intro.html
@@ -1,17 +1,18 @@
-{% capture important %}
 {% case integration.db-type %}
 {% when 'mysql' %}
+{% capture important %}
 **To use binlog replication, your {{ integration.display_name }} database must be running MySQL version 5.6.2 or greater**.
-
-{% when 'postgres' %}
-**To use logical replication, your {{ integration.display_name }} database must be running PostgreSQL version 9.4 or greater**.
-{% endcase %}
 
 Additionally, setting up binlog replication requires rebooting your database to ensure parameter changes take effect. To minimize disruptions, we recommend performing the reboot during non-peak usage hours.
 {% endcapture %}
 
-
 {% include important.html first-line="**Requirements for configuring binlog replication**" content=important %}
+
+{% when 'postgres' %}
+{% include notifications/postgres-binlog-limitations.html %}
+{% endcase %}
+
+
 
 Next, you'll configure your server to use [Log-based Incremental Replication]({{ link.replication.rep-methods | prepend: site.baseurl }}), or binlog replication.
 

--- a/_includes/notifications/postgres-binlog-limitations.html
+++ b/_includes/notifications/postgres-binlog-limitations.html
@@ -1,0 +1,13 @@
+{% capture logical-replication-limitations %}
+On August 6, 2018, we discovered some limitations with {{ integration.display_name }} Log-based Replication. Currently, Log-based Replication requires:
+
+- **PostgreSQL databases running PostgreSQL versions 9.4.x-9.9.x.** If your database is running PostgreSQL 10 or greater, Log-based Replication will not work. Some of the functions Stitch uses to replicate data were renamed in PostgreSQL 10.
+
+   We are working on adding support for logical replication - which is what Stitch uses to perform Log-based Replication - to the integration. In the meantime, use Key-based Incremental Replication.
+
+- **A connection to the master instance.** Log-based Replication will not work on read replicas. When PostgreSQL initially released logical replication, support for replicating from read replicas wasn't implemented.
+
+   [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding this feature to a future version. Until this feature is released, you can connect Stitch to the master instance and use Log-based Replication, **or** connect to a read replica and use Key-based Incremental Replication.
+{% endcapture %}
+
+{% include important.html first-line="**Log-based Replication requirements**" content=logical-replication-limitations %}

--- a/_includes/notifications/postgres-binlog-limitations.html
+++ b/_includes/notifications/postgres-binlog-limitations.html
@@ -5,9 +5,9 @@ On August 6, 2018, we discovered some limitations with {{ integration.display_na
 
    We are working on adding support for logical replication - which is what Stitch uses to perform Log-based Replication - to the integration. In the meantime, use Key-based Incremental Replication.
 
-- **A connection to the master instance.** Log-based Replication will not work on read replicas. When PostgreSQL initially released logical replication, support for replicating from read replicas wasn't implemented.
+- **A connection to the master instance.** Log-based replication will only work on master instances due to a feature gap in PostgreSQL 10. [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding support for using logical replication on a read replica to a future version.
 
-   [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding this feature to a future version. Until this feature is released, you can connect Stitch to the master instance and use Log-based Replication, **or** connect to a read replica and use Key-based Incremental Replication.
+   Until this feature is released, you can connect Stitch to the master instance and use Log-based Replication, **or** connect to a read replica and use Key-based Incremental Replication.
 {% endcapture %}
 
 {% include important.html first-line="**Log-based Replication requirements**" content=logical-replication-limitations %}


### PR DESCRIPTION
This PR adds info about logical replication limitations to the overview and setup docs for vanilla Postgres and Postgres RDS.

The limitations:

- The Singer PostgreSQL tap only supports logical replication for Postgres databases running 9.4.x - 9.9.x.
   Version 10 renames some of the functions used for logical replication. We're working on adding this feature to the tap.
- Only master instances can use logical replication. Log-based replication will only work on master instances due to a feature gap in PostgreSQL 10. [Based on their forums, PostgreSQL](https://commitfest.postgresql.org/12/788/) is working on adding support for using logical replication on a read replica to a future version.