### PR TITLE
Move destination guides to new template

### DIFF
--- a/_destinations/bigquery/switching-location-of-google-bigquery.md
+++ b/_destinations/bigquery/switching-location-of-google-bigquery.md
@@ -11,111 +11,104 @@ toc: true
 layout: destination
 display_name: "BigQuery"
 type: "bigquery"
+
+sections:
+  - content: |
+      {% capture only-for-existing-destinations %}This guide is only for changing **existing** {{ destination.display_name }} destinations, or those already connected to Stitch. To connect a new {{ destination.display_name }} destination, [refer to these instructions]({{ link.destinations.setup.bigquery | prepend: site.baseurl }}).
+      {% endcapture %}
+
+      {% include important.html type="single-line" content=only-for-existing-destinations %}
+
+      Need to change the location in which {{ destination.display_name }} stores your data? Using Stitch's Destination Change feature, you can delete the current destination and connect a new one with the desired data storage location.
+
+  - title: "Considerations"
+    anchor: "considerations"
+    content: |
+      Here's what you need to know to ensure a smooth switch:
+
+      - **Your integrations will be paused.** After the switch is complete, you'll need to manually unpause the integrations you'd like to resume.
+
+      - **Some webhook data may be lost during this process**. Due to their continuous, real-time nature, some webhook data may be lost during the switch.
+
+      - **Historical data from webhook-based integrations must be either manually backfilled or replayed**. Some webhook providers - such as Segment - allow customers on certain plans to ‘replay’ their historical data. This feature varies from provider to provider and may not always be available.
+
+  - title: "Step 1: Select a historical data setting"
+    anchor: "select-historical-data-setting"
+    content: |
+      If you need historical data in the new destination, you’ll need to either manually transfer your historical data or queue a historical replication job.
+
+      - **Manually transfer historical data**: To accomplish this, you can use Google's UI to import the existing datasets into the new {{ destination.display_name }} instance. Ensure that all dataset names remain the same during the transfer, or loading errors may occur.
+
+         **Complete the historical transfer before continuing.**
+
+      - **Queue a historical replication job**: Initializing a historical replication will re-replicate all historical data from your integrations. For SaaS integrations, Stitch will replicate data beginning with the **Start Date** currently in the integration's settings.
+    subsections:
+      - title: "Define the setting"
+        anchor: "define-the-setting"
+        content: |
+          1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
+          2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
+          3. In the **Historical Data** section, select how you want data to be replicated to the new destination: 
+             {% for field in page-settings.bigquery-historical-data %}
+             - {{ field.field }}: {{ field.copy | flatify }}
+             {% endfor %}
+  
+  - title: "Step 2: Delete the current destination"
+    anchor: "delete-current-bigquery-destination"
+    content: |
+      1. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
+      2. To complete the switch, Stitch must delete your current destination configuration. **Note**: This will not delete data in the destination itself - it only clears this destination's settings from Stitch.
+
+         To continue with the switch, click **OK** to delete the current destination settings.
+
+  - title: "Step 3: Connect the new {{ destination.display_name }} destination"
+    anchor: "connect-new-bigquery-destination"
+    content: |
+      {% capture permissions %}
+      1. **A user with full access to an existing [Google Cloud Platform (GCP) project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**.
+
+      2. **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions. Stitch requires these permissions to [create and use a GCS bucket](https://cloud.google.com/storage/docs/access-control/bucket-level-iam){:target="_blank"} to load replicated data into BigQuery.
+
+      3. **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
+      {% endcapture %}
+
+      {% include important.html first-line="**Requirements for connecting BigQuery:**" content=permissions %}
+
+      1. On the next page in Stitch, click the **{{ destination.display_name }}** icon.
+      2. Click **Sign in with Google**.
+      3. If you aren't already signed into your Google account, you'll be prompted for your credentials.
+      4. After you sign in, you'll see a list of the permissions requested by Stitch:
+           - **Read/Write Access to Google Cloud Storage** - Stitch requires Read/Write access to create and use a GCS bucket to load replicated data into BigQuery.
+           - **Full Access to BigQuery** - Stitch requires full access to be able to create datasets and load data into BigQuery.
+           - **Read-Only Access to Projects** - Stitch requires read-only access to projects to allow you to select a project to use during the BigQuery setup process.
+           - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
+           - **Offline Access** - To continuously load data, Stitch requires offline access. This allows the authorization token generated during setup process to be used for more than an hour after the initial authentication takes place.
+      5. To grant access, click the **Authorize** button.
+      6. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
+         Fill in the fields that display:
+            - **Google Cloud Project**: From the dropdown, select the project you want to connect to Stitch.
+            - **Google Cloud Storage Location**: From the dropdown, select the new location you want to use.
+      7. Click **Finish Setup**.
+
+  - title: "Step 4: Delete the existing Google Cloud Storage bucket"
+    anchor: "delete-current-bucket"
+    content: |
+      To ensure Stitch can load data into the new BigQuery instance, you'll need to delete the Google Cloud Storage (GCS) bucket that's attached to the project.
+
+      {% include important.html type="single-line" content="Before completing this step, verify that all data you want to retain has been transferred. Google permanently deletes objects within buckets, and they cannot be recovered after this process completes." %}
+
+      1. In another browser tab, [log into the Google console](https://console.cloud.google.com/).
+      2. Use [Google's instructions](https://cloud.google.com/storage/docs/deleting-buckets) to locate the bucket in Google's UI.
+      3. Locate the Stitch bucket. **If you're unsure of which bucket belongs to Stitch**, reach out to Stitch support.
+      4. Delete the bucket.
+
+  - title: "Step 5: Unpause integrations"
+    anchor: "unpause-integrations"
+    content: |
+      After you've successfully connected the new {{ destination.display_name }} destination and deleted the original Stitch GCS bucket, un-pause your integrations in Stitch.
+
+      Your data will begin replicating according to the historical data option selected in [Step 1](#select-historical-data-setting).
 ---
 {% assign destination = site.destinations | where:"type","bigquery" | first %}
 {% assign page-settings = site.data.ui.change-destinations-page %}
 {% include misc/data-files.html %}
-
-{% capture only-for-existing-destinations %}This guide is only for changing **existing** {{ destination.display_name }} destinations, or those already connected to Stitch. To connect a new {{ destination.display_name }} destination, [refer to these instructions]({{ link.destinations.setup.bigquery | prepend: site.baseurl }}).
-{% endcapture %}
-
-{% include important.html type="single-line" content=only-for-existing-destinations %}
-
-Need to change the location in which {{ destination.display_name }} stores your data? Using Stitch's Destination Change feature, you can delete the current destination and connect a new one with the desired data storage location.
-
----
-
-## Considerations
-
-Here's what you need to know to ensure a smooth switch:
-
-- **Your integrations will be paused.** After the switch is complete, you'll need to manually unpause the integrations you'd like to resume.
-
-- **Some webhook data may be lost during this process**. Due to their continuous, real-time nature, some webhook data may be lost during the switch.
-
-- **Historical data from webhook-based integrations must be either manually backfilled or replayed**. Some webhook providers - such as Segment - allow customers on certain plans to ‘replay’ their historical data. This feature varies from provider to provider and may not always be available.
-
-   If you don’t have the ability to replay historical webhook data, then it must be manually backfilled after the switch is complete.
-
-- **We won’t delete or transfer any data from your current {{ destination.display_name }} destination**. Depending on your needs, how historical data is imported into the new instance may vary. See the next section for details.
-
----
-
-## Step 1: Select a historical data setting {#select-historical-data-setting}
-
-If you need historical data in the new destination, you’ll need to either manually transfer your historical data or queue a historical replication job.
-
-- **Manually transfer historical data**: To accomplish this, you can use Google's UI to import the existing datasets into the new {{ destination.display_name }} instance. Ensure that all dataset names remain the same during the transfer, or loading errors may occur.
-
-   **Complete the historical transfer before continuing.**
-
-- **Queue a historical replication job**: Initializing a historical replication will re-replicate all historical data from your integrations. For SaaS integrations, Stitch will replicate data beginning with the **Start Date** currently in the integration's settings.
-
-### Define the setting
-
-1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
-2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
-3. In the **Historical Data** section, select how you want data to be replicated to the new destination: 
-   {% for field in page-settings.bigquery-historical-data %}
-   - {{ field.field }}: {{ field.copy | flatify }}
-   {% endfor %}
-
----
-
-## Step 2: Delete the current destination {#delete-current-bigquery-destination}
-
-1. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
-2. To complete the switch, Stitch must delete your current destination configuration. **Note**: This will not delete data in the destination itself - it only clears this destination's settings from Stitch.
-
-   To continue with the switch, click **OK** to delete the current destination settings.
-
----
-
-## Step 3: Connect the new {{ destination.display_name }} destination {#connect-new-bigquery-destination}
-
-{% capture permissions %}
-1. **A user with full access to an existing [Google Cloud Platform (GCP) project within {{ destination.display_name }}]({{ destination.setup-project }}){:target="_blank"}**.
-
-2. **Admin permissions for BigQuery and Google Cloud Storage (GCS)**. This includes the BigQuery Admin and Storage Admin permissions. Stitch requires these permissions to [create and use a GCS bucket](https://cloud.google.com/storage/docs/access-control/bucket-level-iam){:target="_blank"} to load replicated data into BigQuery.
-
-3. **Access to a project where [billing is enabled]({{ destination.enable-billing }}){:target="_blank"} and a credit card is attached**. Even if you're using BigQuery's free trial, billing must still be enabled for Stitch to load data.
-{% endcapture %}
-
-{% include important.html first-line="**Requirements for connecting BigQuery:**" content=permissions %}
-
-1. On the next page in Stitch, click the **{{ destination.display_name }}** icon.
-2. Click **Sign in with Google**.
-3. If you aren't already signed into your Google account, you'll be prompted for your credentials.
-4. After you sign in, you'll see a list of the permissions requested by Stitch:
-     - **Read/Write Access to Google Cloud Storage** - Stitch requires Read/Write access to create and use a GCS bucket to load replicated data into BigQuery.
-     - **Full Access to BigQuery** - Stitch requires full access to be able to create datasets and load data into BigQuery.
-     - **Read-Only Access to Projects** - Stitch requires read-only access to projects to allow you to select a project to use during the BigQuery setup process.
-     - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
-     - **Offline Access** - To continuously load data, Stitch requires offline access. This allows the authorization token generated during setup process to be used for more than an hour after the initial authentication takes place.
-5. To grant access, click the **Authorize** button.
-6. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
-   Fill in the fields that display:
-      - **Google Cloud Project**: From the dropdown, select the project you want to connect to Stitch.
-      - **Google Cloud Storage Location**: From the dropdown, select the new location you want to use.
-7. Click **Finish Setup**.
-
----
-
-## Step 4: Delete the existing Google Cloud Storage bucket {#delete-current-bucket}
-
-To ensure Stitch can load data into the new BigQuery instance, you'll need to delete the Google Cloud Storage (GCS) bucket that's attached to the project.
-
-{% include important.html type="single-line" content="Before completing this step, verify that all data you want to retain has been transferred. Google permanently deletes objects within buckets, and they cannot be recovered after this process completes." %}
-
-1. In another browser tab, [log into the Google console](https://console.cloud.google.com/).
-2. Use [Google's instructions](https://cloud.google.com/storage/docs/deleting-buckets) to locate the bucket in Google's UI.
-3. Locate the Stitch bucket. **If you're unsure of which bucket belongs to Stitch**, reach out to Stitch support.
-4. Delete the bucket.
-
----
-
-## Step 5: Unpause integrations {#unpause-integrations}
-
-After you've successfully connected the new {{ destination.display_name }} destination and deleted the original Stitch GCS bucket, un-pause your integrations in Stitch.
-
-Your data will begin replicating according to the historical data option selected in [Step 1](#select-historical-data-setting).

--- a/_destinations/bigquery/understanding-stitch-impact-on-bigquery-costs.md
+++ b/_destinations/bigquery/understanding-stitch-impact-on-bigquery-costs.md
@@ -10,58 +10,64 @@ content-type: "destination-general"
 
 toc: false
 type: "bigquery"
+
+sections:
+  - content: |
+      Unlike traditional relational databases and other cloud solutions like Amazon Redshift, Google BigQuery pricing is based on usage instead of fixed pricing. Because of this, it can be difficult to estimate how much a Stitch-enabled BigQuery data warehouse will cost to use over time.
+
+      Stitch employs a number of different operations across both Google Cloud Storage and BigQuery as part of the replication process. In this article, we'll give you an overview of those operations and the impact they may have.
+
+  - title: "BigQuery pricing basics"
+    anchor: "bigquery-pricing-basics"
+    content: |
+      BigQuery pricing includes two categories: storage and usage costs.
+
+      Before we get into the specifics, we strongly recommend that you familiarize yourself with the [BigQuery Pricing Model]({{ destination.pricing }}).
+
+      We'll only cover the specific ways Stitch may potentially impact BigQuery costs in this doc, so reading Google's brief overview will help you make an informed decision.
+
+  - title: "Google Cloud Storage Costs"
+    anchor: "google-cloud-storage-costs"
+    content: |
+      Before your data is loaded into BigQuery, Stitch's replication engine will replicate, process, and prepare data from your various integrations and temporarily move it into a Google Cloud Storage (GCS) bucket. This Cloud Storage bucket is automatically created by Stitch but owned by you.
+
+      While there isn't a cost associated for moving data into a Cloud Storage bucket, there are some minimal costs for the standard operations that handle the data placed there: 
+
+      - Stitch makes a number of Class A and B API calls on GCS during the replication process
+      - Google charges for these calls, but in increments of 10,000 and at a very minimal rate
+
+      Stitch files are deleted immediately after data is loaded into BigQuery, so the storage costs associated with a Cloud Storage bucket should be negligible. 
+
+      **We expect the cost of using Google Cloud Storage with Stitch to be less than $5 a month.**
+
+      [Click here]({{ destination.storage-pricing }}) for more info on Google's Cloud Storage pricing model.
+
+  - title: "BigQuery Usage Costs"
+    anchor: "bigquery-usage-costs"
+    content: |
+      BigQuery ultimately breaks down pricing into two categories: Storage pricing and query pricing.
+
+    subsections:
+      - title: "Storage pricing"
+        anchor: "storage-pricing"
+        content: |
+          The cost of storing your data in BigQuery is entirely dependent on how much data you replicate into the data warehouse.
+
+          However, when estimating how much data you expect to store in your data warehouse, it's important to understand the append-only nature of how Stitch replicates most data into BigQuery.
+
+          **To summarize: existing data isn't updated. Updates are added as new rows to existing tables. Due to this, the size of tables can grow substantially over time.**
+
+          [Click here]({{ destination.pricing | append: "#storage" }}) for more info on Google's Storage pricing model.
+
+      - title: "Query pricing"
+        anchor: "query-pricing"
+        content: |
+          **The cost of loading data into BigQuery from Google Cloud Storage is free.**
+
+          Queries currently run by Stitch to replicate your data do not currently count towards the $5/TB model currently charged by Google. 
+
+          [Click here]({{ destination.pricing | append: "#queries" }}) for more info on Google's Query pricing model.
+
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type","bigquery" | first %}
-
-Unlike traditional relational databases and other cloud solutions like Amazon Redshift, Google BigQuery pricing is based on usage instead of fixed pricing. Because of this, it can be difficult to estimate how much a Stitch-enabled BigQuery data warehouse will cost to use over time.
-
-Stitch employs a number of different operations across both Google Cloud Storage and BigQuery as part of the replication process. In this article, we'll give you an overview of those operations and the impact they may have.
-
----
-
-## BigQuery Pricing Basics 
-
-BigQuery pricing includes two categories: storage and usage costs.
-
-Before we get into the specifics, we strongly recommend that you familiarize yourself with the [BigQuery Pricing Model]({{ destination.pricing }}).
-
-We'll only cover the specific ways Stitch may potentially impact BigQuery costs in this doc, so reading Google's brief overview will help you make an informed decision.
-
----
-
-## Google Cloud Storage Costs
-
-Before your data is loaded into BigQuery, Stitch's replication engine will replicate, process, and prepare data from your various integrations and temporarily move it into a Google Cloud Storage (GCS) bucket. This Cloud Storage bucket is automatically created by Stitch but owned by you.
-
-While there isn't a cost associated for moving data into a Cloud Storage bucket, there are some minimal costs for the standard operations that handle the data placed there: 
-
-- Stitch makes a number of Class A and B API calls on GCS during the replication process
-- Google charges for these calls, but in increments of 10,000 and at a very minimal rate
-
-Stitch files are deleted immediately after data is loaded into BigQuery, so the storage costs associated with a Cloud Storage bucket should be negligible. 
-
-**We expect the cost of using Google Cloud Storage with Stitch to be less than $5 a month.**
-
-[Click here]({{ destination.storage-pricing }}) for more info on Google's Cloud Storage pricing model.
-
----
-
-## BigQuery Usage Costs
-BigQuery ultimately breaks down pricing into two categories: storage pricing and query pricing.
-
-### Storage Pricing
-The cost of storing your data in BigQuery is entirely dependent on how much data you replicate into the data warehouse.
-
-However, when estimating how much data you expect to store in your data warehouse, it's important to understand the append-only nature of how Stitch replicates most data into BigQuery.
-
-**To summarize: existing data isn't updated. Updates are added as new rows to existing tables. Due to this, the size of tables can grow substantially over time.**
-
-[Click here]({{ destination.pricing | append: "#storage" }}) for more info on Google's Storage pricing model.
-
-### Query Pricing
-**The cost of loading data into BigQuery from Google Cloud Storage is free.**
-
-Queries currently run by Stitch to replicate your data do not currently count towards the $5/TB model currently charged by Google. 
-
-[Click here]({{ destination.pricing | append: "#queries" }}) for more info on Google's Query pricing model.

--- a/_destinations/redshift/apply-encodings-sort-dist-keys-redshift.md
+++ b/_destinations/redshift/apply-encodings-sort-dist-keys-redshift.md
@@ -9,145 +9,160 @@ content-type: "destination-general"
 
 toc: true
 type: "redshift"
+
+sections:
+  - content: |
+      {% include important.html type="single-line" content="The process we outline in this tutorial - which includes dropping tables - can lead to data corruption and other issues if done incorrectly. **Please proceed with caution or reach out to Stitch support if you have questions.**" %}
+
+      Want to improve your query performance? In this article, we’ll walk you through how to use encoding, Sort, and Distribution keys to streamline query processing.
+
+  - title: "Overview"
+    anchor: "overview"
+    content: |
+      What do each of these query performance enhancing tools do? Before we dive into their application, here's a quick overview:
+
+    subsections:
+      - title: "Encodings"
+        anchor: "encodings"
+        content: |
+          **Encodings**, or [compression types](http://docs.aws.amazon.com/redshift/latest/dg/t_Compressing_data_on_disk.html), are used to reduce the amount of required storage space and the size of data that’s read from storage. This in turn can lead to a reduction in processing time for queries.
+
+      - title: "SORT keys"
+        anchor: "overview-sort-keys"
+        content: |
+          **[Sort keys](http://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html)** determine the order in which rows in a table are stored. When properly applied, Sort Keys allow large chunks of data to be skipped during query processing. Less data to scan means a shorter processing time, thus improving the query’s performance.
+
+      - title: "Distribution keys"
+        anchor: "overview-dist-keys"
+        content: |
+          **[Distribution, or DIST keys](http://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html)** determine where data is stored in Redshift. When data is replicated into your data warehouse, it’s stored across the compute nodes that make up the cluster. If data is heavily skewed - meaning a large amount is placed on a single node - query performance will suffer. Even distribution prevents these bottlenecks by ensuring that nodes equally share the processing load.
+
+  - title: "Things to think about"
+    anchor: "things-to-think-about"
+    content: |
+      Consider the following before diving in:
+
+      1. **Optimizing for every single query isn’t possible.** We suggest selecting the most important queries and selecting Sort/Dist keys that will improve the performance of those queries.
+      2. **Columns with few unique values aren’t good Sort keys**. Because Sort Keys store records together based on similar values, selecting a column with few unique values as the Sort key will heavily skew the data. This will lead to an increase in query processing time.
+      3. **Tables using Full Table Replication aren’t good candidates for this process** Due to the nature of Full Table Replication, encodings, Sort, and DIST keys in these tables may be overwritten during the replication attempts that follow application.
+
+  - title: "Apply encodings, DIST, and SORT keys"
+    anchor: "apply-encodings-dist-sort-keys"
+    content: |
+      {% include note.html type="single-line" content="The process outlined here can be used across the board to apply encodings **and** Keys." %}
+
+      We’ll use a table called `orders`, which is contained in the `rep_sales` schema.
+
+      Log into your Redshift database using your SQL client to get started.
+
+    subsections:
+      - title: "Step 1: Retrieve the table schema"
+        anchor: "step-1-retrieve-table-schema"
+        content: |
+          Use this command to retrieve the table schema for orders:
+
+          ```sql
+          \d+ [schema_name].[table_name]
+          ```
+
+          This command will produce the table schema. In our case, the result looks like this:
+
+          ```
+          Column              | Data Type                  
+          --------------------+----------------------------+
+          id                  | BIGINT               
+          rep_name            | VARCHAR(128)              
+          order_amount        | BIGINT                     
+          order_confirmed     | BOOLEAN                    
+          created_at          | TIMESTAMP                  
+          _sdc_sequence       | NUMERIC                    
+          _sdc_received_at    | TIMESTAMP WITHOUT TIMEZONE 
+          _sdc_batched_at     | TIMESTAMP WITHOUT TIMEZONE 
+          _sdc_table_version  | BIGINT                     
+          _sdc_replication_id | VARCHAR(128)
+          ```
+
+      - title: "Step 2: Create a table copy and redefine the schema"
+        anchor: "step-2-create-table-copy"
+        content: |
+          In this step, you’ll create a copy of the table, redefine its structure to include the `DIST` and `SORT` Keys, insert/rename the table, and then drop the "old" table.
+
+          But first, retrieve the table's Primary Key using the following query:
+
+          ```sql
+          SELECT description FROM pg_description WHERE objoid = 'old_orders'::regclass;             
+             /* This will retrieve the Primary Key comment: {"primary_keys":["XXXXX"]} */
+          ```
+
+          This will be used in the next step to indicate which column(s) are the table's Primary Keys.
+
+          {% include important.html first-line="**Primary Key comments**" content="Redshift doesn’t enforce the use of Primary Keys, but Stitch requires them to replicate data. In the following example, you'll see `COMMENT` being used to note the table's Primary Key. **Make sure you include the Primary Key comment in the next step, as missing Primary Keys will cause issues with data replication.**" %}
+
+          Here's the transaction we'd use on the `rep_sales.orders` table:
+
+          ```sql
+          SET search_path to rep_sales;
+          BEGIN;
+          ALTER TABLE orders RENAME TO old_orders;
+          CREATE TABLE new_orders (
+              id bigint,
+              rep_name character varying(128) encode bytedict,     /* Sets the encoding */
+              order_amount bigint,
+              order_confirmed boolean,
+              created_at timestamp without time zone,
+              _sdc_sequence numeric(18,0),
+              _sdc_received_at timestamp without time zone,
+              _sdc_batched_at timestamp without time zone,
+              _sdc_table_version bigint,
+              _sdc_replication_id character varying(128)
+          )  distkey (id)     // Sets the DIST Key
+             sortkey (id);     // Sets the SORT Key
+          INSERT INTO new_orders (SELECT * FROM old_orders);
+
+          COMMENT ON table new_orders IS '{"primary_keys":["XXXXX"]}';
+                                                                  /* Sets Primary Key comment */
+
+          ALTER TABLE new_orders RENAME TO orders;
+          ALTER TABLE orders OWNER TO stitch_user;      /* Grants table ownership to Stitch */
+          DROP TABLE old_orders;                        /* Drops the "old" table */
+          END;
+          ```
+
+      - title: "Step 3: Verify the table owner"
+        anchor: "step-3-verify-table-owner"
+        content: |
+          When you perform this process yourself, **make sure that the Stitch Redshift user retains ownership of the table**.
+
+          If Stitch isn't the owner of the table, issues with data replication will arise.
+
+      - title: "Step 4: Verify the encoding and key application"
+        anchor: "step-4-verify-application"
+        content: |
+          To verify that the changes were applied correctly, retrieve the table’s schema again using this command:
+
+          ```sql
+          \d+ [schema_name].[table_name]
+          ```
+
+          In this example, if the Keys and encodings were applied correctly, the response would look something like this:
+
+          ```sql
+          | Column              | Data type                  | Encoding | Distkey | Sortkey |
+          |---------------------+----------------------------+----------+---------+---------|
+          | id                  | BIGINT                     | none     | true    | true    |  
+          | rep_name            | VARCHAR(128)               | bytedict | false   | false   |  
+          | order_amount        | BIGINT                     | none     | false   | false   |
+          | order_confirmed     | BOOLEAN                    | none     | false   | false   |
+          | created_at          | TIMESTAMP                  | none     | false   | false   |
+          | _sdc_sequence       | NUMERIC                    | none     | false   | false   |
+          | _sdc_received_at    | TIMESTAMP WITHOUT TIMEZONE | none     | false   | false   |
+          | _sdc_batched_at     | TIMESTAMP WITHOUT TIMEZONE | none     | false   | false   |
+          | _sdc_table_version  | BIGINT                     | none     | false   | false   |
+          | _sdc_replication_id | VARCHAR(128)               | none     | false   | false   |
+          ```
+
+          For the `id` column, the `Distkey` and `Sortkey` is set to `true`, meaning that the keys were properly applied. For `rep_name`, the `Encoding` is set to `bytedict`, indicating that the encoding was also properly applied.
+
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type","redshift" | first %}
-
-{% include important.html type="single-line" content="The process we outline in this tutorial - which includes dropping tables - can lead to data corruption and other issues if done incorrectly. **Please proceed with caution or reach out to Stitch support if you have questions.**" %}
-
-Want to improve your query performance? In this article, we’ll walk you through how to use encoding, Sort, and Distribution keys to streamline query processing.
-
----
-
-## Overview
-
-### Encodings
-**Encodings**, or [compression types](http://docs.aws.amazon.com/redshift/latest/dg/t_Compressing_data_on_disk.html), are used to reduce the amount of required storage space and the size of data that’s read from storage. This in turn can lead to a reduction in processing time for queries.
-
-### Sort Keys {#overview-sort-keys}
-**[Sort keys](http://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html)** determine the order in which rows in a table are stored. When properly applied, Sort Keys allow large chunks of data to be skipped during query processing. Less data to scan means a shorter processing time, thus improving the query’s performance.
-
-### Distribution Keys {#overview-dist-keys}
-**[Distribution, or DIST keys](http://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html)** determine where data is stored in Redshift. When data is replicated into your data warehouse, it’s stored across the compute nodes that make up the cluster. If data is heavily skewed - meaning a large amount is placed on a single node - query performance will suffer. Even distribution prevents these bottlenecks by ensuring that nodes equally share the processing load.
-
----
-
-## Things to think about
-
-Consider the following before diving in:
-
-1. **Optimizing for every single query isn’t possible.** We suggest selecting the most important queries and selecting Sort/Dist keys that will improve the performance of those queries.
-2. **Columns with few unique values aren’t good Sort keys**. Because Sort Keys store records together based on similar values, selecting a column with few unique values as the Sort key will heavily skew the data. This will lead to an increase in query processing time.
-3. **Tables using Full Table Replication aren’t good candidates for this process** Due to the nature of Full Table Replication, encodings, Sort, and DIST keys in these tables may be overwritten during the replication attempts that follow application.
-
----
-
-## Apply encodings, DIST, and Sort keys
-
-{% include note.html type="single-line" content="The process outlined here can be used across the board to apply encodings **and** Keys." %}
-
-We’ll use a table called `orders`, which is contained in the `rep_sales` schema.
-
-Log into your Redshift database using your SQL client to get started.
-
-### Step 1: Retrieve the table schema
-Use this command to retrieve the table schema for orders:
-
-```sql
-\d+ [schema_name].[table_name]
-```
-
-This command will produce the table schema. In our case, the result looks like this:
-
-```
-Column              | Data Type                  
---------------------+----------------------------+
-id                  | BIGINT               
-rep_name            | VARCHAR(128)              
-order_amount        | BIGINT                     
-order_confirmed     | BOOLEAN                    
-created_at          | TIMESTAMP                  
-_sdc_sequence       | NUMERIC                    
-_sdc_received_at    | TIMESTAMP WITHOUT TIMEZONE 
-_sdc_batched_at     | TIMESTAMP WITHOUT TIMEZONE 
-_sdc_table_version  | BIGINT                     
-_sdc_replication_id | VARCHAR(128)
-```
-
-### Step 2: Create a table copy and redefine the schema
-
-In this step, you’ll create a copy of the table, redefine its structure to include the `DIST` and `SORT` Keys, insert/rename the table, and then drop the "old" table.
-
-But first, retrieve the table's Primary Key using the following query:
-
-```sql
-SELECT description FROM pg_description WHERE objoid = 'old_orders'::regclass;             
-   /* This will retrieve the Primary Key comment: {"primary_keys":["XXXXX"]} */
-```
-
-This will be used in the next step to indicate which column(s) are the table's Primary Keys.
-
-{% include important.html first-line="**Primary Key comments**" content="Redshift doesn’t enforce the use of Primary Keys, but Stitch requires them to replicate data. In the following example, you'll see `COMMENT` being used to note the table's Primary Key. **Make sure you include the Primary Key comment in the next step, as missing Primary Keys will cause issues with data replication.**" %}
-
-Here's the transaction we'd use on the `rep_sales.orders` table:
-
-```sql
-SET search_path to rep_sales;
-BEGIN;
-ALTER TABLE orders RENAME TO old_orders;
-CREATE TABLE new_orders (
-    id bigint,
-    rep_name character varying(128) encode bytedict,     /* Sets the encoding */
-    order_amount bigint,
-    order_confirmed boolean,
-    created_at timestamp without time zone,
-    _sdc_sequence numeric(18,0),
-    _sdc_received_at timestamp without time zone,
-    _sdc_batched_at timestamp without time zone,
-    _sdc_table_version bigint,
-    _sdc_replication_id character varying(128)
-)  distkey (id)     // Sets the DIST Key
-   sortkey (id);     // Sets the SORT Key
-INSERT INTO new_orders (SELECT * FROM old_orders);
-
-COMMENT ON table new_orders IS '{"primary_keys":["XXXXX"]}';
-                                                        /* Sets Primary Key comment */
-
-ALTER TABLE new_orders RENAME TO orders;
-ALTER TABLE orders OWNER TO stitch_user;      /* Grants table ownership to Stitch */
-DROP TABLE old_orders;                        /* Drops the "old" table */
-END;
-```
-
-### Step 3: Verify the table owner
-
-When you perform this process yourself, **make sure that the Stitch Redshift user retains ownership of the table**.
-
-If Stitch isn't the owner of the table, issues with data replication will arise.
-
-### Step 4: Verify the encoding and key application
-
-To verify that the changes were applied correctly, retrieve the table’s schema again using this command:
-
-```sql
-\d+ [schema_name].[table_name]
-```
-
-In this example, if the Keys and encodings were applied correctly, the response would look something like this:
-
-```sql
-| Column              | Data type                  | Encoding | Distkey | Sortkey |
-|---------------------+----------------------------+----------+---------+---------|
-| id                  | BIGINT                     | none     | true    | true    |  
-| rep_name            | VARCHAR(128)               | bytedict | false   | false   |  
-| order_amount        | BIGINT                     | none     | false   | false   |
-| order_confirmed     | BOOLEAN                    | none     | false   | false   |
-| created_at          | TIMESTAMP                  | none     | false   | false   |
-| _sdc_sequence       | NUMERIC                    | none     | false   | false   |
-| _sdc_received_at    | TIMESTAMP WITHOUT TIMEZONE | none     | false   | false   |
-| _sdc_batched_at     | TIMESTAMP WITHOUT TIMEZONE | none     | false   | false   |
-| _sdc_table_version  | BIGINT                     | none     | false   | false   |
-| _sdc_replication_id | VARCHAR(128)               | none     | false   | false   |
-```
-
-For the `id` column, the `Distkey` and `Sortkey` is set to `true`, meaning that the keys were properly applied. For `rep_name`, the `Encoding` is set to `bytedict`, indicating that the encoding was also properly applied.

--- a/_destinations/redshift/remove-database-integration-columns-redshift.md
+++ b/_destinations/redshift/remove-database-integration-columns-redshift.md
@@ -9,177 +9,174 @@ type: "redshift"
 
 content-type: "destination-general"
 
+
+sections:
+  - content: |
+      {% include important.html type="single-line" content="Columns can only be removed from integration tables where column selection is supported. If Stitch detects data for a removed column, the column will be recreated in the destination." %}
+
+      When you rename or no longer want to replicate a column, what happens? For both Full Table and Incremental replication, the old column and all historical data will remain in the table even if there aren’t any new values being replicated.
+
+      For some Stitch users, retaining these columns is perfectly fine. If you like to keep things tidy, however, you can easily remove the unwanted columns by recreating your realized tables without those columns.
+
+      We recommend using `pg_dump` for this process, which is similar to altering the `SORT and DIST` keys on your tables.
+
+  - title: "Step 1: Retrieve the table definition"
+    anchor: "step-1-retrieve-table-definition"
+    content: |
+      In this example, we’ll show you how to remove the unwanted columns using `pg_dump` from the command line. We marked everything you’ll need to define yourself in square brackets `[like this]`.
+
+      {% include note.html type="single-line" content="If any new data is detected for the deleted column, Stitch will recreate the column in your data warehouse." %}
+
+      First, you’ll grab a full definition of your target table and then create the new table structure, removing the unwanted column(s):
+
+      ```
+      pg_dump --host [yourawshost.redshift.amazonaws.com] --port [your_port] --username [admin_username][database_name] -t '[schema_name.original_target_table_name]'
+      ```
+
+      The above command will return a response similar to the following:
+
+      ```
+      SET statement_timeout = 0;
+      SET client_encoding = 'UTF8';
+      SET standard_conforming_strings = off;
+      SET check_function_bodies = false;
+      SET client_min_messages = warning;
+      SET escape_string_warning = off;
+
+      SET search_path = schema_name, pg_catalog;
+
+      SET default_tablespace = '';
+
+      SET default_with_oids = true;
+
+      --
+      -- Name: original_target_table_name; Type: TABLE; Schema: schema_name; 
+        Owner: admin_username; Tablespace: 
+      --
+
+      CREATE TABLE original_target_table_name (
+           id bigint,
+           value character varying(128),
+           the_column_being_removed numeric(18,0), 
+           {{ system-column.sequence }} numeric(18,0),
+           {{ system-column.received-at }} timestamp without time zone,
+           {{ system-column.batched-at }} timestamp without time zone,
+           {{ system-column.table-version }} bigint,
+           {{ system-column.replication-id }} character varying(128)
+      );
+
+      ALTER TABLE schema_name.original_target_table_name OWNER TO admin;
+
+      --
+      -- Data for Name: original_target_table_name; Type: TABLE DATA; Schema: 
+        schema_name; Owner: admin
+      --
+      ...
+      ```
+
+  - title: "Step 2: Retrieve the table's Primary Key comment"
+    anchor: "step-2-retrieve-primary-key-comment"
+    content: |
+      Next, you need to retrieve the table's Primary Key comment. This will be used in the next step to indicate which column(s) are the table's Primary Keys.
+
+      Run the following query:
+
+      ```sql
+      SELECT description
+        FROM pg_description
+       WHERE objoid = '[original_target_table_name]'::regclass;
+      ```
+
+      This will retrieve the table's Primary Key comment:
+
+      ```
+      {"primary_keys":["column_name"]}
+              /* format for Primary Key with one column */
+
+      {"primary_keys":["column_name1", "column_name2"]}
+              /* format for Primary Key with multiple columns */
+      ```
+
+      This will be used in the next step to indicate which column(s) are the table's Primary Keys.
+
+      {% include important.html first-line="**Primary Key comments**" content="Redshift doesn’t enforce the use of Primary Keys, but Stitch requires them to replicate data. In the following example, you'll see `COMMENT` being used to note the table's Primary Key. **Make sure you include the Primary Key comment in the next step, as missing Primary Keys will cause issues with data replication.**" %}
+
+  - title: "Step 3: Copy historical data into the new table"
+    anchor: "step-3-copy-historical-data-new-table"
+    content: |
+      Next, you’ll `SELECT` all the historical data from the unwanted column into the new table. When you run this transaction yourself, you’ll need to change everything inside `[the square brackets]` as well as the following:
+
+      - The column names in the table. Be sure to add `{{ system-column.rjm-prefix }}` or `{{ system-column.prefix }}` columns into the new table schema.
+      - In the `ALTER TABLE OWNER` line, you’ll see `[stitch_redshift_user]`. This is the username of the Redshift user that Stitch uses to connect to your data warehouse. **Failing to enter the Stitch username here will prevent Stitch from replicating data for this table.**
+
+      Here’s the transaction for our example table. Note where the undesired column is marked - when running the transaction yourself, you'll remove this:
+
+      ```sql
+      SET search_path to [schema_name];
+      BEGIN;
+       ALTER TABLE [table_name] RENAME TO [old_table_name];
+       CREATE TABLE [new_table_name] (
+          id bigint,
+          value character varying(128),
+          column_being_removed (18,0),                /* The undesired column - take it out */
+          {{ system-column.sequence }} numeric(18,0),
+          {{ system-column.received-at }} timestamp without time zone,
+          {{ system-column.batched-at }} timestamp without time zone,
+          {{ system-column.table-version }} bigint,
+          {{ system-column.replication-id }} character varying(128)
+       );
+       INSERT INTO [new_table_name]
+          (SELECT id,                                 /* Repeat the desired schema here */
+                  value,
+                  {{ system-column.sequence }},
+                  {{ system-column.received-at }},
+                  {{ system-column.batched-at }},
+                  {{ system-column.table-version }},
+                  {{ system-column.replication-id }}
+           FROM [old_table_name]);
+
+      COMMENT ON table [new_table_name]               /* Sets Primary Key comment */
+      IS '{"primary_keys":["column_name"]}';          /* This is the most important part! */
+
+      ALTER TABLE [new_table_name] RENAME TO [table_name];
+
+      ALTER TABLE [table_name] OWNER TO [stitch_redshift_user];
+                                          /* Grants table ownership to Stitch */
+
+      DROP TABLE [old_table_name];
+                                          /* Drops the "old" table with the undesired column */
+      END;
+      ```
+
+  - title: "Step 4: Verify the table owner"
+    anchor: "step-4-verify-table-owner"
+    content: |
+      When you perform this process yourself, **make sure that the Stitch Redshift user retains ownership of the table.**
+
+      If Stitch isn't the owner of the table, issues with data replication will arise.
+
+  - title: "Step 5: Verify the new schema"
+    anchor: "step-5-verify-new-table-schema"
+    content: |
+      Verify your changes by using this command to retrieve the table’s schema:
+
+      ```sql
+      \d+ [schema_name].[table_name]
+      ```
+
+      The response would look something like this for the example table in this tutorial:
+
+      ```markdown
+      | column              | data type                   |
+      |---------------------+-----------------------------|
+      | id                  | BIGINT                      |
+      | value               | VARCHAR(128)                |
+      | {{ system-column.sequence }}       | NUMERIC                     |
+      | {{ system-column.received-at }}    | TIMESTAMP WITHOUT TIMEZONE  |
+      | {{ system-column.batched-at }}     | TIMESTAMP WITHOUT TIMEZONE  |
+      | {{ system-column.table-version }}  | BIGINT                      |
+      | {{ system-column.replication-id }} | VARCHAR(128)                |
+      ```
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type","redshift" | first %}
-
-{% include important.html type="single-line" content="Columns can only be removed from integration tables where column selection is supported. If Stitch detects data for a removed column, the column will be recreated in the destination." %}
-
-When you rename or no longer want to replicate a column, what happens? For both Full Table and Incremental replication, the old column and all historical data will remain in the table even if there aren’t any new values being replicated.
-
-For some Stitch users, retaining these columns is perfectly fine. If you like to keep things tidy, however, you can easily remove the unwanted columns by recreating your realized tables without those columns.
-
-We recommend using `pg_dump` for this process, which is similar to altering the `SORT and DIST` keys on your tables.
-
----
-
-## Step 1: Retrieve the table definition {#retrieve-table-definition}
-
-In this example, we’ll show you how to remove the unwanted columns using `pg_dump` from the command line. We marked everything you’ll need to define yourself in square brackets `[like this]`.
-
-{% include note.html type="single-line" content="If any new data is detected for the deleted column, Stitch will recreate the column in your data warehouse." %}
-
-First, you’ll grab a full definition of your target table and then create the new table structure, removing the unwanted column(s):
-
-```
-pg_dump --host [yourawshost.redshift.amazonaws.com] --port [your_port] --username [admin_username][database_name] -t '[schema_name.original_target_table_name]'
-```
-
-The above command will return a response similar to the following:
-
-```
-SET statement_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = off;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
-SET escape_string_warning = off;
-
-SET search_path = schema_name, pg_catalog;
-
-SET default_tablespace = '';
-
-SET default_with_oids = true;
-
---
--- Name: original_target_table_name; Type: TABLE; Schema: schema_name; 
-  Owner: admin_username; Tablespace: 
---
-
-CREATE TABLE original_target_table_name (
-     id bigint,
-     value character varying(128),
-     the_column_being_removed numeric(18,0), 
-     {{ system-column.sequence }} numeric(18,0),
-     {{ system-column.received-at }} timestamp without time zone,
-     {{ system-column.batched-at }} timestamp without time zone,
-     {{ system-column.table-version }} bigint,
-     {{ system-column.replication-id }} character varying(128)
-);
-
-ALTER TABLE schema_name.original_target_table_name OWNER TO admin;
-
---
--- Data for Name: original_target_table_name; Type: TABLE DATA; Schema: 
-  schema_name; Owner: admin
---
-...
-```
-
----
-
-## Step 2: Retrieve the table's Primary Key comment {#retrieve-primary-key-comment}
-
-Next, you need to retrieve the table's Primary Key comment. This will be used in the next step to indicate which column(s) are the table's Primary Keys.
-
-Run the following query:
-
-```sql
-SELECT description
-  FROM pg_description
- WHERE objoid = '[original_target_table_name]'::regclass;
-```
-
-This will retrieve the table's Primary Key comment:
-
-```
-{"primary_keys":["column_name"]}
-        /* format for Primary Key with one column */
-
-{"primary_keys":["column_name1", "column_name2"]}
-        /* format for Primary Key with multiple columns */
-```
-
-This will be used in the next step to indicate which column(s) are the table's Primary Keys.
-
-{% include important.html first-line="**Primary Key comments**" content="Redshift doesn’t enforce the use of Primary Keys, but Stitch requires them to replicate data. In the following example, you'll see `COMMENT` being used to note the table's Primary Key. **Make sure you include the Primary Key comment in the next step, as missing Primary Keys will cause issues with data replication.**" %}
-
----
-
-## Step 3: Copy historical data into the new table {#copy-historical-data-new-table}
-
-Next, you’ll `SELECT` all the historical data from the unwanted column into the new table. When you run this transaction yourself, you’ll need to change everything inside `[the square brackets]` as well as the following:
-
-- The column names in the table. Be sure to add `{{ system-column.rjm-prefix }}` or `{{ system-column.prefix }}` columns into the new table schema.
-- In the `ALTER TABLE OWNER` line, you’ll see `[stitch_redshift_user]`. This is the username of the Redshift user that Stitch uses to connect to your data warehouse. **Failing to enter the Stitch username here will prevent Stitch from replicating data for this table.**
-
-Here’s the transaction for our example table. Note where the undesired column is marked - when running the transaction yourself, you'll remove this:
-
-```sql
-SET search_path to [schema_name];
-BEGIN;
- ALTER TABLE [table_name] RENAME TO [old_table_name];
- CREATE TABLE [new_table_name] (
-    id bigint,
-    value character varying(128),
-    column_being_removed (18,0),                /* The undesired column - take it out */
-    {{ system-column.sequence }} numeric(18,0),
-    {{ system-column.received-at }} timestamp without time zone,
-    {{ system-column.batched-at }} timestamp without time zone,
-    {{ system-column.table-version }} bigint,
-    {{ system-column.replication-id }} character varying(128)
- );
- INSERT INTO [new_table_name]
-    (SELECT id,                                 /* Repeat the desired schema here */
-            value,
-            {{ system-column.sequence }},
-            {{ system-column.received-at }},
-            {{ system-column.batched-at }},
-            {{ system-column.table-version }},
-            {{ system-column.replication-id }}
-     FROM [old_table_name]);
-
-COMMENT ON table [new_table_name]               /* Sets Primary Key comment */
-IS '{"primary_keys":["column_name"]}';          /* This is the most important part! */
-
-ALTER TABLE [new_table_name] RENAME TO [table_name];
-
-ALTER TABLE [table_name] OWNER TO [stitch_redshift_user];
-                                    /* Grants table ownership to Stitch */
-
-DROP TABLE [old_table_name];
-                                    /* Drops the "old" table with the undesired column */
-END;
-```
-
----
-
-## Step 4: Verify the table owner {#verify-table-owner}
-
-When you perform this process yourself, **make sure that the Stitch Redshift user retains ownership of the table.**
-
-If Stitch isn't the owner of the table, issues with data replication will arise.
-
----
-
-## Step 5: Verify the new schema {#verify-new-table-schema}
-
-Verify your changes by using this command to retrieve the table’s schema:
-
-```sql
-\d+ [schema_name].[table_name]
-```
-
-The response would look something like this for the example table in this tutorial:
-
-```markdown
-| column              | data type                   |
-|---------------------+-----------------------------|
-| id                  | BIGINT                      |
-| value               | VARCHAR(128)                |
-| {{ system-column.sequence }}       | NUMERIC                     |
-| {{ system-column.received-at }}    | TIMESTAMP WITHOUT TIMEZONE  |
-| {{ system-column.batched-at }}     | TIMESTAMP WITHOUT TIMEZONE  |
-| {{ system-column.table-version }}  | BIGINT                      |
-| {{ system-column.replication-id }} | VARCHAR(128)                |
-```

--- a/_destinations/switching-stitch-destinations.md
+++ b/_destinations/switching-stitch-destinations.md
@@ -10,67 +10,65 @@ content-type: "destination-general"
 toc: true
 type: "all"
 destination: "false"
+
+sections:
+  - content: |
+      Sometimes, you may want to replicate data to a different location than what you initially connected to Stitch. 
+
+      For example: Nou now want to replicate data from your integrations to a different database in your Redshift cluster, or you simply decide that Redshift isn't the destination for you.
+
+  - title: "Prerequisites"
+    anchor: "prerequisites"
+    content: |
+      The only prerequisite to changing destinations is that the **new** destination is ready to be connected to Stitch. This will minimize any downtime you may experience.
+
+      If you need a refresher on how to spin up a destination for Stitch, check out the [destination setup guides]({{ site.baseurl }}/destinations#current-destinations).
+
+  - title: "Considerations"
+    anchor: "considerations"
+    content: |
+      Here's what you need to know to ensure a smooth switch:
+
+      - **Some destinations may structure data differently than your current destination.** For example: if you're changing from Redshift to BigQuery, there will be some differences in how your data is stored. Detailed info about how Stitch loads data can be found in the [Data Loading Guide]({{ link.destinations.storage.loading-data | prepend: site.baseurl }}) for each destination.
+
+      - **Your integrations will be paused.** After the switch is complete, you’ll need to manually unpause the integrations you’d like to resume.
+
+      - **We won’t delete or transfer any data from your current destination.** To get historical data into your new destination, you'll need to queue a full re-sync of all your integrations. 
+
+         Re-syncing historical data will count towards your row usage and may take some time, depending on the volume of data and API limitations imposed by the provider.
+
+      - **Some webhook data may be lost during this process.** Due to their continuous, real-time nature, some webhook data may be lost during the switch.
+
+      - **Historical data from webhook-based integrations must be either manually backfilled or replayed.** Some webhook providers - such as Segment - allow customers on certain plans to 'replay' their historical data. This feature varies from provider to provider and may not always be available.
+
+         If you don't have the ability to replay historical webhook data, then it must be manually backfilled after the switch is complete.
+
+  - title: "Switch destinations"
+    anchor: "switch-destinations"
+    content: |
+      1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
+      2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
+      3. In the **Historical Data** section, select how you want data to be replicated to the new destination:
+         {% for field in page-settings.default-historical-data %}
+         - {{ field.field }}: {{ field.copy | flatify }}
+         {% endfor %}
+      4. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
+      5. To complete the switch, Stitch must delete your current destination configuration. **Note**: This will not delete data in the destination itself - it only clears this destination's settings from Stitch.
+
+         To continue with the switch, click **OK** to delete the current destination settings.
+      6. On the next page, click the icon of the destination type you want to switch to.
+      7. Follow the instructions for that destination type to complete the setup. If you need some help, refer to the destination's setup guide:
+         {% for destination in site.destinations %}
+         {% if destination.destination == true %}
+         - [{{ destination.display_name }} Setup]({{ destination.url | prepend: site.baseurl | append:"#setup" }})
+         {% endif %}
+         {% endfor %}
+      8. After you've successfully connected the new destination, un-pause your integrations. Your data will begin replicating according to the historical data option selected in Step 3.
+
+  - title: "Troubleshooting"
+    anchor: "troubleshooting"
+    content: |
+      If you encounter connection issues, check out the [Destination Connection Errors guide]({{ link.troubleshooting.dw-connection-errors | prepend: site.baseurl }}) for common problems and solutions.
 ---
 {% assign page-settings = site.data.ui.change-destinations-page %}
 {% include misc/data-files.html %}
-
-Sometimes, you may want to replicate data to a different location than what you initially connected to Stitch. 
-
-For example: you now want to replicate data from your integrations to a different database in your Redshift cluster, or you simply decide that Redshift isn't the data warehouse for you.
-
----
-
-## Prerequisites
-
-The only prerequisite to changing destinations is that the **new** destination is ready to be connected to Stitch. This will minimize any downtime you may experience.
-
-If you need a refresher on how to spin up a destination for Stitch, check out the [destination setup guides]({{ site.baseurl }}/destinations#current-destinations).
-
----
-
-## Considerations
-
-Here's what you need to know to ensure a smooth switch:
-
-- **Some destinations may structure data differently than your current destination.** For example: if you're changing from Redshift to BigQuery, there will be some differences in how your data is stored. Detailed info about how Stitch loads data can be found in the [Data Loading Guide]({{ link.destinations.storage.loading-data | prepend: site.baseurl }}) for each destination.
-
-- **Your integrations will be paused.** After the switch is complete, you’ll need to manually unpause the integrations you’d like to resume.
-
-- **We won’t delete or transfer any data from your current destination.** To get historical data into your new destination, you'll need to queue a full re-sync of all your integrations. 
-
-   Re-syncing historical data will count towards your row usage and may take some time, depending on the volume of data and API limitations imposed by the provider.
-
-- **Some webhook data may be lost during this process.** Due to their continuous, real-time nature, some webhook data may be lost during the switch.
-
-- **Historical data from webhook-based integrations must be either manually backfilled or replayed.** Some webhook providers - such as Segment - allow customers on certain plans to 'replay' their historical data. This feature varies from provider to provider and may not always be available.
-
-   If you don't have the ability to replay historical webhook data, then it must be manually backfilled after the switch is complete.
-
----
-
-## Switch Destinations
-
-1. From the {{ app.page-names.dashboard }}, click the {{ app.menu-paths.destination-settings }}.
-2. At the bottom of the page, click the {{ app.buttons.change-destination }} button.
-3. In the **Historical Data** section, select how you want data to be replicated to the new destination:
-   {% for field in page-settings.default-historical-data %}
-   - {{ field.field }}: {{ field.copy | flatify }}
-   {% endfor %}
-4. Click **Continue**. A message will display asking you to confirm the removal of the current destination's settings.
-5. To complete the switch, Stitch must delete your current destination configuration. **Note**: This will not delete data in the destination itself - it only clears this destination's settings from Stitch.
-
-   To continue with the switch, click **OK** to delete the current destination settings.
-6. On the next page, click the icon of the destination type you want to switch to.
-7. Follow the instructions for that destination type to complete the setup. If you need some help, refer to the destination's setup guide:
-   {% for destination in site.destinations %}
-   {% if destination.destination == true %}
-   - [{{ destination.display_name }} Setup]({{ destination.url | prepend: site.baseurl | append:"#setup" }})
-   {% endif %}
-   {% endfor %}
-8. After you've successfully connected the new destination, un-pause your integrations. Your data will begin replicating according to the historical data option selected in Step 3.
-
----
-
-## Troubleshooting
-
-If you encounter connection issues, check out the [Destination Connection Errors guide]({{ link.troubleshooting.dw-connection-errors | prepend: site.baseurl }}) for common problems and solutions.


### PR DESCRIPTION
This PR moves some destination guides that got missed during the overhaul for Azure over to the new template.