### PR TITLE
GitHub/v1: Update repository name instructions

### DIFF
--- a/_saas-integrations/github/github-latest.md
+++ b/_saas-integrations/github/github-latest.md
@@ -65,7 +65,7 @@ setup-steps:
   - title: "add integration"
     content: |
       4. In the **GitHub Access Token** field, paste the access token you created in the Step 1.
-      5. In the **GitHub Repository Name** field, enter the repository you want to track. For example: `docs`
+      5. In the **GitHub Repository Name** field, enter the username and repository you want to track seperated by a forwardslash. For example: `mygithubusername/docs`
 
          **Note**: At this time, only one repository may be tracked per integration. To track multiple repositories, you'll need to create additional GitHub integrations in your Stitch account.
   - title: "historical sync"


### PR DESCRIPTION
Unless you include the "username/" before the repository name you'll get a permissions error on first sync.