### PR TITLE
Fix SFMC table names

### DIFF
--- a/_integration-schemas/salesforce-marketing-cloud/v1/content_area.md
+++ b/_integration-schemas/salesforce-marketing-cloud/v1/content_area.md
@@ -11,7 +11,7 @@
 tap: "salesforce-marketing-cloud"
 # version: "1.0"
 
-name: "table_name"
+name: "content_areas"
 doc-link: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm
 singer-schema: https://github.com/singer-io/tap-exacttarget/blob/master/tap_exacttarget/endpoints/content_areas.py
 description: |

--- a/_integration-schemas/salesforce-marketing-cloud/v1/content_area.md
+++ b/_integration-schemas/salesforce-marketing-cloud/v1/content_area.md
@@ -11,7 +11,7 @@
 tap: "salesforce-marketing-cloud"
 # version: "1.0"
 
-name: "content_areas"
+name: "content_area"
 doc-link: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm
 singer-schema: https://github.com/singer-io/tap-exacttarget/blob/master/tap_exacttarget/endpoints/content_areas.py
 description: |

--- a/_integration-schemas/salesforce-marketing-cloud/v1/list.md
+++ b/_integration-schemas/salesforce-marketing-cloud/v1/list.md
@@ -19,10 +19,6 @@ description: |
 
 replication-method: "Key-based Incremental"
 
-api-method:
-  name: ""
-  doc-link: ""
-
 attributes:
   - name: "ID"
     type: "integer"

--- a/_integration-schemas/salesforce-marketing-cloud/v1/send.md
+++ b/_integration-schemas/salesforce-marketing-cloud/v1/send.md
@@ -11,7 +11,7 @@
 tap: "salesforce-marketing-cloud"
 # version: 
 
-name: "table_name"
+name: "send"
 doc-link: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm
 singer-schema: https://github.com/singer-io/tap-exacttarget/blob/master/tap_exacttarget/endpoints/sends.py
 description: |

--- a/_integration-schemas/salesforce-marketing-cloud/v1/subscriber.md
+++ b/_integration-schemas/salesforce-marketing-cloud/v1/subscriber.md
@@ -11,7 +11,7 @@
 tap: "salesforce-marketing-cloud"
 # version: 
 
-name: "table_name"
+name: "subscriber"
 doc-link: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/subscriber.htm
 singer-schema: https://github.com/singer-io/tap-exacttarget/blob/master/tap_exacttarget/endpoints/subscribers.py
 description: |


### PR DESCRIPTION
This PR fixes some issues with the tables for the Salesforce Marketing Cloud integration.