### PR TITLE
AdWords: Fix link in `account_performance_report`

### DIFF
--- a/_integration-schemas/google-adwords/account_performance_report.md
+++ b/_integration-schemas/google-adwords/account_performance_report.md
@@ -33,5 +33,5 @@ attributes:
 
   - name: "Custom Fields"
     description: |
-      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report){:target="_blank"}.
+      Columns (attributes/segments/metrics) selected by you. For descriptions of available columns, see [Google's documentation](https://developers.google.com/adwords/api/docs/appendix/reports/account-performance-report){:target="_blank"}.
 ---


### PR DESCRIPTION
Corrects the link for the custom fields column attributes