### PR TITLE
HubSpot/v2 - Email events permissions

### DIFF
--- a/_integration-schemas/hubspot/campaigns.md
+++ b/_integration-schemas/hubspot/campaigns.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Full Table"
 api-method:
-  name: getCampaignForParticularCampaign
+  name: "Get campaign for particular campaign"
   doc-link: https://developers.hubspot.com/docs/methods/email/get_campaign_data
 
 attributes:

--- a/_integration-schemas/hubspot/companies.md
+++ b/_integration-schemas/hubspot/companies.md
@@ -14,7 +14,7 @@ replication-key:
   name: "hs_lastmodifieddate"
 
 api-method:
-  name: getACompany
+  name: "Get a company"
   doc-link: https://developers.hubspot.com/docs/methods/companies/get_company
 
 attributes:

--- a/_integration-schemas/hubspot/contact_lists.md
+++ b/_integration-schemas/hubspot/contact_lists.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getContactLists
+  name: "Get contact lists"
   doc-link: https://developers.hubspot.com/docs/methods/lists/get_lists
 
 attributes:

--- a/_integration-schemas/hubspot/contacts.md
+++ b/_integration-schemas/hubspot/contacts.md
@@ -16,7 +16,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getContacts
+  name: "Get contacts"
   doc-link: https://developers.hubspot.com/docs/methods/contacts/get_contacts
 
 attributes:

--- a/_integration-schemas/hubspot/deal_pipelines.md
+++ b/_integration-schemas/hubspot/deal_pipelines.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Full Table"
 api-method:
-  name: getAllDealPipelines
+  name: "Get all deal pipelines"
   doc-link: https://developers.hubspot.com/docs/methods/deal-pipelines/get-all-deal-pipelines
 
 attributes:

--- a/_integration-schemas/hubspot/deals.md
+++ b/_integration-schemas/hubspot/deals.md
@@ -13,7 +13,7 @@ replication-key:
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getAllDeals
+  name: "Get all deals"
   doc-link: https://developers.hubspot.com/docs/methods/deals/get-all-deals
 
 attributes:

--- a/_integration-schemas/hubspot/email_events.md
+++ b/_integration-schemas/hubspot/email_events.md
@@ -20,7 +20,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getEventsForCampaignOrRecipient
+  name: "Get events for campaign or recipient"
   doc-link: https://developers.hubspot.com/docs/methods/email/get_events
 
 attributes:

--- a/_integration-schemas/hubspot/email_events.md
+++ b/_integration-schemas/hubspot/email_events.md
@@ -8,7 +8,15 @@ singer-schema: https://github.com/singer-io/tap-hubspot/blob/master/tap_hubspot/
 description: |
   The `email_events` table contains info about email events and how recipients interact with content.
 
-notes: 
+  #### Email events and HubSpot permissions
+
+  Replicating this table requires **Super Admin** permissions in HubSpot. The Super Admin role is different than the Admin role, which you can read more about in [HubSpot's documentation](https://knowledge.hubspot.com/articles/kcs_article/settings/hubspot-user-roles-guide#admin).
+
+  If this table is selected and you don't have Super Admin permissions in HubSpot, an error similar to the following will surface in the integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}):
+
+  ```
+  tap - ERROR b'{"status":"error","message":"This oauth-token (**********) does not have proper permissions! (requires any of [email-access])", [...]
+  ```
 
 replication-method: "Key-based Incremental"
 api-method:

--- a/_integration-schemas/hubspot/engagements.md
+++ b/_integration-schemas/hubspot/engagements.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getAllEngagements
+  name: "Get all engagements"
   doc-link: https://developers.hubspot.com/docs/methods/engagements/get-all-engagements
 
 attributes:

--- a/_integration-schemas/hubspot/forms.md
+++ b/_integration-schemas/hubspot/forms.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getAllFormsFromAPortal
+  name: "Get all forms from a portal"
   doc-link: https://developers.hubspot.com/docs/methods/forms/v2/get_forms
 
 attributes:

--- a/_integration-schemas/hubspot/owners.md
+++ b/_integration-schemas/hubspot/owners.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getOwners
+  name: "Get owners"
   doc-link: https://developers.hubspot.com/docs/methods/owners/get_owners
 
 attributes:

--- a/_integration-schemas/hubspot/subscription_changes.md
+++ b/_integration-schemas/hubspot/subscription_changes.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getSubscriptionsTimeline
+  name: "Get subscriptions timeline"
   doc-link: https://developers.hubspot.com/docs/methods/email/get_subscriptions_timeline
 
 attributes:

--- a/_integration-schemas/hubspot/workflows.md
+++ b/_integration-schemas/hubspot/workflows.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: getWorkflows
+  name: "Get workflows"
   doc-link: https://developers.hubspot.com/docs/methods/workflows/v3/get_workflows
 
 attributes:

--- a/_saas-integrations/hubspot/v2/hubspot-v2.md
+++ b/_saas-integrations/hubspot/v2/hubspot-v2.md
@@ -48,8 +48,9 @@ incompatible:
 # -------------------------- #
 
 requirements-list:
-  - item: "**For HubSpot CRM or Marketing products:** Administrator permissions in HubSpot"
-  - item: "**For the HubSpot Sales product:** Sales Administrator permissions in HubSpot"
+  - item: |
+      **For HubSpot CRM or Marketing products:** Administrator permissions in HubSpot. **Note**: To replicate [email events](#email_events), you'll need to have **Super Admin** permissions in HubSpot.
+  - item: "**For the HubSpot Sales product:** Sales Administrator permissions in HubSpot."
 
 requirements-info: |
   More information about HubSpot user roles and permissions can be found in [HubSpot's documentation](https://knowledge.hubspot.com/articles/kcs_article/settings/hubspot-user-roles-guide){:target="new"}.


### PR DESCRIPTION
This PR updates the HubSpot v2 docs to include info about the permissions required to replicate `email_events`. As of now, Super Admin permissions are required by HubSpot to access this data via the API.