### PR TITLE
Zendesk: Add `ticket_id` to `ticket_comments` table

### DIFF
--- a/_integration-schemas/zendesk/foreign-keys.md
+++ b/_integration-schemas/zendesk/foreign-keys.md
@@ -117,6 +117,7 @@ foreign-keys:
       - table: "tickets"
         join-on: "id"
       - table: "ticket_audits"
+      - table: "ticket_comments"
       - table: "ticket_metrics"
 
   - id: "ticket-metric-id"

--- a/_integration-schemas/zendesk/ticket_comments.md
+++ b/_integration-schemas/zendesk/ticket_comments.md
@@ -30,6 +30,11 @@ attributes:
     type: "string"
     description: "The body of the comment."
 
+  - name: "ticket_id"
+    type: "integer"
+    description: "The ID of the ticket associated with the comment."
+    foreign-key-id: "ticket-id"
+
   - name: "type"
     type: "string"
     description: |


### PR DESCRIPTION
The `ticket_id` was [added](https://github.com/singer-io/tap-zendesk/pull/22) to the `ticket_comments` stream.  

This PR adds it to the docs.

