### PR TITLE
Switch Azure SQL DW to Open Beta

### DIFF
--- a/_destinations/microsoft-azure.md
+++ b/_destinations/microsoft-azure.md
@@ -28,7 +28,7 @@ type: "microsoft-azure"
 db-type: "mssql"
 pricing_tier: "standard" ## for Stitch
 
-status: "Closed Beta"
+status: "Open Beta"
 description: *summary
 port: 1433
 pricing_model: "Usage" ## provider model


### PR DESCRIPTION
This changes the status of the Azure SQL DW destination to `Open Beta`.