### PR TITLE
updating typeform example

### DIFF
--- a/_saas-integrations/typeform/v1/typeform-v1.md
+++ b/_saas-integrations/typeform/v1/typeform-v1.md
@@ -93,7 +93,7 @@ setup-steps:
       4. In the **API Token** field, paste the {{ integration.display_name }} API token you generated in [Step 1](#generate-{{ integration.name }}-api-token).
       5. In the **Forms** field, enter a comma-separated list of the form IDs you retrieved in [Step 2](#retrieve-{{ integration.name }}-form-ids). For example:
          - **Single form**: `FrZ6iD`
-         - **Multiple forms**: `FrZ6iD, f8nzFM`
+         - **Multiple forms**: `FrZ6iD,f8nzFM`
       6. In the **Incremental Range** dropdown, select the type of data aggregation you want Stitch to use:
 
          - **Daily**: Data will be aggregated by day.


### PR DESCRIPTION
Changes the example given for the `Forms` field, since I'm told the list of forms needs to be delimitated with commas only (and no spaces). Product is going to change the placeholder text to make this clearer as well.