### PR TITLE
DoubleClick Campaign Manager - add to Connect

### DIFF
--- a/_connect-files/api/objects/form-properties/sources/doubleclick-campaign-manager-object.md
+++ b/_connect-files/api/objects/form-properties/sources/doubleclick-campaign-manager-object.md
@@ -1,0 +1,24 @@
+---
+content-type: "api-form"
+form-type: "source"
+key: "source-form-properties-doubleclick-campaign-manager-object"
+
+title: "DoubleClick Campaign Manager Source Form Property"
+description: "{{ api.form-properties.source-forms.doubleclick-campaign-manager.description }}"
+
+object-attributes:
+  - name: "frequency_in_minutes"
+    type: "string"
+    required: true
+    description: |
+      {{ connect.common.attributes.frequency | replace: "[INTEGRATION]","DoubleClick Campaign Manager" }}
+
+examples: 
+  - code: |
+      {  
+       "type":"platform.doubleclick-campaign-manager",
+       "properties":{
+          "frequency_in_minutes":"1440"
+        }
+      }
+---

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -279,6 +279,11 @@ form-properties:
       section: "#source-form-properties-bing-ads-object"
       description: "A Bing Ads connection reads data from the Bing Ads API and corresponds to source `type: platform.bingads`."
 
+    doubleclick-campaign-manager:
+      title: "DoubleClick Campaign Manager"
+      section: "#source-form-properties-doubleclick-campaign-manager-object"
+      description: "A DoubleClick Campaign Manager connection reads data from the DoubleClick Campaign Manager API and corresponds to source `type: platform.doubleclick-campaign-manager`."
+
     cloudsql-mysql:
       title: "Google CloudSQL MySQL"
       section: "#source-form-properties-cloudsql-mysql-object"

--- a/_data/sidebars/connect.yml
+++ b/_data/sidebars/connect.yml
@@ -168,6 +168,10 @@ api:
                 method: "object"
                 url: "{{ api.form-properties.source-forms.bronto.section }}"
 
+              - title: "DoubleClick Campaign Manager"
+                method: "object"
+                url: "{{ api.form-properties.source-forms.doubleclick-campaign-manager.section }}"
+
               - title: "Facebook Ads"
                 method: "object"
                 url: "{{ api.form-properties.source-forms.facebook-ads.section }}"


### PR DESCRIPTION
This PR adds the DoubleClick Campaign Manager report card to Connect.