### PR TITLE
BigQuery: Add supported regions

### DIFF
--- a/_data/destinations/reference/amazon-s3.yml
+++ b/_data/destinations/reference/amazon-s3.yml
@@ -156,6 +156,10 @@ column-naming-info:
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+    
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier

--- a/_data/destinations/reference/bigquery.yml
+++ b/_data/destinations/reference/bigquery.yml
@@ -23,10 +23,6 @@
 destination-details-info:
   fully-managed: &fully-managed |
     true
-
-destination-details-info:
-  fully-managed: &fully-managed |
-    true
   pricing-model: &pricing-model |
     Usage
   free-option: &free-option |
@@ -40,6 +36,16 @@ destination-details-info:
 # Details about Stitch's implementation &
 # requirements for the destination.
 
+region-list:
+  - name: "United States (`US`)"
+  - name: "European Union (`EU`)"
+  - name: "London (`europe-west2`)"
+  - name: "Singapore (`asia-southeast`)"
+  - name: "Tokyo (`asia-northeast`)"
+  - name: "Sydney (`australia-southeast`)"
+
+
+
 stitch-details-info:
   release-status: &release-status |
     Released
@@ -47,6 +53,10 @@ stitch-details-info:
     All Stitch plans
   supported-versions: &supported-versions |
     n/a
+  supported-regions: |
+    {% for region in site.data.destinations.reference.bigquery.region-list %}
+    - {{ region.name | markdownify }}
+    {% endfor %}
 
 # Connection methods
 
@@ -166,6 +176,10 @@ reserved-words: "https://cloud.google.com/bigquery/docs/reference/standard-sql/l
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier
@@ -173,6 +187,12 @@ attributes:
   - id: "supported-versions"
     categories: "stitch-details"
     value: *supported-versions
+
+  - id: "supported-regions"
+    categories: "stitch-details"
+    value: "Stitch supports the following Google Storage Location regions:"
+    description: |
+      {{ site.data.destinations.reference.bigquery.stitch-details-info.supported-regions | flatify }}
 
   - id: "ssl-connections"
     categories: "stitch-details"

--- a/_data/destinations/reference/defaults.yml
+++ b/_data/destinations/reference/defaults.yml
@@ -22,6 +22,11 @@ stitch-details:
         description: |
           The database versions supported for use with Stitch.
 
+      - id: "supported-regions"
+        name: "Supported regions"
+        description: |
+          The regions Stitch supports for the destination.
+
       - id: "ssh-connections"
         name: "SSH connections"
         description: |

--- a/_data/destinations/reference/microsoft-azure.yml
+++ b/_data/destinations/reference/microsoft-azure.yml
@@ -159,6 +159,10 @@ reserved-words: "https://docs.microsoft.com/en-us/sql/t-sql/language-elements/re
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+    
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier

--- a/_data/destinations/reference/panoply.yml
+++ b/_data/destinations/reference/panoply.yml
@@ -157,6 +157,10 @@ reserved-words: "http://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.htm
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+  
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier

--- a/_data/destinations/reference/postgres.yml
+++ b/_data/destinations/reference/postgres.yml
@@ -168,6 +168,10 @@ reserved-words: "https://www.postgresql.org/docs/9.6/static/sql-keywords-appendi
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+    
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier

--- a/_data/destinations/reference/snowflake.yml
+++ b/_data/destinations/reference/snowflake.yml
@@ -160,6 +160,10 @@ reserved-words: "https://docs.snowflake.net/manuals/sql-reference/reserved-keywo
 # and then change whatever you need to change.
 
 attributes:
+  - id: "release-status"
+    categories: "stitch-details"
+    value: *release-status 
+
   - id: "pricing-tier"
     categories: "stitch-details"
     value: *pricing-tier

--- a/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
+++ b/_destinations/bigquery/connecting-google-bigquery-to-stitch.md
@@ -57,7 +57,7 @@ setup-steps:
   - title: "Authenticate with Google"
     anchor: "authenticate-with-google"
     content: |
-      The last step is to complete Google's authorization process and grant Stitch access to the BigQuery project you created in Step 2.
+      Next, you'll complete Google's authorization process and grant Stitch access to the BigQuery project you created in [Step 2](#create-gcp-project-enable-billing).
 
       1. Sign into your Stitch account, if you haven't already.
       2. Click the {{ app.menu-paths.destination-settings }}, then the **{{ destination.display_name }}** icon.
@@ -70,13 +70,22 @@ setup-steps:
          - **Basic Profile Information** - Stitch uses your basic profile info to retrieve your user ID.
          - **Offline Access** - To continuously load data, Stitch requires offline access. This allows the authorization token generated during setup process to be used for more than an hour after the initial authentication takes place.
       6. To grant access, click the **Authorize** button.
-      7. After you sign into Google and grant Stitch access, you'll be redirected back to Stitch.
-         Fill in the fields that display: 
-            - **Google Cloud Project**: From the dropdown, select the project you created in [Step 2](#create-gcp-project-enable-billing).
-            - **Google Cloud Storage Location**: From the dropdown, select the location where data should be stored:
-                - **US**: Data will be stored in the United States
-                - **EU**: Data will be stored in Europe
-      8. Click **Finish Setup**.
+
+  - title: "Select a Google Cloud Project and Storage Location"
+    anchor: "select-gcp-project-storage-location"
+    content: |
+      After you sign into Google and grant Stitch access, you'll be redirected back to Stitch. The last step is to select the select a project and define a storage location for your destination.
+
+      Fill in the fields as follows:
+     
+      1. From the **Google Cloud Project** dropdown, select the project you created in [Step 2](#create-gcp-project-enable-billing).
+
+      2. From the **Google Cloud Storage Location**, select the location where data should be stored:
+
+         {% for region in site.data.destinations.reference.bigquery.region-list %}
+         - {{ region.name | markdownify }}
+         {% endfor %}
+      3. Click **Finish Setup**.
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type","bigquery" | first %}


### PR DESCRIPTION
This PR adds a list of supported regions for the BigQuery destination. Stitch now supports the following BQ regions:

- United States (US)
- European Union (EU)
- London (europe-west2)
- Singapore (asia-southeast)
- Tokyo (asia-northeast)
- Sydney (australia-southeast)