### PR TITLE
GitHub/v1 - Add comments and review_comments tables

### DIFF
--- a/_integration-schemas/github/comments.md
+++ b/_integration-schemas/github/comments.md
@@ -1,0 +1,136 @@
+---
+tap: "github"
+# version: "1.0"
+
+name: "comments"
+doc-link: https://developer.github.com/v3/comments/
+singer-schema: https://github.com/singer-io/tap-github/blob/master/tap_github/comments.json
+description: |
+  The `comments` table contains info about comments made on issues.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: "List comments on a pull request"
+  doc-link: https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
+
+attributes:
+  - name: "id"
+    type: "integer"
+    primary-key: true
+    description: "The comment ID."
+    # foreign-key-id: "comment-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the comment was last updated."
+
+  # - name: "author_association"
+  #   type: "string"
+  #   description: ""
+
+  - name: "body"
+    type: "string"
+    description: "The body of the comment."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time the comment was created."
+
+  - name: "home_url"
+    type: "string"
+    description: "The home URL of the comment."
+
+  - name: "html_url"
+    type: "string"
+    description: "The HTML URL of the comment."
+
+  - name: "issue_url"
+    type: "string"
+    description: "The URL of the issue associated with the comment."
+
+  - name: "node_id"
+    type: "string"
+    description: "The node ID."
+
+  - name: "url"
+    type: "string"
+    description: "The GitHub URL of the comment."
+
+  - name: "user"
+    type: "object"
+    description: "Details about the user who created the comment."
+    object-attributes:
+      - name: "login"
+        type: "string"
+        description: "The login name of the user who created the comment."
+
+      - name: "id"
+        type: "string"
+        description: "The ID of the user who created the comment."
+
+      - name: "node_id"
+        type: "string"
+        description: "The node ID of the user who created the comment."
+
+      - name: "avatar_url"
+        type: "string"
+        description: "The URL of the avatar of the user who created the comment."
+
+      - name: "gravatar_id"
+        type: "string"
+        description: "The URL of the Gravatar of the user who created the comment."
+
+      - name: "url"
+        type: "string"
+        description: "The API URL of the user who created the comment."
+
+      - name: "html_url"
+        type: "string"
+        description: "The GitHub URL of the user who created the comment."
+
+      - name: "followers_url"
+        type: "string"
+        description: "The URL to the user's followers page."
+
+      - name: "following_url"
+        type: "string"
+        description: "The URL to the user's following page."
+
+      - name: "gists_url"
+        type: "string"
+        description: "The URL to the user's gists page."
+
+      - name: "starred_url"
+        type: "string"
+        description: "The URL to the user's starred page."
+
+      - name: "subscriptions_url"
+        type: "string"
+        description: "The URL to the user's subscriptions page."
+
+      - name: "organizations_url"
+        type: "string"
+        description: "The URL to the user's organizations page."
+
+      - name: "repos_url"
+        type: "string"
+        description: "The URL to the user's repositories page."
+
+      - name: "events_url"
+        type: "string"
+        description: "The URL to the user's events page."
+
+      - name: "received_events_url"
+        type: "string"
+        description: "The URL to the user's received events page."
+
+      - name: "type"
+        type: "string"
+        description: "The type of the user."
+
+      - name: "site_admin"
+        type: "string"
+        description: "Indicates if the user is a site administrator."
+---

--- a/_integration-schemas/github/foreign-keys.md
+++ b/_integration-schemas/github/foreign-keys.md
@@ -24,6 +24,13 @@ foreign-keys:
         subattribute: "user"
         join-on: "id"
 
+  - id: "comment-id"
+    attribute: "comment_id"
+    table: "comments"
+    all-foreign-keys:
+      - table: "comments"
+        join-on: "id"
+
   - id: "commit-id"
     attribute: "commit_id"
     table: "commits"
@@ -31,6 +38,9 @@ foreign-keys:
       - table: "commits"
         join-on: "id"
       - table: "reviews"
+      - table: "review_comments"
+      - table: "review_comments"
+        join-on: "original_commit_id"
 
   - id: "issue-id"
     attribute: "issue_id"
@@ -50,12 +60,21 @@ foreign-keys:
       - table: "issues"
         join-on: "id"
 
+  - id: "review-comment-id"
+    attribute: "review_comment_id"
+    table: "review_comments"
+    all-foreign-keys:
+      - table: "review_comments"
+        join-on: "id"
+
   - id: "review-id"
     attribute: "review_id"
     table: "reviews"
     all-foreign-keys:
       - table: "reviews"
         join-on: "id"
+      - table: "review_comments"
+        join-on: "pull_request_review_id"
 
   - id: "sha"
     attribute: "sha"

--- a/_integration-schemas/github/review_comments.md
+++ b/_integration-schemas/github/review_comments.md
@@ -1,0 +1,181 @@
+---
+tap: "github"
+# version: "1.0"
+
+name: "review_comments"
+doc-link: https://developer.github.com/v3/pulls/comments/
+singer-schema: https://github.com/singer-io/tap-github/blob/master/tap_github/review_comments.json
+description: |
+  The `review_comments` table contains info about comments made on pull request reviews.
+
+  **Note**: In order to replicate this table, you must also set the [`pull_requests`](#pull_requests) table to replicate.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: "List comments on a pull request"
+  doc-link: https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
+
+attributes:
+  - name: "id"
+    type: "integer"
+    primary-key: true
+    description: "The review comment ID."
+    # foreign-key-id: "review-comment-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the review comment was last updated."
+
+  # - name: "assignee"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "assignees"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "author_association"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "base"
+  #   type: "string"
+  #   description: ""
+
+  - name: "body"
+    type: "string"
+    description: "The body of the review comment."
+
+  # - name: "comments_url"
+  #   type: "string"
+  #   description: ""
+
+  - name: "commit_id"
+    type: "string"
+    description: "The ID of the commit the review comment is associated with."
+    foreign-key-id: "commit-id"
+
+  # - name: "commits_url"
+  #   type: "string"
+  #   description: ""
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time the review comment was created."
+
+  # - name: "diff_hunk"
+  #   type: "string"
+  #   description: ""
+
+  - name: "diff_url"
+    type: "string"
+    description: "The diff URL associated with the review comment."
+
+  # - name: "head"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "home_url"
+  #   type: "string"
+  #   description: ""
+
+  - name: "html_url"
+    type: "string"
+    description: "The HTML URL of the review comment."
+
+  - name: "in_reply_to_id"
+    type: "integer"
+    description: "If the review comment is a reply to another review comment, this will be the ID of the review comment it is in response to."
+
+  - name: "issue_url"
+    type: "string"
+    description: "The URL of the issue associated with the review comment."
+
+  # - name: "labels"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "locked"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "merge_commit_sha"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "milestone"
+  #   type: "string"
+  #   description: ""
+
+  - name: "node_id"
+    type: "string"
+    description: "The review comment's node ID."
+
+  - name: "original_position"
+    type: "integer"
+    description: "The original position of the review comment."
+
+  - name: "original_commit_id"
+    type: "string"
+    description: "The ID of the original comment the review comment is associated with."
+    foreign-key-id: "commit-id"  
+
+  # - name: "patch_url"
+  #   type: "string"
+  #   description: ""
+
+  - name: "pull_request_review_id"
+    type: "integer"
+    description: "The ID of the pull request review the comment is a part of."
+    foreign-key-id: "review-id"
+
+  - name: "path"
+    type: "string"
+    description: "The path of the file the review comment was made on."
+
+  - name: "position"
+    type: "integer"
+    description: "The position of the review comment."
+
+  - name: "pull_request_url"
+    type: "string"
+    description: "The URL of the pull request associated with the review comment."
+
+  # - name: "requested_reviewers"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "requested_teams"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "review_comment_url"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "review_comments_url"
+  #   type: "string"
+  #   description: ""
+
+  # - name: "statuses_url"
+  #   type: "string"
+  #   description: ""
+
+  - name: "url"
+    type: "string"
+    description: "The GitHub URL of the review comment."
+
+  - name: "user"
+    type: "object"
+    description: "Details about the user who created the review comment."
+    object-attributes:
+      - name: "login"
+        type: "string"
+        description: "The login name of the user who created the review comment."
+
+      - name: "id"
+        type: "string"
+        description: "The ID of the user who created the review comment."
+---

--- a/_integration-schemas/github/reviews.md
+++ b/_integration-schemas/github/reviews.md
@@ -8,6 +8,8 @@ singer-schema: https://github.com/singer-io/tap-github/blob/master/tap_github/re
 description: |
   The `reviews` table contains info about pull request reviews. A pull request review is a group of comments on a pull request.
 
+    **Note**: In order to replicate this table, you must also set the [`pull_requests`](#pull_requests) table to replicate.
+
 replication-method: "Full Table"
 
 api-method:


### PR DESCRIPTION
This PR adds documentation for the new `comments` and `review_comments` tables in the GitHub integration. (https://github.com/singer-io/tap-github/pull/30)