### PR TITLE
Postgres/v1: Remove v10 notice from binlog setup instructions

### DIFF
--- a/_includes/notifications/postgres-binlog-limitations.html
+++ b/_includes/notifications/postgres-binlog-limitations.html
@@ -1,9 +1,7 @@
 {% capture logical-replication-limitations %}
 On August 6, 2018, we discovered some limitations with {{ integration.display_name }} Log-based Replication. Currently, Log-based Replication requires:
 
-- **PostgreSQL databases running PostgreSQL versions 9.4.x-9.9.x.** If your database is running PostgreSQL 10 or greater, Log-based Replication will not work. Some of the functions Stitch uses to replicate data were renamed in PostgreSQL 10.
-
-   We are working on adding support for logical replication - which is what Stitch uses to perform Log-based Replication - to the integration. In the meantime, use Key-based Incremental Replication.
+- **PostgreSQL databases running PostgreSQL versions 9.4.x or greater.** Earlier versions of PostgreSQL do not include logical replication functionality, which is required for Log-based Replication.
 
 - **A connection to the master instance.** Log-based replication will only work on master instances due to a feature gap in PostgreSQL 10. [Based on their forums](https://commitfest.postgresql.org/12/788/){:target="new"}, PostgreSQL is working on adding support for using logical replication on a read replica to a future version.
 


### PR DESCRIPTION
removes indication that postgresql 10 is not supported, as this support has been added.