### PR TITLE
Correct log-rep for MSSQL databases

### DIFF
--- a/_database-integrations/mssql/azure/msazure.md
+++ b/_database-integrations/mssql/azure/msazure.md
@@ -51,7 +51,7 @@ table-level-reset: true
 define-replication-methods: true
 
 log-based-replication-minimum-version: "n/a"
-log-based-replication-master-instance: true
+log-based-replication-master-instance: false
 log-based-replication-read-replica: false
 
 ## Other Replication Methods

--- a/_database-integrations/mssql/microsoft-sql-server.md
+++ b/_database-integrations/mssql/microsoft-sql-server.md
@@ -49,7 +49,7 @@ table-level-reset: true
 define-replication-methods: true
 
 log-based-replication-minimum-version: "n/a"
-log-based-replication-master-instance: true
+log-based-replication-master-instance: false
 log-based-replication-read-replica: false
 
 ## Other Replication Methods


### PR DESCRIPTION
This PR corrects the value for`log-based-replication-master-instance` for MSSQL and Azure sources. This is not currently supported.