### PR TITLE
Facebook Ads/v1 - Deprecated action field values

### DIFF
--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -78,16 +78,12 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: &action-type-description |
-          The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
-
-          Action types include Page likes, app installs, conversions, event responses, and more.
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
-          - `app_custom_event`
-          - `mention`
-          - `tab_view`
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
 
       - name: "value"
         type: "number"
@@ -134,7 +130,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-october-2018 | flatify }}
 
   - name: "inline_post_engagement"
     type: "integer"
@@ -191,10 +198,6 @@ attributes:
     description: |
       Details about the average cost of a relevant action.
 
-      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
-
-      - `mention`
-      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"
@@ -203,7 +206,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-action-type.deprecated-october-2018 | flatify }}
 
   - name: "unique_link_clicks_ctr"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -81,16 +81,12 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: &action-type-description |
-          The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
-
-          Action types include Page likes, app installs, conversions, event responses, and more.
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
-          - `app_custom_event`
-          - `mention`
-          - `tab_view`
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
 
       - name: "value"
         type: "number"
@@ -137,7 +133,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-october-2018 | flatify }}
 
   - name: "inline_post_engagement"
     type: "integer"
@@ -193,11 +200,6 @@ attributes:
     type: "array"
     description: |
       Details about the average cost of a relevant action.
-
-      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
-
-      - `mention`
-      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"
@@ -206,7 +208,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-action-type.deprecated-october-2018 | flatify }}
 
   - name: "unique_link_clicks_ctr"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -76,16 +76,12 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: &action-type-description |
-          The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
-
-          Action types include Page likes, app installs, conversions, event responses, and more.
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
-          - `app_custom_event`
-          - `mention`
-          - `tab_view`
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
 
       - name: "value"
         type: "number"
@@ -132,7 +128,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-october-2018 | flatify }}
 
   - name: "inline_post_engagement"
     type: "integer"
@@ -189,10 +196,6 @@ attributes:
     description: |
       Details about the average cost of a relevant action.
 
-      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
-
-      - `mention`
-      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"
@@ -201,7 +204,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-action-type.deprecated-october-2018 | flatify }}
 
   - name: "unique_link_clicks_ctr"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -90,16 +90,12 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: &action-type-description |
-          The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
-
-          Action types include Page likes, app installs, conversions, event responses, and more.
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
-          - `app_custom_event`
-          - `mention`
-          - `tab_view`
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
 
       - name: "value"
         type: "number"
@@ -146,7 +142,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-october-2018 | flatify }}
 
   - name: "inline_post_engagement"
     type: "integer"
@@ -203,10 +210,6 @@ attributes:
     description: |
       Details about the average cost of a relevant action.
 
-      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
-
-      - `mention`
-      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"
@@ -215,7 +218,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-action-type.deprecated-october-2018 | flatify }}
 
   - name: "unique_link_clicks_ctr"
     type: "number"

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -76,16 +76,12 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: &action-type-description |
-          The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
-
-          Action types include Page likes, app installs, conversions, event responses, and more.
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
 
           **Note**: As of July 2018, Facebook has deprecated the following `action` types:
 
-          - `app_custom_event`
-          - `mention`
-          - `tab_view`
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
 
       - name: "value"
         type: "number"
@@ -132,7 +128,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-unique-action-type.deprecated-october-2018 | flatify }}
 
   - name: "inline_post_engagement"
     type: "integer"
@@ -189,10 +196,6 @@ attributes:
     description: |
       Details about the average cost of a relevant action.
 
-      **Note**: As of July 2018, Facebook has deprecated the following `cost_per_action` types:
-
-      - `mention`
-      - `tab_view`
     doc-link: https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
     array-attributes:
       - name: "value"
@@ -201,7 +204,18 @@ attributes:
 
       - name: "action_type"
         type: "string"
-        description: *action-type-description
+        description: |
+          {{ integration.cost-per-action-type.description | flatify }}
+
+          **Note**: Facebook has deprecated some values for this field. They are as follows:
+
+          In July 2018:
+
+          {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+          In October 2018:
+
+          {{ integration.cost-per-action-type.deprecated-october-2018 | flatify }}
 
   - name: "unique_link_clicks_ctr"
     type: "number"

--- a/_saas-integrations/facebook-ads/facebook-ads-latest.md
+++ b/_saas-integrations/facebook-ads/facebook-ads-latest.md
@@ -146,6 +146,48 @@ schema-sections:
       - **Core Object** tables contain foundational data that's useful for analysis. These are the [`adcreative`](#adcreative), [`ads`](#ads), [`adsets`](#adsets), and [`campaigns`](#campaigns) tables. To learn more about how Facebook Ads data is structured, we recommend checking out their [API guide](https://developers.facebook.com/docs/marketing-api/buying-api).
       - **Insights** tables contain performance data for every campaign/adset/ad combination, segmented by day and demographics specific to each table. For example: The [`ads_insights_age_and_gender`](#ads_insights_age_and_gender) table is segmented by day, age, and gender.
 
+# This is used in the schema sections to display values that have
+# been deprecated for specific fields.
+
+cost-per-action-type:
+  description: |
+    The kind of actions taken on the ad, Page, app, or event after your ad was served to someone, even if they didn't click on it.
+
+    Action types include Page likes, app installs, conversions, event responses, and more.
+
+  deprecated-common-october-2018: |
+    - `app_custom_event_fb_mobile_add_to_cart` 
+    - `app_custom_event_fb_mobile_add_to_wishlist`
+    - `app_custom_event_fb_mobile_initiated_checkout`
+    - `app_custom_event_fb_mobile_search`
+    - `app_custom_event_fb_mobile_complete_registration`
+    - `app_custom_event_fb_mobile_achievement_unlocked`
+    - `app_custom_event_fb_mobile_add_payment_info`
+    - `app_custom_event_fb_mobile_content_view`
+    - `app_custom_event_fb_mobile_level_achieved`
+    - `app_custom_event_fb_mobile_purchase`
+    - `app_custom_event_fb_mobile_rate`
+    - `app_custom_event_fb_mobile_spent_credits`
+    - `app_custom_event_fb_mobile_tutorial_completion`
+
+  deprecated-july-2018: |
+    - `mention`
+    - `tab_view`
+
+  deprecated-october-2018: |
+    {{ integration.cost-per-action-type.deprecated-common-october-2018 | flatify }}
+    - `app_install`
+    - `mobile_app_install`
+    - `onsite_conversion.add_to_cart`
+    - `onsite_conversion.view_content`
+
+cost-per-unique-action-type:
+  deprecated-july-2018: |
+    - `app_custom_event`
+    {{ integration.cost-per-action-type.deprecated-july-2018 | flatify }}
+
+  deprecated-october-2018: |
+    {{ integration.cost-per-action-type.deprecated-common-october-2018 | flatify }}
 ---
 {% assign integration = page %}
 {% include misc/data-files.html %}


### PR DESCRIPTION
This PR adds info about field values that Facebook has deprecated in v3.2 for `action` fields.

Changelog is here: https://developers.facebook.com/docs/graph-api/changelog/version3.2#marketing-api