### PR TITLE
HubSpot/v2 - Add content scope field

### DIFF
--- a/_integration-schemas/hubspot/email_events.md
+++ b/_integration-schemas/hubspot/email_events.md
@@ -8,7 +8,7 @@ singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/
 description: |
   The `email_events` table contains info about email events and how recipients interact with content.
 
-notes: 
+  **Note**: To replicate this table, the **NAME OF SETTING IN UI** checkbox in the Integration Settings page must be checked.
 
 replication-method: "Key-based Incremental"
 api-method:

--- a/_saas-integrations/hubspot/v2/hubspot-v2.md
+++ b/_saas-integrations/hubspot/v2/hubspot-v2.md
@@ -56,6 +56,8 @@ requirements-info: |
 
 setup-steps:
   - title: "add integration"
+    content: |
+      4. [ADD CONTENT HERE]
   - title: "historical sync"
   - title: "replication frequency"
   - title: "Authorize Stitch to access HubSpot"


### PR DESCRIPTION
This PR adds a new field to the Integration Settings page for HubSpot. This field will allow the integration to set the `content` scope, which is required to replicate `email_events`.