### PR TITLE
CloudSQL PG: Remove `standby` parameters

### DIFF
--- a/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
+++ b/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
@@ -82,8 +82,6 @@ notice-copy: |
 requirements-list:
   - item: "**Permissions in PostgreSQL that allow you to create users.** This is required to create a database user for Stitch."
   - item: "**To be running PostgeSQL 9.3+ or greater**. PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations."
-  - item: |
-      **To verify if the database is a read replica, or follower**. While we always recommend connecting a replica over a production database, this also means you may need to verify some of its settings - specifically the `max_standby_streaming_delay` and `max_standby_archive_delay` settings - before connecting it to Stitch. We recommend setting these parameters to 8-12 hours for an initial replication job, and then decreasing them afterwards.
 
 # -------------------------- #
 #     Setup Instructions     #


### PR DESCRIPTION
This PR removes the mention of modifying `standby_*` parameters in Google CloudSQL PostgreSQL, as Google doesn’t currently allow users to modify these settings.