### PR TITLE
remove total_action_value from facebook insights schemas

### DIFF
--- a/_integration-schemas/facebook-ads/ads_insights.md
+++ b/_integration-schemas/facebook-ads/ads_insights.md
@@ -231,10 +231,6 @@ attributes:
     type: "number"
     description: "The average cost of each unique click (all)."
 
-  - name: "total_action_value"
-    type: "number"
-    description: "The total value of all conversions contributed to the ad."
-
   - name: "unique_clicks"
     type: "integer"
     description: "The number of people who performed a click (all)."

--- a/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
+++ b/_integration-schemas/facebook-ads/ads_insights_age_and_gender.md
@@ -233,10 +233,6 @@ attributes:
     type: "number"
     description: "The average cost of each unique click (all)."
 
-  - name: "total_action_value"
-    type: "number"
-    description: "The total value of all conversions contributed to the ad."
-
   - name: "unique_clicks"
     type: "integer"
     description: "The number of people who performed a click (all)."

--- a/_integration-schemas/facebook-ads/ads_insights_country.md
+++ b/_integration-schemas/facebook-ads/ads_insights_country.md
@@ -229,10 +229,6 @@ attributes:
     type: "number"
     description: "The average cost of each unique click (all)."
 
-  - name: "total_action_value"
-    type: "number"
-    description: "The total value of all conversions contributed to the ad."
-
   - name: "unique_clicks"
     type: "integer"
     description: "The number of people who performed a click (all)."

--- a/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
+++ b/_integration-schemas/facebook-ads/ads_insights_platform_and_device.md
@@ -243,10 +243,6 @@ attributes:
     type: "number"
     description: "The average cost of each unique click (all)."
 
-  - name: "total_action_value"
-    type: "number"
-    description: "The total value of all conversions contributed to the ad."
-
   - name: "unique_clicks"
     type: "integer"
     description: "The number of people who performed a click (all)."

--- a/_integration-schemas/facebook-ads/ads_insights_region.md
+++ b/_integration-schemas/facebook-ads/ads_insights_region.md
@@ -229,10 +229,6 @@ attributes:
     type: "number"
     description: "The average cost of each unique click (all)."
 
-  - name: "total_action_value"
-    type: "number"
-    description: "The total value of all conversions contributed to the ad."
-
   - name: "unique_clicks"
     type: "integer"
     description: "The number of people who performed a click (all)."


### PR DESCRIPTION
tap-facebook was recently updated to use v3.2 of facebook's `facebook_business` sdk, (see [this PR](https://github.com/singer-io/tap-facebook/pull/51))

Part of the upgrade meant that `total_action_value` was removed from the ads_insights streams.

This PR removes that value from those schemas' docs.