### PR TITLE
Append only query update

### DIFF
--- a/_data/sidebars/stitchnav.yml
+++ b/_data/sidebars/stitchnav.yml
@@ -289,7 +289,7 @@ all-docs:
       url: "{{ link.destinations.storage.structure-changes }}"
 
     - title: Append-Only Tables
-      url: "{{ link.replication.append-only }}"
+      url: "{{ link.replication.append-only-querying }}"
 
     - title: "_sdc Columns"
       url: "{{ link.destinations.storage.stitch-schema }}#_sdc-columns"


### PR DESCRIPTION
This PR updates the append-only query example to include the `_sdc_batched_at` column, which adds another layer of uniqueness to query results.