### PR TITLE
Xero/Change v19-10-2016 status

### DIFF
--- a/_saas-integrations/xero/v19-10-2016/xero-v19-10-2016.md
+++ b/_saas-integrations/xero/v19-10-2016/xero-v19-10-2016.md
@@ -25,7 +25,7 @@ this-version: "19-10-2016"
 #       Stitch Details       #
 # -------------------------- #
 
-status: "Closed Beta"
+status: "Deprecated"
 certified: true
 
 historical: "1 year"


### PR DESCRIPTION
This PR updates the release status of the 19-10-2016 version of Xero to `deprecated`.