### PR TITLE
Outbrain: Correct `campaigns` Replication Method

### DIFF
--- a/_integration-schemas/outbrain/campaigns.md
+++ b/_integration-schemas/outbrain/campaigns.md
@@ -8,7 +8,7 @@ singer-schema: https://github.com/singer-io/tap-outbrain/blob/master/tap_outbrai
 description: |
   The `campaigns` table contains info about your Outbrain campaigns.
 
-replication-method: "Key-based Incremental"
+replication-method: "Full Table"
 api-method:
   name: listAllCampaignsAssociatedWithAMarketer
   doc-link: http://docs.amplifyv01.apiary.io/#reference/campaigns/campaigns-collection-via-marketer/list-all-campaigns-associated-with-a-marketer
@@ -20,7 +20,7 @@ attributes:
     description: "The campaign ID."
 
   - name: "n/a"
-    replication-key: true
+    replication-key: false
 
   - name: "name"
     type: "string"

--- a/_integration-schemas/outbrain/campaigns.md
+++ b/_integration-schemas/outbrain/campaigns.md
@@ -19,9 +19,6 @@ attributes:
     primary-key: true
     description: "The campaign ID."
 
-  - name: "n/a"
-    replication-key: false
-
   - name: "name"
     type: "string"
     description: "The name of the campaign."


### PR DESCRIPTION
This PR changes the Outbrain `campaigns` table's Replication Method to Full Table.