### PR TITLE
Amplitude/v1 - Free

### DIFF
--- a/_saas-integrations/amplitude/v1/amplitude-v1.md
+++ b/_saas-integrations/amplitude/v1/amplitude-v1.md
@@ -32,7 +32,7 @@ certified: false
 
 historical: "n/a"
 frequency: "30 minutes"
-tier: "Free/Paid"
+tier: "Free"
 status-url: "https://status.amplitude.com/"
 icon: /images/integrations/icons/amplitude.svg
 whitelist:


### PR DESCRIPTION
This PR updates the integration’s Availability to correctly be `Free`.