### PR TITLE
Zendesk/v1: Add `satisfaction_ratings` & `ticket_comments`

### DIFF
--- a/_data/taps/versions/zendesk.yml
+++ b/_data/taps/versions/zendesk.yml
@@ -16,3 +16,37 @@ released-versions:
     date-last-connection: "July 31, 2018"
     deprecated: true
     deprecation-date: "November 5, 2018"
+
+# -------------------------- #
+#     ZENDESK CHANGELOG     #
+# -------------------------- #
+
+# Changelog entry types:
+# - new-release
+# - version-deprecation
+# - schema-change
+# - maintenance
+# - new-data
+
+# Depending on the entry type, some initial copy and a pre-defined
+# Summary heading might display. See:
+# _includes/integrations/templates/versioning/integration-changelog.html
+
+changelog-entries:
+  - date: "August 15, 2018"
+    version: "1.0"
+    type: "new-data"
+    content: |
+      Two additional tables have been added to v1.0 of Zendesk:
+
+      - `satisfaction_ratings` - This table contains info about ratings users have offered on ticket.
+      - `ticket_comments` - This table contains info about the conversation between agents, requesters, and collaborators on tickets.
+
+  - date: "August 1, 2018"
+    version: "1.0"
+    type: "new-version"
+    content: |
+      Highlights include:
+
+      - Table and column selection
+      - Support for Extraction Logs, Loading Reports, and Anchor Scheduling

--- a/_integration-schemas/zendesk/foreign-keys.md
+++ b/_integration-schemas/zendesk/foreign-keys.md
@@ -13,6 +13,7 @@ foreign-keys:
         join-on: "id"
       - table: "group_memberships"
       - table: "organizations"
+      - table: "satisfaction_ratings"
       - table: "tickets"
       - table: "users"
         join-on: "default_group_id"
@@ -85,6 +86,7 @@ foreign-keys:
         join-on: "id"
       - table: "ticket_audits"
         subtable: "events"
+      - table: "ticket_comments"
 
   - id: "ticket-field-id"
     attribute: "ticket_field_id"
@@ -114,6 +116,7 @@ foreign-keys:
     table: "tickets"
     join-on: "id"
     all-foreign-keys:
+      - table: "satisfaction_ratings"
       - table: "tickets"
         join-on: "id"
       - table: "ticket_audits"
@@ -132,7 +135,13 @@ foreign-keys:
     table: "users"
     join-on: "id"
     all-foreign-keys:
+      - table: "satisfaction_ratings"
+        join-on: "assignee_id"
+      - table: "satisfaction_ratings"
+        join-on: "requester_id"
       - table: "ticket_audits"
+        join-on: "author_id"
+      - table: "ticket_comments"
         join-on: "author_id"
       - table: "tickets"
         join-on: "requester_id"

--- a/_integration-schemas/zendesk/satisfaction_ratings.md
+++ b/_integration-schemas/zendesk/satisfaction_ratings.md
@@ -1,0 +1,88 @@
+---
+tap: "zendesk"
+version: "1.0"
+
+name: "satisfaction_ratings"
+doc-link: https://developer.zendesk.com/rest_api/docs/core/satisfaction_ratings
+singer-schema: https://github.com/singer-io/tap-zendesk/blob/master/tap_zendesk/schemas/satisfaction_ratings.json
+description: |
+  The `{{ table.name }}` table contains info about ratings users have offered on support tickets. 
+
+  **Note**: This table is only available if satisfaction ratings are enabled in your {{ integration.display_name }} account.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: List satisfaction ratings
+  doc-link: https://developer.zendesk.com/rest_api/docs/core/satisfaction_ratings#list-satisfaction-ratings
+
+attributes:
+  - name: "id"
+    type: "integer"
+    primary-key: true
+    description: "The satisfaction rating ID."
+
+  - name: "updated_at"
+    type: "string"
+    replication-key: true
+    description: "The time the rating was last updated."
+
+  - name: "assignee_id"
+    type: "integer"
+    description: "The ID of the agent assigned at the time of the rating."
+    foreign-key-id: "user-id"
+
+  - name: "created_at"
+    type: "string"
+    description: "The time the rating was created."
+
+  - name: "group_id"
+    type: "integer"
+    description: "The ID of the group assigned at the time of the rating."
+    foreign-key-id: "group-id"
+
+  - name: "reason_id"
+    type: "integer"
+    description: |
+      The ID of the reason the user selected for giving a negative rating. Possible values are:
+
+      - `0` - No reason provided (user didn't select a reason from the list menu)
+      - `5` - The issue took too long to resolve
+      - `6` - The issue wasn't resolved
+      - `7` - The agent's knowledge is unsatisfactory
+      - `8` - The agent's attitude is unsatisfactory
+      - `100` - Some other reason
+
+  - name: "requester_id"
+    type: "integer"
+    description: "The ID of the ticket requester submitting the rating."
+    foreign-key-id: "user-id"
+
+  - name: "ticket_id"
+    type: "integer"
+    description: "The ID of the ticket being rated."
+    foreign-key-id: "ticket-id"
+
+  - name: "url"
+    type: "string"
+    description: "The API URL of the rating."
+
+  - name: "score"
+    type: "string"
+    description: |
+      The rating. Possible values are:
+
+      - `offered`
+      - `unoffered`
+      - `good`
+      - `bad`
+
+  - name: "reason"
+    type: "string"
+    description: |
+      **Only applicable if [satisfaction reasons](https://support.zendesk.com/hc/en-us/articles/223152967){:target="new"} are enabled.** The reason for a bad rating, given by the requester in a follow-up question.
+
+  - name: "comment"
+    type: "string"
+    description: "The comment recieved with the rating, if available."
+---

--- a/_integration-schemas/zendesk/ticket_comments.md
+++ b/_integration-schemas/zendesk/ticket_comments.md
@@ -1,0 +1,204 @@
+---
+tap: "zendesk"
+version: "1.0"
+
+name: "ticket_comments"
+doc-link: https://developer.zendesk.com/rest_api/docs/core/ticket_comments
+singer-schema: https://github.com/singer-io/tap-zendesk/blob/master/tap_zendesk/schemas/ticket_comments.json
+description: |
+  The `{{ table.name }}` table contains info about the comments on tickets, which is the conversation between requesters, collaborators, and agents. Comments can be public or private.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: List comments
+  doc-link: https://developer.zendesk.com/rest_api/docs/core/ticket_comments#list-comments
+
+attributes:
+  - name: "id"
+    type: "integer"
+    description: "The ticket comment ID."
+    primary-key: true
+    foreign-key-id: "ticket-comment-id"
+
+  - name: "created_at"
+    type: "string"
+    replication-key: true
+    description: "The time the ticket comment was created."
+
+  - name: "body"
+    type: "string"
+    description: "The body of the comment."
+
+  - name: "type"
+    type: "string"
+    description: |
+      The comment type. Possible values are `Comment` or `VoiceComment`.
+
+  - name: "html_body"
+    type: "string"
+    description: "The comment formatted as HTML."
+
+  - name: "plain_body"
+    type: "string"
+    description: "The comment as plain text."
+
+  - name: "public"
+    type: "boolean"
+    description: "If `true`, the comment is public. Otherwise, the comment is an internal note."
+
+  - name: "audit_id"
+    type: "integer"
+    description: "The ID of the associated ticket audit."
+    foreign-key-id: "ticket-audit-id"
+
+  - name: "author_id"
+    type: "integer"
+    description: "The ID of the comment author."
+    foreign-key-id: "user-id"
+
+  - name: "attachments"
+    type: "array"
+    description: "Details about attachments associated with the ticket comment, if any."
+    array-attributes:
+      - name: "id"
+        type: "integer"
+        description: "The attachment ID."
+
+      - name: "file_name"
+        type: "string"
+        description: "The name of the image file."
+
+      - name: "content_url"
+        type: "string"
+        description: "The full URL where the image file can be downloaded."
+
+      - name: "content_type"
+        type: "string"
+        description: "The content type of the image. For example: `image/png`"
+
+      - name: "size"
+        type: "integer"
+        description: "The size of the image file in bytes."
+
+      - name: "inline"
+        type: "boolean"
+        description: "If `true`, the attachment is excluded from the attachment list and the attachment URL can be referenced within the comment of a ticket."
+
+      - name: "thumbnails"
+        type: "array"
+        description: "Details about the attachment's thumbnails."
+        array-attributes:
+          - name: "id"
+            type: "integer"
+            description: "The attachment thumbnail ID."
+
+          - name: "file_name"
+            type: "string"
+            description: "The name of the image thumbnail file."
+
+          - name: "content_url"
+            type: "string"
+            description: "The full URL where the image thumbnail file can be downloaded."
+
+          - name: "content_type"
+            type: "string"
+            description: "The content type of the image thumbnail. For example: `image/png`"
+
+          - name: "size"
+            type: "integer"
+            description: "The size of the image thumbnail in bytes."
+
+  - name: "via"
+    type: "object"
+    description: "Details about how the ticket comment was created."
+    object-attributes:
+      - name: "source"
+        type: "object"
+        description: "Details about how the ticket comment was created."
+        object-attributes:
+          - name: "from"
+            type: "object"
+            description: ""
+            object-attributes:
+              - name: "name"
+                type: "string"
+                description: ""
+
+              - name: "ticket_id"
+                type: "integer"
+                description: ""
+                foreign-key-id: "ticket-id"
+
+              - name: "address"
+                type: "string"
+                description: ""
+
+              - name: "subject"
+                type: "string"
+                description: ""
+
+          - name: "to"
+            type: "object"
+            description: ""
+            object-attributes:
+              - name: "address"
+                type: "string"
+                description: ""
+
+              - name: "name"
+                type: "string"
+                description: ""
+
+          - name: "rel"
+            type: "string"
+            description: ""
+
+      - name: "channel"
+        type: "string"
+        description: "The channel used to create the ticket comment. For example: `web`, `rule`, `mobile`"
+
+  - name: "metadata"
+    type: "object"
+    description: "System information (web client, IP address, etc.) and comment flags, if any."
+    object-attributes:
+      # Commenting out these fields - they're not documented by Zendesk.
+      # - name: "custom"
+      #   type: 
+      #   description: ""
+
+      # - name: "trusted"
+      #   type: "boolean"
+      #   description: ""
+
+      # - name: "notifications_suppressed_for"
+      #   type: "array"
+      #   description: "[TODO]"
+      #   array-attributes:
+      #     - name: "value"
+      #       type: "integer"
+      #       description: "[TODO]"
+
+      - name: "flags"
+        type: "array"
+        description: "For `Comment` and `VoiceComment` events, the comment flags applied to the comment."
+        array-attributes:
+          - name: "value"
+            type: "integer"
+            description: |
+              The value of the flag applied to the comment. [Refer to Zendesk's documentation for more info](https://developer.zendesk.com/rest_api/docs/core/ticket_comments#comment-flags).
+
+              Possible values are:
+
+              - `0` - Zendesk is unsure the comment should be trusted.
+              - `2` - The comment author was not part of the conversation.
+              - `3` - The comment author wasn't signed in when the comment was submitted.
+              - `4` - The comment was automatically generated.
+              - `5` - The attached file was rejected because it's too big.
+              - `11` - The comment was submitted by the user on behalf of the author.
+
+      - name: "flags_options"
+        type: "object"
+        description: "For `Comment` and `VoiceComment` events, additional information about the comment flags."
+        object-attributes:
+---


### PR DESCRIPTION
This PR:

- Adds documentation for the new `satisfaction_ratings` table (https://github.com/singer-io/tap-zendesk/pull/17)
- Adds documentation for the new `ticket_comments` table (https://github.com/singer-io/tap-zendesk/pull/17)
- Updates the foreign keys for Zendesk
- Updates Zendesk’s changelog