### PR TITLE
Stripe/v1 - Release

### DIFF
--- a/_includes/notifications/integration-deprecation-notice.html
+++ b/_includes/notifications/integration-deprecation-notice.html
@@ -17,20 +17,11 @@
             **Version {{ version.number }} deprecation**
         {% endcapture %}
 
-        <!-- If the version has a deprecation date, display it -->
-        <!-- And keep everything flush left, otherwise Jekyll throws a fit -->
-            {% unless version.deprecation-date == "n/a" or version.deprecation-date == "To be determined" %}
-{% capture deprecation %}
-This version of the {{ integration.display_name }} integration will be deprecated on **{{ version.deprecation-date }}** and no longer be formally supported by the Stitch Support Team.
+{% if version.deprecation-date == "n/a" or version.deprecation-date == "To be determined" %}
 
-**Connections created from {{ version.date-released }} to {{ version.date-last-connection }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
-    Upgrade to the latest version ({{ latest-version }}) to take advantage of the new enhancements.
-</a>
-{% endcapture %}
+<!-- If the version doesn't have a deprecation date yet -->
+<!-- And keep everything flush left, otherwise Jekyll throws a fit -->
 
-        <!-- Otherwise, just put up a notice -->
-        <!-- And keep everything flush left, otherwise Jekyll throws a fit -->
-            {% else %}
 {% capture deprecation %}
 A newer version of {{ integration.display_name }} is available in Stitch. This version will still continue to replicate data, but may be deprecated at a future date.
 
@@ -38,8 +29,19 @@ A newer version of {{ integration.display_name }} is available in Stitch. This v
 Upgrade to the latest version ({{ latest-version }}) to take advantage of the new enhancements.
 </a>
 {% endcapture %}
-                
-            {% endunless %}
+
+{% else %}
+
+<!-- If the version has a deprecation date, display it -->
+{% capture deprecation %}
+This version of the {{ integration.display_name }} integration will be deprecated on **{{ version.deprecation-date }}** and no longer be formally supported by the Stitch Support Team.
+
+**Connections created from {{ version.date-released }} to {{ version.date-last-connection }} use this version.** <a href="{{ site.baseurl }}/integrations/{% if page.url contains "databases" %}databases{% elsif page.url contains "saas" %}saas{% elsif page.url contains "webhooks" %}webhooks{% endif %}/{{ integration.name }}">
+    Upgrade to the latest version ({{ latest-version }}) to take advantage of the new enhancements.
+</a>
+{% endcapture %}
+{% endif %}
+
 
             {% include important.html first-line=first-line content=deprecation %}
         {% endif %}

--- a/_saas-integrations/stripe/v1/stripe-v1.md
+++ b/_saas-integrations/stripe/v1/stripe-v1.md
@@ -8,12 +8,12 @@
 ## FOR INSTRUCTIONS & REFERENCE INFO
 
 title: Stripe (v1)
-permalink: /integrations/saas/stripe/v1
+permalink: /integrations/saas/stripe
 tags: [saas_integrations]
 keywords: stripe, integration, schema, etl stripe, stripe etl, stripe schema
 summary: "Connection instructions, replication info, and schema details for Stitch's Stripe integration."
 layout: singer
-input: false
+# input: false
 
 # -------------------------- #
 #     Integration Details    #
@@ -32,7 +32,7 @@ this-version: "1.0"
 #       Stitch Details       #
 # -------------------------- #
 
-status: "Open Beta"
+status: "Released"
 certified: true
 
 historical: "1 year"

--- a/_saas-integrations/stripe/v27-02-2015/stripe-v27-02-2015.md
+++ b/_saas-integrations/stripe/v27-02-2015/stripe-v27-02-2015.md
@@ -1,14 +1,12 @@
 ---
 title: Stripe (v27-02-2015)
-permalink: /integrations/saas/stripe
+permalink: /integrations/saas/stripe/v27-02-2015
 tags: [saas_integrations]
 keywords: stripe, integration, schema, etl stripe, stripe etl, stripe schema
 summary: "Connection instructions, replication info, and schema details for Stitch's Stripe integration."
-format: ## controls formatting options in template
-  schema-list: true
-  table-desc: true
-  list: expand
-# input: false
+layout: singer
+old-schema-template: true
+input: false
 
 # -------------------------- #
 #     Integration Details    #


### PR DESCRIPTION
This PR makes Stripe v1 the default, and deprecates the previous version of the integration.