### PR TITLE
Update references to adwords docs to api version v201806

### DIFF
--- a/_integration-schemas/google-adwords/accounts.md
+++ b/_integration-schemas/google-adwords/accounts.md
@@ -3,7 +3,7 @@ tap: "google-adwords"
 version: "1.0"
 
 name: "accounts"
-doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/ManagedCustomerService.ManagedCustomer
+doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/ManagedCustomerService.ManagedCustomer
 singer-schema: https://github.com/singer-io/tap-adwords/blob/master/tap_adwords/schemas/accounts.json
 description: |
   The `accounts` table contains high-level info about the Google AdWords account(s) you’ve connected to Stitch.

--- a/_integration-schemas/google-adwords/ad_groups.md
+++ b/_integration-schemas/google-adwords/ad_groups.md
@@ -3,7 +3,7 @@ tap: "google-adwords"
 version: "1.0"
 
 name: "ad_groups"
-doc-link: https://developers.google.com/adwords/api/docs/reference/v201605/AdGroupService.AdGroup
+doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupService.AdGroup
 singer-schema: https://github.com/singer-io/tap-adwords/blob/master/tap_adwords/schemas/ad_groups.json
 description: |
   The `ad_groups` table contains detailed info about your ad groups.
@@ -24,7 +24,7 @@ attributes:
   - name: "adGroupType"
     type: "string"
     description: "The type of the ad group."
-    doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupService.AdGroupType
+    doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupService.AdGroupType
 
   - name: "baseAdGroupId"
     type: "integer"
@@ -58,7 +58,7 @@ attributes:
               - name: "ComparableValue.Type"
                 type: "string"
                 description: "Indicates that this instance is a subtype of ComparableValue."
-                doc-link: https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupService.Money
+                doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupService.Money
 
               - name: "microAmount"
                 type: "integer"
@@ -127,7 +127,7 @@ attributes:
           - name: "targetAll"
             type: "integer"
             description: "Indicates if criteria of this type can be used to modify bidding but not restrict targeting of ads."
-            doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupService.TargetingSettingDetail
+            doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupService.TargetingSettingDetail
 
           - name: "criterionTypeGroup"
             type: "string"

--- a/_integration-schemas/google-adwords/ads.md
+++ b/_integration-schemas/google-adwords/ads.md
@@ -3,7 +3,7 @@ tap: "google-adwords"
 version: "1.0"
 
 name: "ads"
-doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupAdService.AdGroupAd
+doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupAdService.AdGroupAd
 singer-schema: https://github.com/singer-io/tap-adwords/blob/master/tap_adwords/schemas/ads.json
 description: |
   The `ads` table contains comprehensive info about ads in ad groups in your Google AdWords account.
@@ -47,7 +47,7 @@ attributes:
   - name: "policySummary"
     type: "object"
     description: "Summary of policy findings for the ad."
-    doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/AdGroupAdService.AdGroupAdPolicySummary
+    doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupAdService.AdGroupAdPolicySummary
     object-attributes:
       - name: "combinedApprovalStatus"
         type: "string"
@@ -104,5 +104,5 @@ attributes:
   - name: "trademarkDisapproved"
     type: "integer"
     description: "Indicates if the ad isn't serving because it doesn't meet trademark policy."
-    doc-link: https://developers.google.com/adwords/api/docs/reference/v201702/AdGroupAdService.AdGroupAd#trademarkdisapproved
+    doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupAdService.AdGroupAd#trademarkdisapproved
 ---

--- a/_integration-schemas/google-adwords/campaigns.md
+++ b/_integration-schemas/google-adwords/campaigns.md
@@ -3,7 +3,7 @@ tap: "google-adwords"
 version: "1.0"
 
 name: "campaigns"
-doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/CampaignService.Campaign
+doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/CampaignService.Campaign
 singer-schema: https://github.com/singer-io/tap-adwords/blob/master/tap_adwords/schemas/campaigns.json
 description: |
   The `campaigns` table contains detailed info about your Google AdWords campaigns.
@@ -45,7 +45,7 @@ attributes:
   - name: "campaignTrialType"
     type: "string"
     description: "Indicates the campaign type."
-    doc-link: https://developers.google.com/adwords/api/docs/reference/v201705/CampaignService.CampaignTrialType
+    doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/CampaignService.CampaignTrialType
 
   - name: "customerId"
     type: "integer"

--- a/_saas-integrations/google-adwords/google-adwords-latest.md
+++ b/_saas-integrations/google-adwords/google-adwords-latest.md
@@ -28,7 +28,7 @@ repo-url: https://github.com/singer-io/tap-adwords
 #     Integration Details    #
 # -------------------------- #
 
-api-version: "v201702"
+api-version: "v201806"
 
 status: "Released"
 certified: true # Stitch-supported integration


### PR DESCRIPTION
Tap-adwords just got an update to its API version to the latest v201806. Although the links to google's docs here redirect to that version, I thought I'd make a PR to make them explicit.