### PR TITLE
Postgres/v1 - schema/table name setting

### DIFF
--- a/_connect-content/connect-api.md
+++ b/_connect-content/connect-api.md
@@ -7,3 +7,4 @@ toc: false
 summary: false
 feedback: false
 ---
+{% include misc/data-files.html %}

--- a/_connect-files/api/objects/form-properties/sources/postgresql-object.md
+++ b/_connect-files/api/objects/form-properties/sources/postgresql-object.md
@@ -32,6 +32,11 @@ object-attributes:
     required: true
     description: "{{ connect.common.attributes.password }}"
 
+  - name: "{{ connect.common.attributes.include-schemas-name }}"
+    type: "string"
+    required: false
+    description: "{{ connect.common.attributes.include-schemas-description | flatify }}"
+
   - name: "ssh"
     type: "string"
     required: false
@@ -60,13 +65,14 @@ object-attributes:
 examples:
   - code: |
       {  
-       "type":"platform.postgresql",
+       "type":"platform.postgres",
        "properties":{  
           "host":"postgresql.some-host.com",
           "port":"5432",
           "dbname":"stitch",
           "user":"stitch_user",
           "password":"<PASSWORD>",
+          "{{ connect.common.attributes.include-schemas-name }}":"true",
           "ssh":"true",
           "ssh_host":"postgresql-ssh.host.com",
           "ssh_port":"22",

--- a/_data/connect/general.yml
+++ b/_data/connect/general.yml
@@ -44,6 +44,13 @@ common:
 
     ssl: "If `true`, SSL will be used to connect to the database."
 
+    include-schemas-name: "include_schemas_in_destination_stream_name"
+
+    include-schemas-description: |
+      If `true`, the name of the source schema will be included in the destination table name. For example: `<source_schema_name>__<table_name>`. This can help prevent table name collisions when two tables canonicalize to the same name.
+
+      For more info, refer to the [Database Integration Table Name Collisions guide]({{ link.troubleshooting.database-table-name-collisions | prepend: site.baseurl }}).
+
     ssh: "If `true`, an SSH tunnel will be used to connect to the database."
 
     ssh-host: "The IP address or hostname of the SSH server. This property is only required if `ssh: true`."

--- a/_data/ui/database-integration-settings/postgres.yml
+++ b/_data/ui/database-integration-settings/postgres.yml
@@ -19,7 +19,7 @@ descriptions:
   schema-names-tables: &schema-names-tables-description |
     Checking this setting will include schema names from the source database in the destination table name - for example: `<source_schema_name>__<table_name>`.
 
-          Stitch loads all selected replicated tables to a single schema, preserving only the table name. If two tables canonicalize to the same name - even if they're in different source databases or schemas - name collision errors can arise. Checking this setting can prevent these errors. 
+          Stitch loads all selected replicated tables to a single schema, preserving only the table name. If two tables canonicalize to the same name - even if they're in different source databases or schemas - name collision errors can arise. Checking this setting can prevent these issues. 
 
           **Note**: This setting can not be changed after the integration is saved. Additionally, this setting may create table names that exceed your destination's limits. For more info, refer to the [Database Integration Table Name Collisions guide]({{ link.troubleshooting.database-table-name-collisions | prepend: site.baseurl }}).
 

--- a/_data/ui/database-integration-settings/postgres.yml
+++ b/_data/ui/database-integration-settings/postgres.yml
@@ -11,6 +11,18 @@
 ## NOTE: 'defaults' is a variable assigned to this file: 
 ## /_data/ui/database-integration-settings/default-fields.yml
 
+
+field-names:
+  schema-names-tables: &schema-names-tables-name "Include PostgreSQL schema names in destination tables"
+
+descriptions:
+  schema-names-tables: &schema-names-tables-description |
+    Checking this setting will include schema names from the source database in the destination table name - for example: `<source_schema_name>__<table_name>`.
+
+          Stitch loads all selected replicated tables to a single schema, preserving only the table name. If two tables canonicalize to the same name - even if they're in different source databases or schemas - name collision errors can arise. Checking this setting can prevent these errors. 
+
+          **Note**: This setting can not be changed after the integration is saved. Additionally, this setting may create table names that exceed your destination's limits. For more info, refer to the [Database Integration Table Name Collisions guide]({{ link.troubleshooting.database-table-name-collisions | prepend: site.baseurl }}).
+
 # -------------------------- #
 #      VANILLA POSTGRES      #
 # -------------------------- #
@@ -34,6 +46,9 @@ postgres:
 
   - name: "{{ defaults.field-names.database }}"
     copy: "{{ defaults.field-copy.database | flatify }}"
+
+  - name: *schema-names-tables-name
+    copy: *schema-names-tables-description
 
 
 # -------------------------- #
@@ -61,6 +76,9 @@ cloudsql-postgres:
   - name: "{{ defaults.field-names.database }}"
     copy: "{{ defaults.field-copy.database | flatify }}"
 
+  - name: *schema-names-tables-name
+    copy: *schema-names-tables-description
+
 
 # -------------------------- #
 #           HEROKU           #
@@ -85,6 +103,9 @@ heroku:
 
   - name: "{{ defaults.field-names.database }}"
     copy: "Paste the **Database** name from the {{ integration.display_name }} Database Settings page into this field."
+
+  - name: *schema-names-tables-name
+    copy: *schema-names-tables-description
 
 
 # -------------------------- #
@@ -111,3 +132,6 @@ postgresql-rds:
 
   - name: "{{ defaults.field-names.database }}"
     copy: "{{ defaults.field-copy.database | flatify }}"
+
+  - name: *schema-names-tables-name
+    copy: *schema-names-tables-description

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -206,6 +206,7 @@ troubleshooting:
   mysql-tinyint-bit: /troubleshooting/mysql-tinyint1-stored-as-bit
   salesforce-formula-fields: /troubleshooting/stale-salesforce-data-formula-fields
   segment-missing-data: /troubleshooting/missing-segment-data-selective-integration-snippet
+  database-table-name-collisions: /troubleshooting/data-discrepancies/database-integration-table-name-collisions
 
 ## Replication
   postgres-hot-standby: /troubleshooting/postgres-hot-standby-settings-replication

--- a/_includes/connect/api-form-properties.html
+++ b/_includes/connect/api-form-properties.html
@@ -1,3 +1,4 @@
+{% include misc/data-files.html %}
 {% assign all-form-properties = site.connect-files | where:"content-type","api-form" %}
 
 {% case include.content %}
@@ -40,7 +41,7 @@
             <tr>
                 <td class="attribute-name">
                     <strong>
-                        {{ attribute.name }}
+                        {{ attribute.name | flatify }}
                     </strong><br>
                     {{ attribute.type | upcase }}<br>
 

--- a/_troubleshooting/data-discrepancies/database-integration-table-name-collisions.md
+++ b/_troubleshooting/data-discrepancies/database-integration-table-name-collisions.md
@@ -1,0 +1,50 @@
+---
+title: Database Integration Table Name Collisons
+keywords: troubleshooting, trouble, issue, help, data discrepancy, discrepancies,
+permalink: /troubleshooting/data-discrepancies/database-integration-table-name-collisions
+tags: [data_discrepancy]
+
+summary: "In database integrations, if the names of multiple tables canonicalize to the same name - even if they're from different source databses or schemas - name collisions and data discrepancies can occur. This applies to any database integration available in Stitch."
+type: "discrepancy, database-integration, replication"
+promote: "false"
+---
+
+{{ page.summary }}
+
+---
+
+## Object naming and loading
+
+When Stitch replicates data from a database integration, all selected tables are loaded into a single schema in your destination. Because Stitch doesn't re-create databases and schemas in your destination, if two tables with the same name are replicated, naming collisions and data discrepancies can occur.
+
+### Example 1: Two tables with different names
+
+On the left there are the source tables, prepended by the schema they're contained in. On the right is how the tables are expected to look in the destination schema, named `database_integration`.
+
+| In the source       | In the destination             |
+|---------------------|--------------------------------|
+| customers.orders    | database_integration.orders    |
+| companies.projects  | database_integration.projects  |
+
+### Example 2: Two tables with the same name
+
+Let's say that the source `customers` and `companies` schemas both contain an `addresses` table. In this situation, the table names would canonicalize to the same name in the destination:
+
+| In the source       | In the destination             |
+|---------------------|--------------------------------|
+| customers.addresses | database_integration.addresses |
+| companies.addresses | database_integration.addresses |
+
+When this occurs, you may receive a table name collision error or data for both tables may be incorrectly loaded into one table.
+
+---
+
+## Workarounds
+
+- **Ensure table names are unique across schemas and databases**.
+- **Create multiple database integrations** if it isn't feasible to ensure table name uniqueness between your source databases and schemas. Using this method, you can replicate each table separately and have Stitch load them into different destination schemas, ensuring name uniqueness.
+- **For PostgreSQL-backed database integrations:** Check the **Include PostgreSQL schema names in destination tables** setting during the initial setup of the integration.
+
+   When this setting is checked, Stitch will include the name of the source schema in the destination table name, ensuring table names are unique. For example: `customers.addresses` would result in a destination table named `customers__addresses`.
+
+   **Note**: This setting cannot be changed once the integration is saved. Additionally, including schema names in destination table names may result in tables with names that exceed your destination's object name limits.


### PR DESCRIPTION
This PR:

- Adds documentation for the new **Include schema names in destination tables** setting for PostgreSQL-backed integrations
- Adds a troubleshooting guide for database integration table name collisions