### PR TITLE
Marketo: Update report card

### DIFF
--- a/_connect-files/api/objects/form-properties/sources/saas/marketobulk-object.md
+++ b/_connect-files/api/objects/form-properties/sources/saas/marketobulk-object.md
@@ -31,9 +31,4 @@ object-attributes:
     description: "The user's Marketo REST endpoint URL. For example: `https://457-RFG-234.mktorest.com/rest`"
     value: "https://<some-id-here>.mktorest.com/rest"
 
-  - name: "identity"
-    type: "string"
-    required: true
-    description: "The user's Marketo REST identity URL. For example: `https://457-RFG-234.mktorest.com/identity`"
-    value: "https://<some-id-here>.mktorest.com/identity"
 ---

--- a/_connect-files/api/objects/form-properties/sources/saas/marketobulk-object.md
+++ b/_connect-files/api/objects/form-properties/sources/saas/marketobulk-object.md
@@ -30,5 +30,4 @@ object-attributes:
     required: true
     description: "The user's Marketo REST endpoint URL. For example: `https://457-RFG-234.mktorest.com/rest`"
     value: "https://<some-id-here>.mktorest.com/rest"
-
 ---


### PR DESCRIPTION
This PR removes the `identity` attribute from the `marketobulk` Connect source form property. This attribute isn't used in this version of the integration.