### PR TITLE
Move Azure SQL DW to released

### DIFF
--- a/_data/destinations/reference/microsoft-azure.yml
+++ b/_data/destinations/reference/microsoft-azure.yml
@@ -38,7 +38,7 @@ destination-details-info:
 
 stitch-details-info:
   release-status: &release-status |
-    Open Beta
+    Released
   pricing-tier: &pricing-tier |
     All Stitch plans
   supported-versions: &supported-versions |

--- a/_destinations/microsoft-azure.md
+++ b/_destinations/microsoft-azure.md
@@ -28,7 +28,7 @@ type: "microsoft-azure"
 db-type: "mssql"
 pricing_tier: "standard" ## for Stitch
 
-status: "Open Beta"
+status: "Released"
 description: *summary
 port: 1433
 pricing_model: "Usage" ## provider model


### PR DESCRIPTION
This PR moves the Azure SQL Data Warehouse destination from `open beta` to `released`.