### PR TITLE
Add docs about Postgres SSL certs

### DIFF
--- a/_connect-files/api/objects/form-properties/destinations/postgresql-object.md
+++ b/_connect-files/api/objects/form-properties/destinations/postgresql-object.md
@@ -13,4 +13,14 @@ db-type: "postgres"
 description: ""
 
 uses-common-fields: true
+object-attributes:
+  - name: "sslrootcert"
+    type: "string"
+    required: false
+    description: |
+      **Optional**: The certificate (typically a CA or server certificate) Stitch should verify the SSL connection against. The connection will succeed only if the server's certificate verifies against the certificate provided.
+
+      **Note**: Providing a certificate via this property isn't required to use SSL. This is only if Stitch should verify the connection against a specific certificate.
+    value: |
+      "<OPTIONAL_SSL_CERTIFICATE>"
 ---

--- a/_data/connect/common/destination-forms.yaml
+++ b/_data/connect/common/destination-forms.yaml
@@ -44,4 +44,4 @@ ssl:
     required: false
     type: "boolean"
     description: "If `true`, SSL will be used to connect to the database."
-    value: "false"
+    value: "true"

--- a/_data/ui/destination-settings-page.yml
+++ b/_data/ui/destination-settings-page.yml
@@ -99,6 +99,8 @@ postgres:
     copy: *password-copy
   - field: *database
     copy: *database-copy
+  - field: *ssl
+    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
 
 # -------------------------- #
 #       Heroku-Postgres      #
@@ -137,6 +139,8 @@ postgres-rds:
     copy: *password-copy
   - field: *database
     copy: *database-copy
+  - field: *ssl
+    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
 
 # -------------------------- #
 #     CloudSQL Postgres       #
@@ -153,6 +157,8 @@ cloudsql-postgres:
     copy: *password-copy
   - field: *database
     copy: *database-copy
+  - field: *ssl
+    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
 
 # -------------------------- #
 #          Redshift          #

--- a/_data/ui/destination-settings-page.yml
+++ b/_data/ui/destination-settings-page.yml
@@ -100,8 +100,8 @@ postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
-
+    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
+    
 # -------------------------- #
 #       Heroku-Postgres      #
 # -------------------------- #
@@ -140,7 +140,7 @@ postgres-rds:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
+    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
 
 # -------------------------- #
 #     CloudSQL Postgres       #
@@ -158,7 +158,7 @@ cloudsql-postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL, and optionally provide a certificate (such as a CA or server certificate) to verify the server's certificate.
+    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
 
 # -------------------------- #
 #          Redshift          #

--- a/_data/ui/destination-settings-page.yml
+++ b/_data/ui/destination-settings-page.yml
@@ -57,7 +57,7 @@ default-copy:
   ssl-certificate: &ssl-certificate-copy |
     **Optional**: Provide the certificate (typically a CA or server certificate) Stitch should verify the SSL connection against. The connection will succeed only if the server's certificate verifies against the certificate provided here.
 
-    **Note**: Providing a certificate isn't required to use SSL. This is only if Stitch should verify the connection against a specific certificate.
+            **Note**: Providing a certificate isn't required to use SSL. This is only if Stitch should verify the connection against a specific certificate.
 
 # -------------------------- #
 #         SSH Fields         #

--- a/_data/ui/destination-settings-page.yml
+++ b/_data/ui/destination-settings-page.yml
@@ -100,7 +100,7 @@ postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
+    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
     
 # -------------------------- #
 #       Heroku-Postgres      #
@@ -140,7 +140,7 @@ postgres-rds:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
+    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
 
 # -------------------------- #
 #     CloudSQL Postgres       #
@@ -158,7 +158,7 @@ cloudsql-postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided, the connection will only succeed if the server's certificate verifies against it.
+    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
 
 # -------------------------- #
 #          Redshift          #

--- a/_data/ui/destination-settings-page.yml
+++ b/_data/ui/destination-settings-page.yml
@@ -27,12 +27,14 @@
 ## Defines the default field names in the Destination Settings page.
 
 default-fields:
-  host: &host Host (Endpoint)
-  port: &port Port
-  username: &username Username
-  password: &password Password
-  database: &database Database
-  ssl: &ssl Connect using SSL
+  host: &host "Host (Endpoint)"
+  port: &port "Port"
+  username: &username "Username"
+  password: &password "Password"
+  database: &database "Database"
+  ssl: &ssl "Connect using SSL"
+  ssl-certificate: &ssl-certificate "SSL Certificate"
+
 
 # -------------------------- #
 #        Default Copy        #
@@ -50,6 +52,12 @@ default-copy:
     Enter the password associated with the Stitch {{ destination.display_name }} user.
   database: &database-copy |
     Enter the name of the {{ destination.display_name }} database that you created for Stitch.
+  ssl: &ssl-copy |
+    Check to connect to {{ destination.display_name }} using SSL. **Note**: This is not required to connect Stitch.
+  ssl-certificate: &ssl-certificate-copy |
+    **Optional**: Provide the certificate (typically a CA or server certificate) Stitch should verify the SSL connection against. The connection will succeed only if the server's certificate verifies against the certificate provided here.
+
+    **Note**: Providing a certificate isn't required to use SSL. This is only if Stitch should verify the connection against a specific certificate.
 
 # -------------------------- #
 #         SSH Fields         #
@@ -100,7 +108,9 @@ postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
+    copy: *ssl-copy
+  - field: *ssl-certificate
+    copy: *ssl-certificate-copy
     
 # -------------------------- #
 #       Heroku-Postgres      #
@@ -140,7 +150,9 @@ postgres-rds:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
+    copy: *ssl-copy
+  - field: *ssl-certificate
+    copy: *ssl-certificate-copy
 
 # -------------------------- #
 #     CloudSQL Postgres       #
@@ -158,7 +170,9 @@ cloudsql-postgres:
   - field: *database
     copy: *database-copy
   - field: *ssl
-    copy: Connect with SSL. If a certificate is provided (typically a CA or server certificate) the connection will only succeed if the server's certificate verifies against it. 
+    copy: *ssl-copy
+  - field: *ssl-certificate
+    copy: *ssl-certificate-copy
 
 # -------------------------- #
 #          Redshift          #


### PR DESCRIPTION
This PR adds documentation for user-provided SSL certificates for PostgreSQL destinations.