### PR TITLE
Connect: Add start/stop job & new attributes to `properties` object

### DIFF
--- a/_connect-files/api/documentation/api-terminology.md
+++ b/_connect-files/api/documentation/api-terminology.md
@@ -26,6 +26,10 @@ all-terms:
     definition: |
       {{ site.data.tooltips.connection-check }}
 
+  - name: "Replication job"
+    definition: |
+      {{ site.data.tooltips.replication-job }}
+
   - name: "Structure sync"
     definition: |
       {{ site.data.tooltips.structure-sync }} This is also referred to as discovery.

--- a/_connect-files/api/objects/destination-types/get-a-destination-type.md
+++ b/_connect-files/api/objects/destination-types/get-a-destination-type.md
@@ -56,7 +56,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{destination_type","snowflake" | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{destination_type","redshift" | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
 
@@ -64,8 +64,154 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
-      {{ site.data.connect.code-examples.destination-report-cards.snowflake | remove: "+*" }}
+      {
+        "type": "redshift",
+        "current_step": 1,
+        "current_step_type": "form",
+        "steps": [
+          {
+            "type": "form",
+            "properties": [
+              {
+                "name": "database",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_host",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "ipv4"
+                    },
+                    {
+                      "type": "string",
+                      "format": "ipv6"
+                    },
+                    {
+                      "type": "string",
+                      "format": "hostname"
+                    }
+                  ]
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_port",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_type",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^(ssh|none)$"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_username",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "host",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "ipv4"
+                    },
+                    {
+                      "type": "string",
+                      "format": "ipv6"
+                    },
+                    {
+                      "type": "string",
+                      "format": "hostname"
+                    }
+                  ]
+                },
+                "provided": false
+              },
+              {
+                "name": "password",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "port",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                },
+                "provided": false
+              },
+              {
+                "name": "username",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              }
+            ]
+          },
+          {
+            "type": "fully_configured",
+            "properties": []
+          }
+        ],
+        "details": {
+          "pricing_tier": "standard",
+          "pipeline_state": "released",
+          "protocol": "redshift",
+          "access": true
+        }
+      }
 ---

--- a/_connect-files/api/objects/destination-types/get-a-destination-type.md
+++ b/_connect-files/api/objects/destination-types/get-a-destination-type.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Get a destination type"
 method: "get"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{type}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{destination_type}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: |
@@ -30,7 +30,7 @@ description: |
 # -------------------------- #
 
 arguments:
-  - name: "type"
+  - name: "destination_type"
     required: true
     type: "string"
     description: |
@@ -56,7 +56,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{type","snowflake" | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{destination_type","snowflake" | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
 

--- a/_connect-files/api/objects/destination-types/list-destination-types.md
+++ b/_connect-files/api/objects/destination-types/list-destination-types.md
@@ -50,6 +50,7 @@ examples:
         {
           "type": "azure_sqldw",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -57,9 +58,9 @@ examples:
                 {
                   "name": "host",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -75,86 +76,95 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "port",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "username",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "password",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "azure_storage_account_token",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "azure_storage_sas_url",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
-                    "type": "string"
-                  }
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "provided": false
                 },
                 {
                   "name": "database",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_type",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(ssh|none)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_host",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -170,28 +180,31 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_port",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_username",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -210,6 +223,7 @@ examples:
         {
           "type": "redshift",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -217,19 +231,20 @@ examples:
                 {
                   "name": "database",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_host",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -245,46 +260,50 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_port",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_type",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(ssh|none)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_username",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "host",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -300,38 +319,42 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "password",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "port",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "username",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -350,6 +373,7 @@ examples:
         {
           "type": "postgres",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -357,19 +381,20 @@ examples:
                 {
                   "name": "database",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_host",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -385,46 +410,50 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_port",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_type",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(ssh|none)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "encryption_username",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "host",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -440,58 +469,64 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "password",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "port",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "ssl",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "boolean"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "sslrootcert",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "username",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -510,6 +545,7 @@ examples:
         {
           "type": "snowflake",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -517,19 +553,20 @@ examples:
                 {
                   "name": "database",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "host",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -545,58 +582,64 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "password",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "port",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "role",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "username",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "warehouse",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -615,6 +658,7 @@ examples:
         {
           "type": "s3",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -622,65 +666,71 @@ examples:
                 {
                   "name": "csv_delimiter",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "csv_force_quote",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(true|false)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "output_file_format",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(csv|jsonl)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "s3_bucket",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "s3_key_format_string",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "sentinel_key",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "system_provided_by_default",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^stitch-challenge-file-.*$"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -699,6 +749,7 @@ examples:
         {
           "type": "storagegrid",
           "current_step": 1,
+          "current_step_type": "form",
           "steps": [
             {
               "type": "form",
@@ -706,40 +757,43 @@ examples:
                 {
                   "name": "access_key_id",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "csv_delimiter",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "csv_force_quote",
                   "is_required": false,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(true|false)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "endpoint",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "anyOf": [
                       {
@@ -755,70 +809,77 @@ examples:
                         "format": "hostname"
                       }
                     ]
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "output_file_format",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^(csv|jsonl)$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "port",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^\\d+$"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "s3_bucket",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "s3_key_format_string",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": false,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "secret_access_key",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "user_provided",
                   "json_schema": {
                     "type": "string"
-                  }
+                  },
+                  "provided": false
                 },
                 {
                   "name": "sentinel_key",
                   "is_required": true,
-                  "provided": false,
                   "is_credential": true,
                   "system_provided": false,
+                  "property_type": "system_provided_by_default",
                   "json_schema": {
                     "type": "string",
                     "pattern": "^stitch-challenge-file-.*$"
-                  }
+                  },
+                  "provided": false
                 }
               ]
             },
@@ -828,7 +889,7 @@ examples:
             }
           ],
           "details": {
-            "pricing_tier": "default",
+            "pricing_tier": "enterprise",
             "pipeline_state": "alpha",
             "protocol": "storagegrid",
             "access": false

--- a/_connect-files/api/objects/destinations/v3/update-a-destination-v3.md
+++ b/_connect-files/api/objects/destinations/v3/update-a-destination-v3.md
@@ -8,7 +8,7 @@ version: "3"
 title: "Update a destination"
 method: "put"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{destination_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.destinations.update.short }}"
@@ -16,7 +16,7 @@ description: "{{ api.core-objects.destinations.update.description | flatify }}"
 
 
 arguments:
-  - name: "id"
+  - name: "destination_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the destination to be updated."
@@ -40,7 +40,8 @@ examples:
   - type: "Request"
     language: "json"
     code: |
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | strip_newlines }}
+      {% assign right-bracket = "}" %}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{

--- a/_connect-files/api/objects/destinations/v4/create-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/create-a-destination-v4.md
@@ -67,8 +67,8 @@ examples:
                     "properties": {
                       "host":"<HOST>",
                       "port":"5432",
-                      "username":"<USERNAME>",
-                      "database":"<DATABASE>",
+                      "username":"stitch",
+                      "database":"demni2mf59dt10",
                       "password":"<PASSWORD>",
                       "ssl":false
                       }
@@ -82,24 +82,28 @@ examples:
         code: |
           {
             "properties": {
-              "database": "<DATABASE>",
+              "database": "demni2mf59dt10",
+              "encryption_type": "none",
               "host": "<HOST>",
               "port": "5432",
-              "username": "<USERNAME>"
+              "ssl": "true",
+              "status": "1",
+              "username": "stitch"
             },
-            "updated_at": "2019-01-09T22:16:23Z",
-            "check_job_name": null,
+            "updated_at": "2019-05-24T18:04:08Z",
             "name": "Default Warehouse",
             "type": "postgres",
             "deleted_at": null,
             "system_paused_at": null,
-            "stitch_client_id": <CLIENT_ID>,
+            "stitch_client_id": 116078,
             "paused_at": null,
-            "id": <DESTINATION_ID>,
-            "created_at": "2019-01-09T22:16:23Z",
+            "id": 155582,
+            "display_name": null,
+            "created_at": "2019-05-24T18:03:50Z",
             "report_card": {
               "type": "postgres",
-              "current_step": 1,
+              "current_step": 2,
+              "current_step_type": "fully_configured",
               "steps": [
                 {
                   "type": "form",
@@ -107,19 +111,20 @@ examples:
                     {
                       "name": "database",
                       "is_required": true,
-                      "provided": true,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string"
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "encryption_host",
                       "is_required": false,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "anyOf": [
                           {
@@ -135,46 +140,50 @@ examples:
                             "format": "hostname"
                           }
                         ]
-                      }
+                      },
+                      "provided": false
                     },
                     {
                       "name": "encryption_port",
                       "is_required": false,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string",
                         "pattern": "^\\d+$"
-                      }
+                      },
+                      "provided": false
                     },
                     {
                       "name": "encryption_type",
                       "is_required": true,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string",
                         "pattern": "^(ssh|none)$"
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "encryption_username",
                       "is_required": false,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string"
-                      }
+                      },
+                      "provided": false
                     },
                     {
                       "name": "host",
                       "is_required": true,
-                      "provided": true,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "anyOf": [
                           {
@@ -190,58 +199,64 @@ examples:
                             "format": "hostname"
                           }
                         ]
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "password",
                       "is_required": true,
-                      "provided": true,
                       "is_credential": true,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string"
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "port",
                       "is_required": true,
-                      "provided": true,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string",
                         "pattern": "^\\d+$"
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "ssl",
                       "is_required": true,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "boolean"
-                      }
+                      },
+                      "provided": true
                     },
                     {
                       "name": "sslrootcert",
                       "is_required": false,
-                      "provided": false,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string"
-                      }
+                      },
+                      "provided": false
                     },
                     {
                       "name": "username",
                       "is_required": true,
-                      "provided": true,
                       "is_credential": false,
                       "system_provided": false,
+                      "property_type": "user_provided",
                       "json_schema": {
                         "type": "string"
-                      }
+                      },
+                      "provided": true
                     }
                   ]
                 },

--- a/_connect-files/api/objects/destinations/v4/create-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/create-a-destination-v4.md
@@ -66,7 +66,7 @@ examples:
                     "type":"postgres",
                     "properties": {
                       "host":"<HOST>",
-                      "port":5432,
+                      "port":"5432",
                       "username":"<USERNAME>",
                       "database":"<DATABASE>",
                       "password":"<PASSWORD>",

--- a/_connect-files/api/objects/destinations/v4/delete-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/delete-a-destination-v4.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Delete a destination"
 method: "delete"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{destination_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 
@@ -29,7 +29,7 @@ description: "{{ api.core-objects.destinations.delete.description | flatify }}"
 # -------------------------- #
 
 arguments:
-  - name: "id"
+  - name: "destination_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the destination to be deleted."
@@ -54,7 +54,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
 

--- a/_connect-files/api/objects/destinations/v4/delete-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/delete-a-destination-v4.md
@@ -54,7 +54,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","155582" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
 

--- a/_connect-files/api/objects/destinations/v4/destination-object-v4.md
+++ b/_connect-files/api/objects/destinations/v4/destination-object-v4.md
@@ -40,9 +40,9 @@ object-attributes:
     sub-type: "destination form properties"
     url: "{{ api.form-properties.destination-forms.section }}"
     description: |
-      Parameters for connecting to the destination, excluding any sensitive credentials.
+      Parameters for connecting to the destination, excluding any sensitive credentials. The parameters must adhere to the `type` of destination.
 
-      The parameters must adhere to the `type` of destination.
+      **Note**: When included in responses, this object will contain the current values for the destination's form properties. If an optional property (`is_required: false`) has not been provided, it will not be present in this object.
 
   - name: "report_card"
     type: "object"

--- a/_connect-files/api/objects/destinations/v4/list-destinations-v4.md
+++ b/_connect-files/api/objects/destinations/v4/list-destinations-v4.md
@@ -28,8 +28,9 @@ description: "{{ api.core-objects.destinations.list.description | flatify }}"
 # -------------------------- #
 
 returns: |
-  If successful, the API will return a status of `200 OK` and a [Destination object]({{ api.core-objects.destinations.object }}) with a `report_card` property.
+  If successful, the API will return a status of `200 OK` and an array of [Destination objects]({{ api.core-objects.destinations.object }}), one for each destination connected to the account.
 
+  **Note**: Stitch currently supports only one destination per account.
 
 # ------------------------------ #
 #   EXAMPLE REQUEST & RESPONSES  #
@@ -45,180 +46,195 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
       [
-        {
-          "properties": {
-            "database": "<DATABASE>",
-            "host": "<HOST>",
-            "port": "5432",
-            "username": "<USERNAME>"
-          },
-          "updated_at": "2019-01-10T16:46:50Z",
-          "name": "Default Warehouse",
-          "type": "postgres",
-          "deleted_at": null,
-          "system_paused_at": null,
-          "stitch_client_id": <CLIENT_ID>,
-          "paused_at": null,
-          "id": 120603,
-          "created_at": "2019-01-10T16:46:50Z",
-          "report_card": {
-            "type": "postgres",
-            "current_step": 1,
-            "steps": [
-              {
-                "type": "form",
-                "properties": [
+         {
+            "properties":{
+               "database":"demni2mf59dt10",
+               "encryption_type":"none",
+               "host":"<HOST>",
+               "port":"5432",
+               "ssl":"true",
+               "status":"1",
+               "username":"stitch"
+            },
+            "updated_at":"2019-05-24T18:04:08Z",
+            "name":"Default Warehouse",
+            "type":"postgres",
+            "deleted_at":null,
+            "system_paused_at":null,
+            "stitch_client_id":116078,
+            "paused_at":null,
+            "id":155582,
+            "display_name":null,
+            "created_at":"2019-05-24T18:03:50Z",
+            "report_card":{
+               "type":"postgres",
+               "current_step":2,
+               "current_step_type":"fully_configured",
+               "steps":[
                   {
-                    "name": "database",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "encryption_host",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "anyOf": [
+                     "type":"form",
+                     "properties":[
                         {
-                          "type": "string",
-                          "format": "ipv4"
+                           "name":"database",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string"
+                           },
+                           "provided":true
                         },
                         {
-                          "type": "string",
-                          "format": "ipv6"
+                           "name":"encryption_host",
+                           "is_required":false,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "anyOf":[
+                                 {
+                                    "type":"string",
+                                    "format":"ipv4"
+                                 },
+                                 {
+                                    "type":"string",
+                                    "format":"ipv6"
+                                 },
+                                 {
+                                    "type":"string",
+                                    "format":"hostname"
+                                 }
+                              ]
+                           },
+                           "provided":false
                         },
                         {
-                          "type": "string",
-                          "format": "hostname"
+                           "name":"encryption_port",
+                           "is_required":false,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string",
+                              "pattern":"^\\d+$"
+                           },
+                           "provided":false
+                        },
+                        {
+                           "name":"encryption_type",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string",
+                              "pattern":"^(ssh|none)$"
+                           },
+                           "provided":true
+                        },
+                        {
+                           "name":"encryption_username",
+                           "is_required":false,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string"
+                           },
+                           "provided":false
+                        },
+                        {
+                           "name":"host",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "anyOf":[
+                                 {
+                                    "type":"string",
+                                    "format":"ipv4"
+                                 },
+                                 {
+                                    "type":"string",
+                                    "format":"ipv6"
+                                 },
+                                 {
+                                    "type":"string",
+                                    "format":"hostname"
+                                 }
+                              ]
+                           },
+                           "provided":true
+                        },
+                        {
+                           "name":"password",
+                           "is_required":true,
+                           "is_credential":true,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string"
+                           },
+                           "provided":true
+                        },
+                        {
+                           "name":"port",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string",
+                              "pattern":"^\\d+$"
+                           },
+                           "provided":true
+                        },
+                        {
+                           "name":"ssl",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"boolean"
+                           },
+                           "provided":true
+                        },
+                        {
+                           "name":"sslrootcert",
+                           "is_required":false,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string"
+                           },
+                           "provided":false
+                        },
+                        {
+                           "name":"username",
+                           "is_required":true,
+                           "is_credential":false,
+                           "system_provided":false,
+                           "property_type":"user_provided",
+                           "json_schema":{
+                              "type":"string"
+                           },
+                           "provided":true
                         }
-                      ]
-                    }
+                     ]
                   },
                   {
-                    "name": "encryption_port",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^\\d+$"
-                    }
-                  },
-                  {
-                    "name": "encryption_type",
-                    "is_required": true,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^(ssh|none)$"
-                    }
-                  },
-                  {
-                    "name": "encryption_username",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "host",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "ipv4"
-                        },
-                        {
-                          "type": "string",
-                          "format": "ipv6"
-                        },
-                        {
-                          "type": "string",
-                          "format": "hostname"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "name": "password",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": true,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "port",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^\\d+$"
-                    }
-                  },
-                  {
-                    "name": "ssl",
-                    "is_required": true,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "boolean"
-                    }
-                  },
-                  {
-                    "name": "sslrootcert",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "name": "username",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
+                     "type":"fully_configured",
+                     "properties":[
+
+                     ]
                   }
-                ]
-              },
-              {
-                "type": "fully_configured",
-                "properties": []
-              }
-            ]
-          }
-        }
+               ]
+            }
+         }
       ]
 ---

--- a/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
@@ -68,7 +68,7 @@ examples:
                 "type":"postgres",
                 "properties": {
                   "host": "<HOST>",
-                  "port": 5432,
+                  "port": "5432",
                   "username": "<USERNAME>",
                   "database": "<DATABASE>",
                   "password": "<PASSWORD>",

--- a/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
@@ -33,11 +33,6 @@ arguments:
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the destination to be updated."
 
-  - name: "type"
-    required: true
-    type: "string"
-    description: "{{ connect.common.attributes.destination-type | flatify }}"
-
   - name: "properties"
     required: true
     type: "object"
@@ -61,200 +56,206 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","155582" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{
-                "type":"postgres",
                 "properties": {
-                  "host": "<HOST>",
-                  "port": "5432",
-                  "username": "<USERNAME>",
-                  "database": "<DATABASE>",
-                  "password": "<PASSWORD>",
-                  "ssl": false
+                  "username": "stitch_admin"
                   }
               }"
 
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
-      [
-        {
-          "properties": {
-            "database": "<DATABASE>",
-            "host": "<HOST>",
-            "port": "5432",
-            "username": "<USERNAME>"
-          },
-          "updated_at": "2019-01-10T16:46:50Z",
-          "name": "Default Warehouse",
+      {
+        "properties": {
+          "database": "demni2mf59dt10",
+          "encryption_type": "none",
+          "host": "<HOST>",
+          "port": "5432",
+          "ssl": "true",
+          "status": "1",
+          "username": "stitch_admin"
+        },
+        "updated_at": "2019-05-28T15:37:37Z",
+        "check_job_name": "116078.155582.check.859f4746-815e-11e9-bb8e-0693226a5168",
+        "name": "Default Warehouse",
+        "type": "postgres",
+        "deleted_at": null,
+        "system_paused_at": null,
+        "stitch_client_id": 116078,
+        "paused_at": null,
+        "id": 155582,
+        "display_name": null,
+        "created_at": "2019-05-24T18:03:50Z",
+        "report_card": {
           "type": "postgres",
-          "deleted_at": null,
-          "system_paused_at": null,
-          "stitch_client_id": <CLIENT_ID>,
-          "paused_at": null,
-          "id": 120603,
-          "created_at": "2019-01-10T16:46:50Z",
-          "report_card": {
-            "type": "postgres",
-            "current_step": 1,
-            "steps": [
-              {
-                "type": "form",
-                "properties": [
-                  {
-                    "name": "database",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
+          "current_step": 2,
+          "current_step_type": "fully_configured",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "database",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
                   },
-                  {
-                    "name": "encryption_host",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "ipv4"
-                        },
-                        {
-                          "type": "string",
-                          "format": "ipv6"
-                        },
-                        {
-                          "type": "string",
-                          "format": "hostname"
-                        }
-                      ]
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "encryption_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "ipv4"
+                      },
+                      {
+                        "type": "string",
+                        "format": "ipv6"
+                      },
+                      {
+                        "type": "string",
+                        "format": "hostname"
+                      }
+                    ]
                   },
-                  {
-                    "name": "encryption_port",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^\\d+$"
-                    }
+                  "provided": false
+                },
+                {
+                  "name": "encryption_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
                   },
-                  {
-                    "name": "encryption_type",
-                    "is_required": true,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^(ssh|none)$"
-                    }
+                  "provided": false
+                },
+                {
+                  "name": "encryption_type",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(ssh|none)$"
                   },
-                  {
-                    "name": "encryption_username",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "encryption_username",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
                   },
-                  {
-                    "name": "host",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "ipv4"
-                        },
-                        {
-                          "type": "string",
-                          "format": "ipv6"
-                        },
-                        {
-                          "type": "string",
-                          "format": "hostname"
-                        }
-                      ]
-                    }
+                  "provided": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "ipv4"
+                      },
+                      {
+                        "type": "string",
+                        "format": "ipv6"
+                      },
+                      {
+                        "type": "string",
+                        "format": "hostname"
+                      }
+                    ]
                   },
-                  {
-                    "name": "password",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": true,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
                   },
-                  {
-                    "name": "port",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string",
-                      "pattern": "^\\d+$"
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
                   },
-                  {
-                    "name": "ssl",
-                    "is_required": true,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "boolean"
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "ssl",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "boolean"
                   },
-                  {
-                    "name": "sslrootcert",
-                    "is_required": false,
-                    "provided": false,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
+                  "provided": true
+                },
+                {
+                  "name": "sslrootcert",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
                   },
-                  {
-                    "name": "username",
-                    "is_required": true,
-                    "provided": true,
-                    "is_credential": false,
-                    "system_provided": false,
-                    "json_schema": {
-                      "type": "string"
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "fully_configured",
-                "properties": []
-              }
-            ]
-          }
+                  "provided": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true
+                }
+              ]
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ]
         }
-      ]
+      }
 
   - type: "Errors"
 ---

--- a/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
+++ b/_connect-files/api/objects/destinations/v4/update-a-destination-v4.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Update a destination"
 method: "put"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{destination_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.destinations.update.short }}"
@@ -28,7 +28,7 @@ description: "{{ api.core-objects.destinations.update.description | flatify }}"
 # -------------------------- #
 
 arguments:
-  - name: "id"
+  - name: "destination_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the destination to be updated."
@@ -60,7 +60,8 @@ examples:
   - type: "Request"
     language: "json"
     code: |
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | strip_newlines }}
+      {% assign right-bracket = "}" %}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{destination_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{

--- a/_connect-files/api/objects/properties/properties-object.md
+++ b/_connect-files/api/objects/properties/properties-object.md
@@ -26,15 +26,9 @@ object-attributes:
     value: |
       "frequency_in_minutes"
 
-  - name: "required_to_be_fully_configured"
+  - name: "is_required"
     type: "boolean"
     description: "If `true`, the property is required for complete configuration."
-    value: |
-      true
-
-  - name: "provided"
-    type: "boolean"
-    description: "If `true`, the property has been provided."
     value: |
       true
 
@@ -46,20 +40,28 @@ object-attributes:
 
   - name: "system_provided"
     type: "boolean"
-    description: "If `true`, the system provides this property."
+    deprecated: true
+    description: |
+      **This property has been deprecated.** Use the `property_type` property instead.
     value: |
       false
 
-  - name: "tap_mutable"
-    type: "boolean"
-    description: "**This is an internal field and is for Stitch use only.**"
-    value: |
-      false
+  - name: "property_type"
+    type: "string"
+    description: |
+      Indicates the type of the property. Possible values are:
+
+      - `user_provided` - Indicates the property must be set by the user.
+      - `read_only` - Indicates the property is read-only and is not settable by the API. Generally, this is an internal field set inside of Stitch.
+      - `system_provided_by_default` - Indicates the property used to be `system_provided: true`, but can now be set by the API consumer. These are generally properties associated with OAuth for generating refresh and access tokens.
+
+         **Note**: Use caution when setting these properties, as using incorrect values can put the source into a non-functioning state.
+    value: "user_provided"
 
   - name: "json_schema"
     type: "array"
     description: |
-      **Note**: Data will only be returned for this array if `system_provided: false`.
+      **Note**: Data will only be returned for this array if `property_type: user_provided` or `property_type: system_provided_by_default`. If `property_type: read_only`, this property will be `null`.
       
       An array containing:
 
@@ -84,49 +86,60 @@ object-attributes:
           ]
           ```
 
+  - name: "provided"
+    type: "boolean"
+    description: "If `true`, the property has been provided. For properties where `property_type: user_provided`, this indicates that the user has provided the property."
+    value: |
+      true
+
+  - name: "tap_mutable"
+    type: "boolean"
+    description: "**This is an internal field and is for Stitch use only.**"
+    value: |
+      false
+
 examples:
-  - code: |
+  - type: "User-provided property"
+    code: |
+        {
+          "name": "frequency_in_minutes",
+          "is_required": false,
+          "is_credential": false,
+          "system_provided": false,
+          "property_type": "user_provided",
+          "json_schema": {
+            "type": "string",
+            "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+          },
+          "provided": false,
+          "tap_mutable": false
+        }
+
+  - type: "Read-only property"
+    code: |
       {
-        "report_card":{  
-            "type":"platform.hubspot",
-            "current_step":2,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               }
-            ]
-         }
+        "name": "image_version",
+        "is_required": true,
+        "is_credential": false,
+        "system_provided": true,
+        "property_type": "read_only",
+        "json_schema": null,
+        "provided": false,
+        "tap_mutable": false
+      }
+
+  - type: "System provided by default property"
+    code: |
+      {
+        "name": "client_id",
+        "is_required": true,
+        "is_credential": true,
+        "system_provided": true,
+        "property_type": "system_provided_by_default",
+        "json_schema": {
+          "type": "string"
+        },
+        "provided": false,
+        "tap_mutable": false
       }
 ---

--- a/_connect-files/api/objects/replication-jobs/replication-jobs-object-v4.md
+++ b/_connect-files/api/objects/replication-jobs/replication-jobs-object-v4.md
@@ -1,0 +1,54 @@
+---
+# -------------------------- #
+#        CONTENT TYPE        #
+# -------------------------- #
+
+content-type: "api-object"
+endpoint: "replication-jobs"
+order: 9
+
+
+# -------------------------- #
+#        OBJECT INFO         #
+# -------------------------- #
+
+title: "Replication Job"
+description: "{{ api.core-objects.replication-jobs.description }}"
+endpoint-url: "/sources/{source_id}/sync"
+
+
+# -------------------------- #
+#        VERSION INFO        #
+# -------------------------- #
+
+latest-version: "4"
+versions:
+  - number: "4"
+    deprecated: false
+
+
+# -------------------------- #
+#      AVAILABLE METHODS     #
+# -------------------------- #
+
+available-methods:
+  - id: "start-a-job"
+    title: "Start a replication job"
+    method: "post"
+    short: "{{ api.core-objects.replication-jobs.post.short | flatify }}"
+
+  - id: "stop-a-job"
+    title: "Stop a replication job"
+    method: "delete"
+    short: "{{ api.core-objects.replication-jobs.delete.short | flatify }}"
+
+
+# -------------------------- #
+#      OBJECT ATTRIBUTES     #
+# -------------------------- #
+
+object-attributes:
+  - name: "job_name"
+    type: "string"
+    description: "A unique identifier for the replication job."
+---

--- a/_connect-files/api/objects/replication-jobs/replication-jobs-object-v4.md
+++ b/_connect-files/api/objects/replication-jobs/replication-jobs-object-v4.md
@@ -13,7 +13,7 @@ order: 9
 # -------------------------- #
 
 title: "Replication Job"
-description: "{{ api.core-objects.replication-jobs.description }}"
+description: "{{ api.core-objects.replication-jobs.description | flatify }}"
 endpoint-url: "/sources/{source_id}/sync"
 
 

--- a/_connect-files/api/objects/replication-jobs/start-a-replication-job-v4.md
+++ b/_connect-files/api/objects/replication-jobs/start-a-replication-job-v4.md
@@ -1,0 +1,84 @@
+---
+# -------------------------- #
+#      ENDPOINT DETAILS      #
+# -------------------------- #
+
+content-type: "api-endpoint"
+endpoint: "replication-jobs"
+key: "start-a-job"
+version: "4"
+
+
+# -------------------------- #
+#       METHOD DETAILS       #
+# -------------------------- #
+
+title: "Start a replication job"
+method: "post"
+short-url: |
+  /v{{ endpoint.version }}{{ object.endpoint-url }}
+full-url: |
+  {{ api.base-url }}{{ endpoint.short-url | flatify }}
+short: "{{ api.core-objects.replication-jobs.post.description }}"
+description: |
+  {{ api.core-objects.replication-jobs.post.description }}
+
+  **Note**: Stitch allows only one replication job to run at a time. Attempting to start a job when another is in progress will return a status of `200 OK` and a single error object. See the **Responses** tab below for an example.
+
+
+# -------------------------- #
+#       METHOD ARGUMENTS     #
+# -------------------------- #
+
+arguments:
+  - name: "source_id"
+    required: true
+    type: "path parameter"
+    description: |
+      A path parameter corresponding to the [unique ID of the source]({{ api.core-objects.sources.object }}).
+    example-value: |
+      120643
+
+
+# -------------------------- #
+#           RETURNS          #
+# -------------------------- #
+
+returns: |
+  If successful, the API will return a status of <code class="api success">200 OK</code> and single [Replication Job object]({{ api.core-objects.replication-jobs.object }}).
+
+  **Note**: Stitch allows only one replication job to run at a time. Attempting to start a job when another is in progress will return a status of `200 OK` and a single error object.
+
+# ------------------------------ #
+#   EXAMPLE REQUEST & RESPONSES  #
+# ------------------------------ #
+
+examples:
+  - type: "Request"
+    language: "json"
+    code: |
+      {% assign right-bracket = "}" %}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","120643" | remove: right-bracket | strip_newlines }}
+           -H "Authorization: Bearer <ACCESS_TOKEN>" 
+           -H "Content-Type: application/json"
+
+  - type: "Responses"
+    subexamples:
+      - type: "Replication job successfully started"
+        code: |
+          {
+          "job_name": "116078.120643.sync.c12fb0a7-7e4a-11e9-abdc-0edc2c318fba"
+          }
+
+      - type: "Replication not started; another job is in progress"
+        code: |
+          {
+            "error": {
+              "type": "already_running",
+              "message": "Did not create job for client-id: <CLIENT_ID>; connection-id: <SOURCE_ID> because one already exists"
+            }
+          }
+
+  - type: "Errors"
+  # The errors live in: _data/connect/response-codes/replication-jobs.yml
+---

--- a/_connect-files/api/objects/replication-jobs/stop-a-replication-job-v4.md
+++ b/_connect-files/api/objects/replication-jobs/stop-a-replication-job-v4.md
@@ -1,0 +1,67 @@
+---
+# -------------------------- #
+#      ENDPOINT DETAILS      #
+# -------------------------- #
+
+content-type: "api-endpoint"
+endpoint: "replication-jobs"
+key: "stop-a-job"
+version: "4"
+
+
+# -------------------------- #
+#       METHOD DETAILS       #
+# -------------------------- #
+
+title: "Stop a replication job"
+method: "delete"
+short-url: |
+  /v{{ endpoint.version }}{{ object.endpoint-url }}
+full-url: |
+  {{ api.base-url }}{{ endpoint.short-url | flatify }}
+short: "{{ api.core-objects.replication-jobs.delete.description }}"
+description: "{{ api.core-objects.replication-jobs.delete.description }}"
+
+
+# -------------------------- #
+#       METHOD ARGUMENTS     #
+# -------------------------- #
+
+arguments:
+  - name: "source_id"
+    required: true
+    type: "path parameter"
+    description: |
+      A path parameter corresponding to the [unique ID of the source]({{ api.core-objects.sources.object }}).
+    example-value: |
+      120643
+
+
+# -------------------------- #
+#           RETURNS          #
+# -------------------------- #
+
+returns: |
+  If successful, the API will return a status of <code class="api success">200 OK</code> and an object with a `status` property with a value of `200`.
+
+
+# ------------------------------ #
+#   EXAMPLE REQUEST & RESPONSES  #
+# ------------------------------ #
+
+examples:
+  - type: "Request"
+    language: "json"
+    code: |
+      {% assign right-bracket = "}" %}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","120643" | remove: right-bracket | strip_newlines }}
+           -H "Authorization: Bearer <ACCESS_TOKEN>" 
+           -H "Content-Type: application/json"
+
+  - type: "Response"
+    language: "json"
+    code: |
+      {
+        "status": 200
+      }
+---

--- a/_connect-files/api/objects/report-cards/destinations/destination-report-card-object.md
+++ b/_connect-files/api/objects/report-cards/destinations/destination-report-card-object.md
@@ -37,7 +37,7 @@ object-attributes:
 
   - name: "type"
     type: "string"
-    description: "The destination connection type. Ex: `postgres` or `redshift`"
+    description: "The destination connection type. For example: `postgres` or `redshift`"
 
 
 # -------------------------- #
@@ -46,5 +46,154 @@ object-attributes:
 
 examples:
   - code: |
-      {{ site.data.connect.code-examples.destination-report-cards.snowflake | remove: "+*" }}
+      {
+        "type": "redshift",
+        "current_step": 1,
+        "current_step_type": "form",
+        "steps": [
+          {
+            "type": "form",
+            "properties": [
+              {
+                "name": "database",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_host",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "ipv4"
+                    },
+                    {
+                      "type": "string",
+                      "format": "ipv6"
+                    },
+                    {
+                      "type": "string",
+                      "format": "hostname"
+                    }
+                  ]
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_port",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_type",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^(ssh|none)$"
+                },
+                "provided": false
+              },
+              {
+                "name": "encryption_username",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "host",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "ipv4"
+                    },
+                    {
+                      "type": "string",
+                      "format": "ipv6"
+                    },
+                    {
+                      "type": "string",
+                      "format": "hostname"
+                    }
+                  ]
+                },
+                "provided": false
+              },
+              {
+                "name": "password",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              },
+              {
+                "name": "port",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                },
+                "provided": false
+              },
+              {
+                "name": "username",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false
+              }
+            ]
+          },
+          {
+            "type": "fully_configured",
+            "properties": []
+          }
+        ],
+        "details": {
+          "pricing_tier": "standard",
+          "pipeline_state": "released",
+          "protocol": "redshift",
+          "access": true
+        }
+      }
 ---

--- a/_connect-files/api/objects/report-cards/sources/source-report-card-object.md
+++ b/_connect-files/api/objects/report-cards/sources/source-report-card-object.md
@@ -38,193 +38,322 @@ examples:
       {
         "type": "platform.mysql",
         "current_step": 1,
+        "current_step_type": "form",
         "steps": [
           {
             "type": "form",
             "properties": [
               {
-                "name": "image_version",
-                "is_required": true,
-                "provided": false,
-                "is_credential": false,
-                "system_provided": true,
-                "tap_mutable": false,
-                "json_schema": null
-              },
-              {
-                "name": "frequency_in_minutes",
-                "is_required": true,
-                "provided": false,
+                "name": "allow_non_auto_increment_pks",
+                "is_required": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
-                  "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
-                }
+                  "pattern": "^(true|false)$"
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "anchor_time",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "format": "date-time"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "check_hostname",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^(true|false)"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "cron_expression",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "database",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "filter_dbs",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "frequency_in_minutes",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "host",
                 "is_required": true,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
-                  "format": "uri"
-                }
+                  "anyOf": [
+                    {
+                      "format": "hostname"
+                    },
+                    {
+                      "format": "ipv4"
+                    }
+                  ]
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "image_version",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": true,
+                "property_type": "read_only",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "password",
                 "is_required": true,
-                "provided": false,
                 "is_credential": true,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "port",
                 "is_required": true,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^\\d+"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "server_id",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^\\d+$"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "ssh",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^(true|false)"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "ssh_host",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
-                  "format": "uri"
-                }
+                  "anyOf": [
+                    {
+                      "format": "hostname"
+                    },
+                    {
+                      "format": "ipv4"
+                    }
+                  ]
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "ssh_port",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^\\d+"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "ssh_user",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "ssl",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^(true|false)"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "ssl_ca",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "ssl_cert",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "ssl_client_auth_enabled",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^(true|false)"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "ssl_key",
+                "is_required": false,
+                "is_credential": true,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "user",
                 "is_required": true,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
               },
               {
                 "name": "use_log_based_replication",
                 "is_required": false,
-                "provided": false,
                 "is_credential": false,
                 "system_provided": false,
-                "tap_mutable": false,
+                "property_type": "user_provided",
                 "json_schema": {
                   "type": "string",
                   "pattern": "^(true|false)$"
-                }
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "verify_mode",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^(true|false)"
+                },
+                "provided": false,
+                "tap_mutable": false
               }
             ]
           },
@@ -240,117 +369,161 @@ examples:
             "type": "fully_configured",
             "properties": []
           }
-        ]
+        ],
+        "details": {
+          "pricing_tier": "standard",
+          "pipeline_state": "released",
+          "default_scheduling_interval": 30,
+          "protocol": "platform.mysql",
+          "access": true
+        }
       }
 
 
   - type: "SaaS source"
     code: |
       {
-         "report_card":{
-            "type":"platform.hubspot",
-            "current_step":2,
-            "steps":[
-               {
-                  "type":"form",
-                  "properties":[
-                     {
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {
-                  "type":"oauth",
-                  "properties":[
-                     {
-                        "name":"client_id",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"client_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"redirect_uri",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     }
-                  ]
-               },
-               {
-                  "type":"discover_schema",
-                  "properties":[
-
-                  ]
-               },
-               {
-                  "type":"field_selection",
-                  "properties":[
-
-                  ]
-               },
-               {
-                  "type":"fully_configured",
-                  "properties":[
-
-                  ]
-               }
+        "type": "platform.hubspot",
+        "current_step": 1,
+        "current_step_type": "form",
+        "steps": [
+          {
+            "type": "form",
+            "properties": [
+              {
+                "name": "anchor_time",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "cron_expression",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "frequency_in_minutes",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "image_version",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": true,
+                "property_type": "read_only",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "start_date",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                },
+                "provided": false,
+                "tap_mutable": false
+              }
             ]
-         }
+          },
+          {
+            "type": "oauth",
+            "properties": [
+              {
+                "name": "client_id",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "client_secret",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "redirect_uri",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "refresh_token",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              }
+            ]
+          },
+          {
+            "type": "discover_schema",
+            "properties": []
+          },
+          {
+            "type": "field_selection",
+            "properties": []
+          },
+          {
+            "type": "fully_configured",
+            "properties": []
+          }
+        ],
+        "details": {
+          "pricing_tier": "premium",
+          "pipeline_state": "released",
+          "default_scheduling_interval": 30,
+          "protocol": "platform.hubspot",
+          "access": true
+        }
       }
 ---

--- a/_connect-files/api/objects/source-types/get-a-source-type.md
+++ b/_connect-files/api/objects/source-types/get-a-source-type.md
@@ -59,106 +59,148 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
-      {  
-         "type":"platform.hubspot",
-         "current_step":1,
-         "steps":[  
-            {  
-               "type":"form",
-               "properties":[  
-                  {  
-                     "name":"image_version",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":false,
-                     "system_provided":true,
-                     "json_schema":null
-                  },
-                  {  
-                     "name":"frequency_in_minutes",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":false,
-                     "system_provided":false,
-                     "json_schema":{  
-                        "type":"string",
-                        "pattern":"^\\d+$"
-                     }
-                  },
-                  {  
-                     "name":"start_date",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":false,
-                     "system_provided":false,
-                     "json_schema":{  
-                        "type":"string",
-                        "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                     }
-                  }
-               ]
-            },
-            {  
-               "type":"oauth",
-               "properties":[  
-                  {  
-                     "name":"client_id",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":true,
-                     "system_provided":true,
-                     "json_schema":{  
-                        "type":"string"
-                     }
-                  },
-                  {  
-                     "name":"client_secret",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":true,
-                     "system_provided":true,
-                     "json_schema":{  
-                        "type":"string"
-                     }
-                  },
-                  {  
-                     "name":"redirect_uri",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":true,
-                     "system_provided":true,
-                     "json_schema":{  
-                        "type":"string",
-                        "format":"uri"
-                     }
-                  },
-                  {  
-                     "name":"refresh_token",
-                     "is_required":true,
-                     "provided":false,
-                     "is_credential":true,
-                     "system_provided":true,
-                     "json_schema":{  
-                        "type":"string"
-                     }
-                  }
-               ]
-            },
-            {  
-               "type":"discover_schema",
-               "properties":[  ]
-            },
-            {  
-               "type":"field_selection",
-               "properties":[  ]
-            },
-            {  
-               "type":"fully_configured",
-               "properties":[  ]
-            }
-         ]
+      {
+        "type": "platform.hubspot",
+        "current_step": 1,
+        "current_step_type": "form",
+        "steps": [
+          {
+            "type": "form",
+            "properties": [
+              {
+                "name": "anchor_time",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "cron_expression",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "frequency_in_minutes",
+                "is_required": false,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "image_version",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": true,
+                "property_type": "read_only",
+                "json_schema": null,
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "start_date",
+                "is_required": true,
+                "is_credential": false,
+                "system_provided": false,
+                "property_type": "user_provided",
+                "json_schema": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                },
+                "provided": false,
+                "tap_mutable": false
+              }
+            ]
+          },
+          {
+            "type": "oauth",
+            "properties": [
+              {
+                "name": "client_id",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "client_secret",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "redirect_uri",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "provided": false,
+                "tap_mutable": false
+              },
+              {
+                "name": "refresh_token",
+                "is_required": true,
+                "is_credential": true,
+                "system_provided": true,
+                "property_type": "system_provided_by_default",
+                "json_schema": {
+                  "type": "string"
+                },
+                "provided": false,
+                "tap_mutable": false
+              }
+            ]
+          },
+          {
+            "type": "discover_schema",
+            "properties": []
+          },
+          {
+            "type": "field_selection",
+            "properties": []
+          },
+          {
+            "type": "fully_configured",
+            "properties": []
+          }
+        ],
+        "details": {
+          "pricing_tier": "premium",
+          "pipeline_state": "released",
+          "default_scheduling_interval": 30,
+          "protocol": "platform.hubspot",
+          "access": true
+        }
       }
 ---

--- a/_connect-files/api/objects/source-types/get-a-source-type.md
+++ b/_connect-files/api/objects/source-types/get-a-source-type.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Get a source type"
 method: "get"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{type}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{source_type}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.source-types.get.short }}"
@@ -28,7 +28,7 @@ description: "{{ api.core-objects.source-types.get.description | flatify }}"
 # -------------------------- #
 
 arguments:
-  - name: "type"
+  - name: "source_type"
     required: true
     type: "string"
     description: |
@@ -52,7 +52,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{type","platform.hubspot" | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | remove: right-bracket | replace:"{source_type","platform.hubspot" | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
 

--- a/_connect-files/api/objects/source-types/list-source-types.md
+++ b/_connect-files/api/objects/source-types/list-source-types.md
@@ -46,601 +46,7948 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-
-      [  
-         {  
-            "type":"platform.hubspot",                                /* HubSpot source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"oauth",
-                  "properties":[  
-                     {  
-                        "name":"client_id",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"client_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"redirect_uri",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {  
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"field_selection",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         },
-         {  
-            "type":"platform.marketo",                                /* Marketo source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"client_id",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"client_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"endpoint",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {  
-                        "name":"identity",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {  
-                        "name":"max_daily_calls",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         },
-         {  
-            "type":"platform.zuora",                                  /* Zuora source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"european",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {  
-                        "name":"password",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"sandbox",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     },
-                     {  
-                        "name":"username",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"field_selection",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         },
-         {  
-            "type":"platform.salesforce",                             /* Salesforce source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"api_type",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^(REST|BULK)$"
-                        }
-                     },
-                     {  
-                        "name":"is_sandbox",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {  
-                        "name":"quota_percent_per_run",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"quota_percent_total",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"select_fields_by_default",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"oauth",
-                  "properties":[  
-                     {  
-                        "name":"client_id",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"client_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"instance_url",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {  
-                        "name":"orgid",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"field_selection",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         },
-         {  
-            "type":"platform.yotpo",                                  /* Yotpo source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"api_key",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"api_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"field_selection",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         },
-         {  
-            "type":"platform.sendgrid",                               /* SendGrid source */
-            "current_step":1,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"api_key",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"field_selection",
-                  "properties":[  ]
-               },
-               {  
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         }
+      [
+        {
+          "type": "platform.closeio",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.closeio",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.hubspot",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "redirect_uri",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.hubspot",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.marketo",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "endpoint",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "identity",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "max_daily_calls",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "deprecated",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.marketo",
+            "access": false
+          }
+        },
+        {
+          "type": "platform.facebook",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "aggregate_level",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "attribution_window",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "include_deleted",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "insights_buffer_days",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "access_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "account_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.facebook",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.adwords",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "customer_ids",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "developer_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 1440,
+            "protocol": "platform.adwords",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.zuora",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_type",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(AQUA|REST)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "european",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "partner_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "sandbox",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.zuora",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.mysql",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "allow_non_auto_increment_pks",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "check_hostname",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "database",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "filter_dbs",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "server_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_ca",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_cert",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_client_auth_enabled",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_key",
+                  "is_required": false,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "use_log_based_replication",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "verify_mode",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.mysql",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.fullstory",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.fullstory",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.aurora",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "allow_non_auto_increment_pks",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "database",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "server_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "use_log_based_replication",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.mysql",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.mariadb",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "allow_non_auto_increment_pks",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "database",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "server_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "use_log_based_replication",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.mysql",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.cloudsql",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "allow_non_auto_increment_pks",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "check_hostname",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "database",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "internal_hostname",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "server_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_ca",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_cert",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_client_auth_enabled",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl_key",
+                  "is_required": false,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "use_log_based_replication",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "verify_mode",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.mysql",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.xero",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "consumer_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "consumer_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_s3_bucket",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_s3_path",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_session_handle",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_token_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "organization_name",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "rsa_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user_agent",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.xero",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.jira",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "base_url",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.jira",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.salesforce",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_type",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(REST|BULK)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "is_sandbox",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "quota_percent_per_run",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "quota_percent_total",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "select_fields_by_default",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "instance_url",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "orgid",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.salesforce",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.pipedrive",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.pipedrive",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.marketobulk",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "endpoint",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "max_daily_calls",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "max_export_days",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 720,
+            "protocol": "platform.marketo",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.listrak",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.listrak",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.bing-ads",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "account_ids",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "customer_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "developer_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user_id",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 1440,
+            "protocol": "platform.bing-ads",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.yotpo",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.yotpo",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.sendgrid",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.sendgrid",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.quickbase",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "qb_appid",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "qb_url",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "qb_user_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.quickbase",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.oracle",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "default_replication_method",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(LOG_BASED|FULL_TABLE)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "filter_schemas",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "sid",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "enterprise",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.oracle",
+            "access": false
+          }
+        },
+        {
+          "type": "platform.bronto",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.bronto",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.postgres",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "dbname",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "debug_lsn",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "default_replication_method",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "filter_dbs",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "include_schemas_in_destination_stream_name",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "itersize",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "logical_poll_total_seconds",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "use_log_based_replication",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.postgres",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.github",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "access_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "repository",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.github",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.zendesk",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "subdomain",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "access_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.zendesk",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.s3-csv",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "account_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "bucket",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "external_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "role_name",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "search_prefix",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "tables",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.s3-csv",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.doubleclick-campaign-manager",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "profile_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.doubleclick-campaign-manager",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.amplitude",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "account",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "database",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "warehouse",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.amplitude",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.uservoice",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "subdomain",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.uservoice",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.heroku_pg",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "dbname",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "default_replication_method",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "filter_dbs",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "include_schemas_in_destination_stream_name",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "itersize",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.postgres",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.cloudsql_pg",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "dbname",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "default_replication_method",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "filter_dbs",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "include_schemas_in_destination_stream_name",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "itersize",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "password",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_host",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "anyOf": [
+                      {
+                        "format": "hostname"
+                      },
+                      {
+                        "format": "ipv4"
+                      }
+                    ]
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d+"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssh_user",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "ssl",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.postgres",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.harvest-forecast",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "account_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.harvest-forecast",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.campaign-monitor",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "access_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.campaign-monitor",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.platformpurple",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "environment",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.platformpurple",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.clubspeed",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "private_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "subdomain",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.clubspeed",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.shopify",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "date_window_size",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "shop",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.shopify",
+            "access": true
+          }
+        },
+        {
+          "type": "import_api",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "import_api",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.responsys",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "host",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "path",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "port",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.responsys",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.stripe",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "date_window_size",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "whitelist_map",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "account_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 30,
+            "protocol": "platform.stripe",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.heap",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "account_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "bucket",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "external_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "role_name",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.heap",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.frontapp",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "incremental_range",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.frontapp",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.revinate",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "username",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.revinate",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.typeform",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "forms",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "incremental_range",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.typeform",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.toggl",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "detailed_report_trailing_days",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.toggl",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.eloqua",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "bulk_page_size",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "redirect_uri",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": true
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "beta",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.eloqua",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.shiphero",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "beta",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.shiphero",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.netsuite",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "account",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "consumer_key",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "consumer_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "page_size",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "token_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "premium",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.netsuite",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.bigcommerce",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "access_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "store_hash",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.bigcommerce",
+            "access": true
+          }
+        {
+          "type": "platform.onfleet",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "quota_limit",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "integer"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "beta",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.onfleet",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.invoiced",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "sandbox",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^(true|false)"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "released",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.invoiced",
+            "access": true
+          }
+        },
+        {
+          "type": "platform.chargebee",
+          "current_step": 1,
+          "current_step_type": "form",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "api_key",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "site",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": false,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ],
+          "details": {
+            "pricing_tier": "standard",
+            "pipeline_state": "beta",
+            "default_scheduling_interval": 60,
+            "protocol": "platform.chargebee",
+            "access": true
+          }
+        }
       ]
 ---

--- a/_connect-files/api/objects/sources/create-a-source.md
+++ b/_connect-files/api/objects/sources/create-a-source.md
@@ -71,8 +71,8 @@ examples:
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{
-                   "type":"platform.hubspot",
-                   "display_name":"HubSpot",
+                   "type":"platform.shopify",
+                   "display_name":"Shopify",
                    "properties":{
                       "start_date":"2017-01-01T00:00:00Z",
                       "frequency_in_minutes":"30"
@@ -81,62 +81,117 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-
       {
          "properties":{
+            "anchor_time":"2019-01-30T18:16:37.205Z",
+            "cron_expression":null,
             "frequency_in_minutes":"30",
             "image_version":"1.latest",
+            "product":"pipeline",
+            "shop":"stitchdatawearhouse",
             "start_date":"2017-01-01T00:00:00Z"
          },
-         "updated_at":"2018-02-06T16:25:06Z",
-         "check_job_name":null,
-         "name":"hubspot",
-         "type":"platform.hubspot",
+         "updated_at":"2019-05-28T13:52:23Z",
+         "schedule":null,
+         "name":"shopify",
+         "type":"platform.shopify",
          "deleted_at":null,
          "system_paused_at":null,
-         "stitch_client_id":<ACCOUNT_ID>,
+         "stitch_client_id":116078,
          "paused_at":null,
-         "id":<SOURCE_ID>,
-         "display_name":"HubSpot",
-         "created_at":"2018-02-06T16:25:06Z",
+         "id":86741,
+         "display_name":"Shopify",
+         "created_at":"2019-01-10T19:38:18Z",
          "report_card":{
-            "type":"platform.hubspot",
-            "current_step":2,
+            "type":"platform.shopify",
+            "current_step":1,
+            "current_step_type":"fully_configured",
             "steps":[
                {
                   "type":"form",
                   "properties":[
                      {
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
+                        "name":"anchor_time",
+                        "is_required":false,
                         "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string",
+                           "format":"date-time"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"cron_expression",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":null,
+                        "provided":false,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"date_window_size",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"integer"
+                        },
+                        "provided":false,
+                        "tap_mutable":false
                      },
                      {
                         "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":true,
+                        "is_required":false,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
                            "type":"string",
-                           "pattern":"^\\d+$"
-                        }
+                           "pattern":"^1$|^30$|^60$|^360$|^720$|^1440$"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"image_version",
+                        "is_required":true,
+                        "is_credential":false,
+                        "system_provided":true,
+                        "property_type":"read_only",
+                        "json_schema":null,
+                        "provided":true,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"shop",
+                        "is_required":true,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      },
                      {
                         "name":"start_date",
                         "is_required":true,
-                        "provided":true,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
                            "type":"string",
                            "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      }
                   ]
                },
@@ -144,59 +199,36 @@ examples:
                   "type":"oauth",
                   "properties":[
                      {
-                        "name":"client_id",
+                        "name":"api_key",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":true,
                         "system_provided":true,
+                        "property_type":"system_provided_by_default",
                         "json_schema":{
                            "type":"string"
-                        }
-                     },
-                     {
-                        "name":"client_secret",
-                        "is_required":true,
+                        },
                         "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"redirect_uri",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{
-                           "type":"string"
-                        }
+                        "tap_mutable":false
                      }
                   ]
                },
                {
                   "type":"discover_schema",
-                  "properties":[ ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"field_selection",
-                  "properties":[ ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"fully_configured",
-                  "properties":[ ]
+                  "properties":[
+
+                  ]
                }
             ]
          }

--- a/_connect-files/api/objects/sources/delete-a-source.md
+++ b/_connect-files/api/objects/sources/delete-a-source.md
@@ -57,122 +57,121 @@ examples:
       curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
-           -d "{}"
 
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-
       {
          "properties":{
-            "frequency_in_minutes":"60",
+            "anchor_time":"2019-01-30T18:16:37.205Z",
+            "cron_expression":null,
+            "frequency_in_minutes":"30",
             "image_version":"1.latest",
+            "product":"pipeline",
+            "shop":"stitchdatawearhouse",
             "start_date":"2017-01-01T00:00:00Z"
          },
-         "updated_at":"2018-02-06T17:37:14Z",
-         "check_job_name":null,
-         "name":"salesforce",
-         "type":"platform.salesforce",
-         "deleted_at":"2019-01-09T17:28:57Z",
+         "updated_at":"2019-05-28T13:52:23Z",
+         "schedule":null,
+         "name":"shopify",
+         "type":"platform.shopify",
+         "deleted_at":"2019-05-28T13:52:23Z",
          "system_paused_at":null,
-         "stitch_client_id":<ACCOUNT_ID>,
+         "stitch_client_id":116078,
          "paused_at":null,
-         "id":<SOURCE_ID>,
-         "display_name":"Salesforce",
-         "created_at":"2018-02-06T17:36:02Z",
+         "id":86741,
+         "display_name":"Shopify",
+         "created_at":"2019-01-10T19:38:18Z",
          "report_card":{
-            "type":"platform.salesforce",
+            "type":"platform.shopify",
             "current_step":1,
+            "current_step_type":"fully_configured",
             "steps":[
                {
                   "type":"form",
                   "properties":[
                      {
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
+                        "name":"anchor_time",
+                        "is_required":false,
                         "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string",
+                           "format":"date-time"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"cron_expression",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":null,
+                        "provided":false,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"date_window_size",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"integer"
+                        },
+                        "provided":false,
+                        "tap_mutable":false
                      },
                      {
                         "name":"frequency_in_minutes",
-                        "is_required":true,
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string",
+                           "pattern":"^1$|^30$|^60$|^360$|^720$|^1440$"
+                        },
                         "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
+                        "tap_mutable":false
                      },
                      {
-                        "name":"api_type",
+                        "name":"image_version",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^(REST|BULK)$"
-                        }
+                        "system_provided":true,
+                        "property_type":"read_only",
+                        "json_schema":null,
+                        "provided":true,
+                        "tap_mutable":false
                      },
                      {
-                        "name":"is_sandbox",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {
-                        "name":"quota_percent_per_run",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {
-                        "name":"quota_percent_total",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {
-                        "name":"select_fields_by_default",
+                        "name":"shop",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
+                           "type":"string"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      },
                      {
                         "name":"start_date",
                         "is_required":true,
-                        "provided":true,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
                            "type":"string",
                            "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      }
                   ]
                },
@@ -180,72 +179,40 @@ examples:
                   "type":"oauth",
                   "properties":[
                      {
-                        "name":"client_id",
+                        "name":"api_key",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":true,
-                        "system_provided":false,
+                        "system_provided":true,
+                        "property_type":"system_provided_by_default",
                         "json_schema":{
                            "type":"string"
-                        }
-                     },
-                     {
-                        "name":"client_secret",
-                        "is_required":true,
+                        },
                         "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"instance_url",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {
-                        "name":"orgid",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
+                        "tap_mutable":false
                      }
                   ]
                },
                {
                   "type":"discover_schema",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"field_selection",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"fully_configured",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                }
             ]
          }
       }
+
   - type: "Errors"
 ---

--- a/_connect-files/api/objects/sources/delete-a-source.md
+++ b/_connect-files/api/objects/sources/delete-a-source.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Delete a source"
 method: "delete"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{source_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 
@@ -29,7 +29,7 @@ description: "{{ api.core-objects.sources.delete.description }}"
 # -------------------------- #
 
 arguments:
-  - name: "id"
+  - name: "source_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the source to be deleted."
@@ -54,7 +54,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{}"

--- a/_connect-files/api/objects/sources/list-sources.md
+++ b/_connect-files/api/objects/sources/list-sources.md
@@ -20,7 +20,10 @@ short-url: |
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.sources.list.description }}"
-description: "{{ api.core-objects.sources.list.description }}"
+description: |
+  {{ api.core-objects.sources.list.description }}
+
+  **Note**: This endpoint retrieves specific configuration information about the sources connected to a single account. To retrieve general configuration information about all supported data source types, use the [List all source types]({{ api.source-types.list.anchor }}) endpoint.
 
 
 # -------------------------- #
@@ -28,9 +31,9 @@ description: "{{ api.core-objects.sources.list.description }}"
 # -------------------------- #
 
 returns: |
-  If successful, the API will return a status of <code class="api success">200 OK</code> and an array of [Source Objects]({{ api.core-objects.sources.object }}), including paused and deleted sources.
+  If successful, the API will return a status of <code class="api success">200 OK</code> and an array of [Source Objects]({{ api.core-objects.sources.object }}), one for each source connected to the account.
 
-
+  
 # ------------------------------ #
 #   EXAMPLE REQUEST & RESPONSES  #
 # ------------------------------ #
@@ -42,185 +45,693 @@ examples:
       curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
+
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
       [
-         {
-            "properties":{
-               "frequency_in_minutes":"30",
-               "image_version":"1.latest",
-               "start_date":"2017-01-01T00:00:00Z"
-            },
-            "updated_at":"2018-02-06T18:04:59Z",
-            "name":"hubspot_api_test",
-            "type":"platform.hubspot",
-            "deleted_at":"2018-02-06T18:04:58Z",
-            "system_paused_at":null,
-            "stitch_client_id":<ACCOUNT_ID>,
-            "paused_at":null,
-            "id":<SOURCE_ID>,
-            "display_name":"HubSpot",
-            "created_at":"2018-02-06T16:25:06Z",
-            "report_card":{
-               "type":"platform.hubspot",
-               "current_step":2,
-               "steps":[
+        {
+          "properties": {
+            "anchor_time": "2019-01-07T23:23:08.116Z",
+            "cron_expression": null,
+            "customer_ids": "1585293495,4224806558,6668731595",
+            "frequency_in_minutes": "30",
+            "image_version": "1.latest",
+            "product": "pipeline",
+            "start_date": "2018-01-01T00:00:00Z",
+            "user_id": "100551921296891141132"
+          },
+          "updated_at": "2019-04-12T19:03:13Z",
+          "schedule": null,
+          "name": "adwords",
+          "type": "platform.adwords",
+          "deleted_at": "2019-01-09T17:28:57Z",
+          "system_paused_at": null,
+          "stitch_client_id": 116078,
+          "paused_at": null,
+          "id": 119945,
+          "display_name": "AdWords2",
+          "created_at": "2019-01-07T23:20:22Z",
+          "report_card": {
+            "type": "platform.adwords",
+            "current_step": 5,
+            "current_step_type": "fully_configured",
+            "steps": [
+              {
+                "type": "form",
+                "properties": [
                   {
-                     "type":"form",
-                     "properties":[ ... ]
+                    "name": "anchor_time",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"oauth",
-                     "properties":[ ... ]
+                    "name": "cron_expression",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": null,
+                    "provided": false,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"discover_schema",
-                     "properties":[  ]
+                    "name": "frequency_in_minutes",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"field_selection",
-                     "properties":[  ]
+                    "name": "image_version",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"fully_configured",
-                     "properties":[  ]
+                    "name": "start_date",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   }
-               ]
-            }
-         },
-         {  
-            "properties":{
-               "frequency_in_minutes":"30",
-               "image_version":"1.latest",
-               "start_date":"2017-01-01T00:00:00Z"
-            },
-            "updated_at":"2018-02-06T18:12:41Z",
-            "name":"hubspot",
-            "type":"platform.hubspot",
-            "deleted_at":null,
-            "system_paused_at":null,
-            "stitch_client_id":<ACCOUNT_ID>,
-            "paused_at":null,
-            "id":<SOURCE_ID>,
-            "display_name":"HubSpot",
-            "created_at":"2018-02-06T18:12:41Z",
-            "report_card":{
-               "type":"platform.hubspot",
-               "current_step":2,
-               "steps":[  
+                ]
+              },
+              {
+                "type": "oauth",
+                "properties": [
                   {
-                     "type":"form",
-                     "properties":[ ... ]
+                    "name": "customer_ids",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"oauth",
-                     "properties":[ ... ]
+                    "name": "developer_token",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"discover_schema",
-                     "properties":[  ]
+                    "name": "oauth_client_id",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"field_selection",
-                     "properties":[  ]
+                    "name": "oauth_client_secret",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"fully_configured",
-                     "properties":[  ]
+                    "name": "refresh_token",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "user_id",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   }
-               ]
-            }
-         },
-         {  
-            "properties":{
-               "frequency_in_minutes":"30",
-               "image_version":"1.latest",
-               "start_date":"2017-01-01T00:00:00Z"
-            },
-            "updated_at":"2018-02-06T18:10:44Z",
-            "name":"salesforce_api_test",
-            "type":"platform.salesforce",
-            "deleted_at":"2018-02-06T18:05:06Z",
-            "system_paused_at":null,
-            "stitch_client_id":<ACCOUNT_ID>,
-            "paused_at":null,
-            "id":<SOURCE_ID>,
-            "display_name":"Salesforce",
-            "created_at":"2018-02-06T17:36:02Z",
-            "report_card":{
-               "type":"platform.salesforce",
-               "current_step":1,
-               "steps":[
-                  {  
-                     "type":"form",
-                     "properties":[ ... ]
+                ]
+              },
+              {
+                "type": "discover_schema",
+                "properties": []
+              },
+              {
+                "type": "field_selection",
+                "properties": []
+              },
+              {
+                "type": "fully_configured",
+                "properties": []
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "anchor_time": "2019-01-09T19:30:00.000Z",
+            "user_agent": "Stitch-c7ad6999-c6d8-4504-9ae6-b153717fdd3e",
+            "oauth_s3_path": "116078-120407-xero",
+            "organization_name": "Stitch Xero",
+            "frequency_in_minutes": "60",
+            "product": "pipeline",
+            "oauth_s3_bucket": "com-stitchdata-prod-platform-oauth-creds",
+            "start_date": "2018-01-09T19:15:49Z",
+            "cron_expression": null,
+            "image_version": "1.latest"
+          },
+          "updated_at": "2019-05-24T16:21:57Z",
+          "schedule": null,
+          "name": "xero",
+          "type": "platform.xero",
+          "deleted_at": null,
+          "system_paused_at": null,
+          "stitch_client_id": 116078,
+          "paused_at": "2019-01-22T18:04:48Z",
+          "id": 120407,
+          "display_name": "Xero",
+          "created_at": "2019-01-09T19:16:03Z",
+          "report_card": {
+            "type": "platform.xero",
+            "current_step": 4,
+            "current_step_type": "field_selection",
+            "steps": [
+              {
+                "type": "form",
+                "properties": [
+                  {
+                    "name": "anchor_time",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
-                  {  
-                     "type":"oauth",
-                     "properties":[ ... ]
+                  {
+                    "name": "cron_expression",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": null,
+                    "provided": false,
+                    "tap_mutable": false
                   },
-                  {  
-                     "type":"discover_schema",
-                     "properties":[  ]
+                  {
+                    "name": "frequency_in_minutes",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   },
-                  {  
-                     "type":"field_selection",
-                     "properties":[  ]
+                  {
+                    "name": "image_version",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
-                  {  
-                     "type":"fully_configured",
-                     "properties":[  ]
+                  {
+                    "name": "start_date",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   }
-               ]
-            }
-         },
-         {  
-            "properties":{
-               "frequency_in_minutes":"30",
-               "image_version":"1.latest",
-               "start_date":"2017-01-01T00:00:00Z"
-            },
-            "updated_at":"2018-02-06T18:05:30Z",
-            "name":"salesforce_api_test",
-            "type":"platform.salesforce",
-            "deleted_at":null,
-            "system_paused_at":null,
-            "stitch_client_id":<ACCOUNT_ID>,
-            "paused_at":null,
-            "id":<SOURCE_ID>,
-            "display_name":"Salesforce",
-            "created_at":"2018-02-06T18:05:30Z",
-            "report_card":{
-               "type":"platform.salesforce",
-               "current_step":1,
-               "steps":[
+                ]
+              },
+              {
+                "type": "oauth",
+                "properties": [
                   {
-                     "type":"form",
-                     "properties":[ ... ]
+                    "name": "consumer_key",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"oauth",
-                     "properties":[ ... ]
+                    "name": "consumer_secret",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"discover_schema",
-                     "properties":[  ]
+                    "name": "oauth_s3_bucket",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"field_selection",
-                     "properties":[  ]
+                    "name": "oauth_s3_path",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
                   },
                   {
-                     "type":"fully_configured",
-                     "properties":[  ]
+                    "name": "oauth_session_handle",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "oauth_token",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "oauth_token_secret",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "organization_name",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "rsa_key",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": true,
+                    "property_type": "system_provided_by_default",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "user_agent",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
                   }
-               ]
-            }
-         }
-      ]
-
+                ]
+              },
+              {
+                "type": "discover_schema",
+                "properties": []
+              },
+              {
+                "type": "field_selection",
+                "properties": []
+              },
+              {
+                "type": "fully_configured",
+                "properties": []
+              }
+            ]
+          }
+        },
+        {
+          "properties": {
+            "ssl": "true",
+            "anchor_time": "2019-01-10T19:39:17.724Z",
+            "frequency_in_minutes": "60",
+            "port": "5432",
+            "dbname": "demni2mf59dt10",
+            "host": "<HOST>",
+            "product": "pipeline",
+            "cron_expression": null,
+            "image_version": "0.latest",
+            "user": "nxucqufdolmwxr"
+          },
+          "updated_at": "2019-05-24T19:54:43Z",
+          "schedule": null,
+          "name": "heroku",
+          "type": "platform.heroku_pg",
+          "deleted_at": "2019-05-24T19:54:43Z",
+          "system_paused_at": null,
+          "stitch_client_id": 116078,
+          "paused_at": null,
+          "id": 120643,
+          "display_name": "Heroku",
+          "created_at": "2019-01-10T19:36:13Z",
+          "report_card": {
+            "type": "platform.heroku_pg",
+            "current_step": 4,
+            "current_step_type": "fully_configured",
+            "steps": [
+              {
+                "type": "form",
+                "properties": [
+                  {
+                    "name": "anchor_time",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "cron_expression",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": null,
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "dbname",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "default_replication_method",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^(true|false)$"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "filter_dbs",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "frequency_in_minutes",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "host",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "anyOf": [
+                        {
+                          "format": "hostname"
+                        },
+                        {
+                          "format": "ipv4"
+                        }
+                      ]
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "image_version",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": true,
+                    "property_type": "read_only",
+                    "json_schema": null,
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "include_schemas_in_destination_stream_name",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "itersize",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^\\d+"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "password",
+                    "is_required": true,
+                    "is_credential": true,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "port",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "integer"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "ssh",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^(true|false)$"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "ssh_host",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "anyOf": [
+                        {
+                          "format": "hostname"
+                        },
+                        {
+                          "format": "ipv4"
+                        }
+                      ]
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "ssh_port",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^\\d+"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "ssh_user",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": false,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "ssl",
+                    "is_required": false,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string",
+                      "pattern": "^(true|false)$"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  },
+                  {
+                    "name": "user",
+                    "is_required": true,
+                    "is_credential": false,
+                    "system_provided": false,
+                    "property_type": "user_provided",
+                    "json_schema": {
+                      "type": "string"
+                    },
+                    "provided": true,
+                    "tap_mutable": false
+                  }
+                ]
+              },
+              {
+                "type": "discover_schema",
+                "properties": []
+              },
+              {
+                "type": "field_selection",
+                "properties": []
+              },
+              {
+                "type": "fully_configured",
+                "properties": []
+              }
+            ]
+          }
+        }
 ---

--- a/_connect-files/api/objects/sources/retrieve-a-source.md
+++ b/_connect-files/api/objects/sources/retrieve-a-source.md
@@ -16,7 +16,7 @@ version: "4"
 title: "Retrieve a source"
 method: "get"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{source_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.sources.retrieve.description }}"
@@ -28,7 +28,7 @@ description: "{{ api.core-objects.sources.retrieve.description }}"
 # -------------------------- #
 
 arguments:
-  - name: "id"
+  - name: "source_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the data source to be retrieved."
@@ -52,7 +52,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
   - type: "Response"

--- a/_connect-files/api/objects/sources/retrieve-a-source.md
+++ b/_connect-files/api/objects/sources/retrieve-a-source.md
@@ -20,7 +20,8 @@ short-url: |
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.sources.retrieve.description }}"
-description: "{{ api.core-objects.sources.retrieve.description }}"
+description: |
+  {{ api.core-objects.sources.retrieve.description }} This endpoint can be used to retrieve an active, paused, or deleted source.
 
 
 # -------------------------- #
@@ -52,131 +53,193 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","120643" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-      
-      {  
-         "properties":{  
-            "frequency_in_minutes":"30",
-            "image_version":"1.latest",
-            "start_date":"2017-01-01T00:00:00Z"
-         },
-         "updated_at":"2018-02-06T18:04:59Z",
-         "name":"hubspot",
-         "type":"platform.hubspot",
-         "deleted_at":"2018-02-06T18:04:58Z",
-         "system_paused_at":null,
-         "stitch_client_id":<ACCOUNT_ID>,
-         "paused_at":null,
-         "id":<SOURCE_ID>,
-         "display_name":"HubSpot",
-         "created_at":"2018-02-06T16:25:06Z",
-         "report_card":{  
-            "type":"platform.hubspot",
-            "current_step":2,
-            "steps":[  
-               {  
-                  "type":"form",
-                  "properties":[  
-                     {  
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
-                     },
-                     {  
-                        "name":"frequency_in_minutes",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {  
-                        "name":"start_date",
-                        "is_required":true,
-                        "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{  
-                           "type":"string",
-                           "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"oauth",
-                  "properties":[  
-                     {  
-                        "name":"client_id",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"client_secret",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     },
-                     {  
-                        "name":"redirect_uri",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {  
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":true,
-                        "json_schema":{  
-                           "type":"string"
-                        }
-                     }
-                  ]
-               },
-               {  
-                  "type":"discover_schema",
-                  "properties":[  
-
-                  ]
-               },
-               {
-                  "type":"field_selection",
-                  "properties":[ ]
-               },
-               {
-                  "type":"fully_configured",
-                  "properties":[  ]
-               }
-            ]
-         }
+      {
+        "properties": {
+          "anchor_time": "2019-01-07T23:23:08.116Z",
+          "cron_expression": null,
+          "customer_ids": "1585293495,4224806558,6668731595",
+          "frequency_in_minutes": "30",
+          "image_version": "1.latest",
+          "product": "pipeline",
+          "start_date": "2018-01-01T00:00:00Z",
+          "user_id": "100551921296891141132"
+        },
+        "updated_at": "2019-04-12T19:03:13Z",
+        "schedule": null,
+        "name": "adwords",
+        "type": "platform.adwords",
+        "deleted_at": "2019-01-09T17:28:57Z",
+        "system_paused_at": null,
+        "stitch_client_id": 116078,
+        "paused_at": null,
+        "id": 120643,
+        "display_name": "AdWords",
+        "created_at": "2019-01-07T23:20:22Z",
+        "report_card": {
+          "type": "platform.adwords",
+          "current_step": 5,
+          "current_step_type": "fully_configured",
+          "steps": [
+            {
+              "type": "form",
+              "properties": [
+                {
+                  "name": "anchor_time",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "cron_expression",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": null,
+                  "provided": false,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "frequency_in_minutes",
+                  "is_required": false,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^1$|^30$|^60$|^360$|^720$|^1440$"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "image_version",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "read_only",
+                  "json_schema": null,
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "start_date",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "oauth",
+              "properties": [
+                {
+                  "name": "customer_ids",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": false,
+                  "property_type": "user_provided",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "developer_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_id",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "oauth_client_secret",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "refresh_token",
+                  "is_required": true,
+                  "is_credential": true,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                },
+                {
+                  "name": "user_id",
+                  "is_required": true,
+                  "is_credential": false,
+                  "system_provided": true,
+                  "property_type": "system_provided_by_default",
+                  "json_schema": {
+                    "type": "string"
+                  },
+                  "provided": true,
+                  "tap_mutable": false
+                }
+              ]
+            },
+            {
+              "type": "discover_schema",
+              "properties": []
+            },
+            {
+              "type": "field_selection",
+              "properties": []
+            },
+            {
+              "type": "fully_configured",
+              "properties": []
+            }
+          ]
+        }
       }
 ---

--- a/_connect-files/api/objects/sources/sources-object.md
+++ b/_connect-files/api/objects/sources/sources-object.md
@@ -89,9 +89,12 @@ object-attributes:
 
   - name: "properties"
     type: "object"
-    sub-type: "properties"
-    url: "{{ api.data-structures.properties.section }}"
-    description: "{{ connect.common.attributes.properties | flatify }}"
+    sub-type: " source form properties"
+    url: "{{ api.form-properties.source-forms.section }}"
+    description: |
+      Parameters for connecting to the source, excluding any sensitive credentials. The parameters must adhere to the `type` of source.
+
+      **Note**: When included in responses, this object will contain the current values for the source's form properties. If an optional property (`is_required: false`) has not been provided, it will not be present in this object.
 
   - name: "report_card"
     type: "object"

--- a/_connect-files/api/objects/sources/update-a-source.md
+++ b/_connect-files/api/objects/sources/update-a-source.md
@@ -8,7 +8,7 @@ version: "4"
 title: "Update a source"
 method: "put"
 short-url: |
-  /v{{ endpoint.version }}{{ object.endpoint-url }}/{id}
+  /v{{ endpoint.version }}{{ object.endpoint-url }}/{source_id}
 full-url: |
   {{ api.base-url }}{{ endpoint.short-url | flatify }}
 short: "{{ api.core-objects.sources.update.description }}"
@@ -16,7 +16,7 @@ description: "{{ api.core-objects.sources.update.description }}"
 
 
 arguments:
-  - name: "id"
+  - name: "source_id"
     required: true
     type: "path parameter"
     description: "A path parameter corresponding to the unique ID of the source to be updated."
@@ -44,7 +44,7 @@ examples:
     language: "json"
     code: |
       {% assign right-bracket = "}" %}
-      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{id","86741" | remove: right-bracket | strip_newlines }}
+      curl -X {{ endpoint.method | upcase }} {{ endpoint.full-url | flatify | replace: "{source_id","86741" | remove: right-bracket | strip_newlines }}
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{

--- a/_connect-files/api/objects/sources/update-a-source.md
+++ b/_connect-files/api/objects/sources/update-a-source.md
@@ -48,7 +48,7 @@ examples:
            -H "Authorization: Bearer <ACCESS_TOKEN>" 
            -H "Content-Type: application/json"
            -d "{
-                   "display_name":"Salesforce",
+                   "display_name":"Shopify",
                    "properties":{
                       "frequency_in_minutes":"60"
                    }
@@ -57,117 +57,117 @@ examples:
   - type: "Response"
     language: "json"
     code: |
-      HTTP/1.1 200 OK
-      Content-Type: application/json;charset=ISO-8859-1
-
       {
          "properties":{
+            "anchor_time":"2019-01-30T18:16:37.205Z",
+            "cron_expression":null,
             "frequency_in_minutes":"60",
             "image_version":"1.latest",
+            "product":"pipeline",
+            "shop":"stitchdatawearhouse",
             "start_date":"2017-01-01T00:00:00Z"
          },
-         "updated_at":"2018-02-06T17:37:14Z",
-         "check_job_name":null,
-         "name":"salesforce",
-         "type":"platform.salesforce",
+         "updated_at":"2019-05-28T13:52:23Z",
+         "schedule":null,
+         "name":"shopify",
+         "type":"platform.shopify",
          "deleted_at":null,
          "system_paused_at":null,
-         "stitch_client_id":<ACCOUNT_ID>,
+         "stitch_client_id":116078,
          "paused_at":null,
-         "id":<SOURCE_ID>,
-         "display_name":"Salesforce",
-         "created_at":"2018-02-06T17:36:02Z",
+         "id":86741,
+         "display_name":"Shopify",
+         "created_at":"2019-01-10T19:38:18Z",
          "report_card":{
-            "type":"platform.salesforce",
+            "type":"platform.shopify",
             "current_step":1,
+            "current_step_type":"fully_configured",
             "steps":[
                {
                   "type":"form",
                   "properties":[
                      {
-                        "name":"image_version",
-                        "is_required":true,
-                        "provided":true,
+                        "name":"anchor_time",
+                        "is_required":false,
                         "is_credential":false,
-                        "system_provided":true,
-                        "json_schema":null
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string",
+                           "format":"date-time"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"cron_expression",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":null,
+                        "provided":false,
+                        "tap_mutable":false
+                     },
+                     {
+                        "name":"date_window_size",
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"integer"
+                        },
+                        "provided":false,
+                        "tap_mutable":false
                      },
                      {
                         "name":"frequency_in_minutes",
-                        "is_required":true,
+                        "is_required":false,
+                        "is_credential":false,
+                        "system_provided":false,
+                        "property_type":"user_provided",
+                        "json_schema":{
+                           "type":"string",
+                           "pattern":"^1$|^30$|^60$|^360$|^720$|^1440$"
+                        },
                         "provided":true,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
+                        "tap_mutable":false
                      },
                      {
-                        "name":"api_type",
+                        "name":"image_version",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^(REST|BULK)$"
-                        }
+                        "system_provided":true,
+                        "property_type":"read_only",
+                        "json_schema":null,
+                        "provided":true,
+                        "tap_mutable":false
                      },
                      {
-                        "name":"is_sandbox",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
-                     },
-                     {
-                        "name":"quota_percent_per_run",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {
-                        "name":"quota_percent_total",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "pattern":"^\\d+$"
-                        }
-                     },
-                     {
-                        "name":"select_fields_by_default",
+                        "name":"shop",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
-                           "type":"string",
-                           "pattern":"^(true|false)$"
-                        }
+                           "type":"string"
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      },
                      {
                         "name":"start_date",
                         "is_required":true,
-                        "provided":true,
                         "is_credential":false,
                         "system_provided":false,
+                        "property_type":"user_provided",
                         "json_schema":{
                            "type":"string",
                            "pattern":"^\\d{4}-\\d{2}-\\d{2}T00:00:00Z$"
-                        }
+                        },
+                        "provided":true,
+                        "tap_mutable":false
                      }
                   ]
                },
@@ -175,69 +175,36 @@ examples:
                   "type":"oauth",
                   "properties":[
                      {
-                        "name":"client_id",
+                        "name":"api_key",
                         "is_required":true,
-                        "provided":false,
                         "is_credential":true,
-                        "system_provided":false,
+                        "system_provided":true,
+                        "property_type":"system_provided_by_default",
                         "json_schema":{
                            "type":"string"
-                        }
-                     },
-                     {
-                        "name":"client_secret",
-                        "is_required":true,
+                        },
                         "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"instance_url",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string",
-                           "format":"uri"
-                        }
-                     },
-                     {
-                        "name":"orgid",
-                        "is_required":false,
-                        "provided":false,
-                        "is_credential":false,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
-                     },
-                     {
-                        "name":"refresh_token",
-                        "is_required":true,
-                        "provided":false,
-                        "is_credential":true,
-                        "system_provided":false,
-                        "json_schema":{
-                           "type":"string"
-                        }
+                        "tap_mutable":false
                      }
                   ]
                },
                {
                   "type":"discover_schema",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"field_selection",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                },
                {
                   "type":"fully_configured",
-                  "properties":[  ]
+                  "properties":[
+
+                  ]
                }
             ]
          }

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -303,6 +303,26 @@ core-objects:
       description: |
         {{ api.core-objects.streams.update.short }} This endpoint is used to define the `metadata` properties returned in the [Stream Schema object's]({{ api.data-structures.stream-schemas.section }}) `non-discoverable-metadata-keys` property.
 
+  replication-jobs:
+    title: "Replication Jobs"
+    section: "#replication-jobs"
+    object: "#replication-job--object"
+    base: "/v4/sources/{source_id}/sync"
+    description: "todo."
+
+    post:
+      name: "{{ site.data.connect.api.core-objects.replication-jobs.base }}"
+      title: "Start a replication job"
+      method: "post"
+      anchor: "#start-a-job"
+      description: "Starts a replication job for a source using the source's unique identifier."
+
+    delete:
+      name: "{{ site.data.connect.api.core-objects.replication-jobs.base }}"
+      title: "Stop a replication job"
+      method: "delete"
+      anchor: "#stop-a-job"
+      description: "Stops an in-progress replication job for a source using the source's unique identifier."
 
 # -------------------------- #
 #       DATA STRUCTURES      #

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -303,12 +303,17 @@ core-objects:
       description: |
         {{ api.core-objects.streams.update.short }} This endpoint is used to define the `metadata` properties returned in the [Stream Schema object's]({{ api.data-structures.stream-schemas.section }}) `non-discoverable-metadata-keys` property.
 
+# -------------------------- #
+#      REPLICATION JOBS      #
+# -------------------------- #
+
   replication-jobs:
     title: "Replication Jobs"
     section: "#replication-jobs"
     object: "#replication-job--object"
     base: "/v4/sources/{source_id}/sync"
-    description: "todo."
+    description: |
+      {{ site.data.tooltips.replication-job }}
 
     post:
       name: "{{ site.data.connect.api.core-objects.replication-jobs.base }}"

--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -91,7 +91,7 @@ core-objects:
         {{ site.data.connect.api.core-objects.destinations.create.short }} Only a single destination is supported per Stitch client account.
 
     update:
-      name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{id}"
+      name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{destination_id}"
       title: "Update a destination"
       method: &put "put"
       anchor: "#update-a-destination"
@@ -107,7 +107,7 @@ core-objects:
       description: "{{ site.data.connect.api.core-objects.destinations.list.short }} Only a single data warehouse is supported per Stitch client account."
 
     delete:
-      name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{id}"
+      name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{destination_id}"
       title: "Delete a destination"
       method: "delete"
       anchor: "#delete-a-destination"
@@ -129,7 +129,7 @@ core-objects:
     description: "The Destination Type object contains the information needed to configure a destination."
 
     get:
-      name: "{{ site.data.connect.api.core-objects.destination-types.base }}/{type}"
+      name: "{{ site.data.connect.api.core-objects.destination-types.base }}/{destination_type}"
       title: "Get a destination type"
       method: *get
       anchor: "#get-a-destination-type"
@@ -215,7 +215,7 @@ core-objects:
     description: "The Source Type object contains the information needed to configure a data source."
 
     get:
-      name: "{{ site.data.connect.api.core-objects.source-types.base }}/{type}"
+      name: "{{ site.data.connect.api.core-objects.source-types.base }}/{source_type}"
       title: "Get a source type"
       method: *get
       anchor: "#get-a-source-type"
@@ -223,7 +223,7 @@ core-objects:
       description: |
         {{ site.data.connect.api.core-objects.source-types.get.short }}
 
-        **Note**: This endpoint doesn't retrieve information about the specific configuration of sources in a single account. Instead, it will return general configuration information for the specified source `type`.
+        **Note**: This endpoint doesn't retrieve information about the specific configuration of sources in a single account. Instead, it will return general configuration information for the specified source `source_type`.
 
         To retrieve information about a specific data source, use the [Get a Source]({{ site.data.connect.api.core-objects.sources.retrieve.anchor }}) endpoint.
 
@@ -318,7 +318,7 @@ data-structures:
   details:
     title: "Details"
     section: "#details-object"
-    short: "A Details object contains information about a destination `type`'s availablity within Stitch."
+    short: "A Details object contains information about a destination `type`'s availability within Stitch."
     description: |
       Contained in a [Destination Report Card object]({{ api.data-structures.report-cards.destination.section }}), the Details object contains information about a destination `type`'s availability within Stitch.
 

--- a/_data/connect/common/destination-forms.yaml
+++ b/_data/connect/common/destination-forms.yaml
@@ -28,9 +28,10 @@ all-destinations:
 
   - name: "port"
     required: true
-    type: "integer"
+    type: "string"
     description: "The port of the database server. The default is `{{ port }}`."
-    value: "{{ port }}"
+    value: |
+      "{{ port }}"
 
   - name: "user"
     required: true
@@ -54,10 +55,10 @@ ssh:
 
   - name: "encryption_port"
     required: false
-    type: "integer"
+    type: "string"
     description: "If using SSH encryption, the port of the SSH server. Required only if `encryption_type` is `ssh`."
     value: |
-      <ENCRYPTION_PORT>
+      "<ENCRYPTION_PORT>"
 
   - name: "encryption_type"
     required: true

--- a/_data/connect/core-objects/destination-types.yml
+++ b/_data/connect/core-objects/destination-types.yml
@@ -9,7 +9,7 @@ base: "/v4/destination-types"
 description: "The Destination Type object contains the information needed to configure a destination."
 
 get:
-  name: "{{ site.data.connect.api.core-objects.destination-types.base }}/{type}"
+  name: "{{ site.data.connect.api.core-objects.destination-types.base }}/{destination_type}"
   title: "Get a destination type"
   method: *get
   anchor: "#get-a-destination-type"
@@ -17,7 +17,7 @@ get:
   description: |
     {{ site.data.connect.api.core-objects.destination-types.get.short }}
 
-    **Note**: This endpoint doesn't retrieve information about the specific configuration of a destination in a single account. Instead, it will return general configuration information for the specified destination `type`.
+    **Note**: This endpoint doesn't retrieve information about the specific configuration of a destination in a single account. Instead, it will return general configuration information for the specified destination `destination_type`.
 
     To retrieve specific information about the destination for an account, use the [List Destinations]({{ site.data.connect.api.core-objects.destinations.list.anchor }}) endpoint.
 

--- a/_data/connect/core-objects/destinations.yml
+++ b/_data/connect/core-objects/destinations.yml
@@ -18,7 +18,7 @@ create:
     {{ site.data.connect.api.core-objects.destinations.create.short }} Only a single destination is supported per Stitch client account.
 
 update:
-  name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{id}"
+  name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{destination_id}"
   title: "Update a destination"
   method: &put "put"
   anchor: "#update-a-destination"
@@ -34,7 +34,7 @@ list:
   description: "{{ site.data.connect.api.core-objects.destinations.list.short }} Only a single data warehouse is supported per Stitch client account."
 
 delete:
-  name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{id}"
+  name: "{{ site.data.connect.api.core-objects.destinations.base | flatify }}/{destination_id}"
   title: "Delete a destination"
   method: "delete"
   anchor: "#delete-a-destination"

--- a/_data/connect/core-objects/replication-jobs.yml
+++ b/_data/connect/core-objects/replication-jobs.yml
@@ -1,0 +1,23 @@
+# ----------------------------- #
+#  REPLICATION JOB CORE OBJECT  #
+# ----------------------------- #
+
+title: "Replication Jobs"
+section: "#replication-jobs"
+object: "#replication-job--object"
+base: "/v4/sources/{source_id}/sync"
+description: "todo."
+
+post:
+  name: "{{ site.data.connect.api.core-objects.replication-jobs.base }}"
+  title: "Start a replication job"
+  method: "post"
+  anchor: "#start-a-job"
+  description: "Starts a replication job for a source using the source's unique identifier."
+
+delete:
+  name: "{{ site.data.connect.api.core-objects.replication-jobs.base }}"
+  title: "Stop a replication job"
+  method: "delete"
+  anchor: "#stop-a-job"
+  description: "Stops an in-progress replication job for a source using the source's unique identifier."

--- a/_data/connect/core-objects/source-types.yml
+++ b/_data/connect/core-objects/source-types.yml
@@ -9,7 +9,7 @@ base: "/v4/source-types"
 description: "The Source Type object contains the information needed to configure a data source."
 
 get:
-  name: "{{ site.data.connect.api.core-objects.source-types.base }}/{type}"
+  name: "{{ site.data.connect.api.core-objects.source-types.base }}/{source_type}"
   title: "Get a source type"
   method: *get
   anchor: "#get-a-source-type"
@@ -17,7 +17,7 @@ get:
   description: |
     {{ site.data.connect.api.core-objects.source-types.get.short }}
 
-    **Note**: This endpoint doesn't retrieve information about the specific configuration of sources in a single account. Instead, it will return general configuration information for the specified source `type`.
+    **Note**: This endpoint doesn't retrieve information about the specific configuration of sources in a single account. Instead, it will return general configuration information for the specified source `source_type`.
 
     To retrieve information about a specific data source, use the [Get a Source]({{ site.data.connect.api.core-objects.sources.retrieve.anchor }}) endpoint.
 

--- a/_data/connect/response-codes/replication-jobs.yml
+++ b/_data/connect/response-codes/replication-jobs.yml
@@ -1,0 +1,60 @@
+# -------------------------------- #
+#  REPLICATION JOB ENDPOINT ERRORS #
+# -------------------------------- #
+
+all:
+  - code: "200"
+    responses:
+      - method: "post"
+        condition: "Replication job is already in progress"
+        version: "all"
+        response-body: |
+          ```json
+          {
+            "error": {
+              "type": "already_running",
+              "message": "Did not create job for client-id: <CLIENT_ID>; connection-id: <SOURCE_ID> because one already exists"
+            }
+          }
+          ```
+
+  - code: "400"
+    responses:
+      - method: "post"
+        condition: "Invalid source ID"
+        version: "all"
+        response-body: |
+          ```json
+          {
+            "error": {
+              "type": "invalid_source",
+              "message": "Unable to locate source(<SOURCE_ID>) for client (<CLIENT_ID>)"
+            }
+          }
+          ```
+
+      - method: "post"
+        condition: "Source has been deleted"
+        version: "all"
+        response-body: |
+          ```json
+          {
+            "error": {
+              "type": "invalid_source",
+              "message": "Integration is deleted."
+            }
+          }
+          ```
+
+      # - method: "post"
+      #   condition: ""
+      #   version: "all"
+      #   response-body: |
+      #     ```json
+      #     {
+      #       "error": {
+      #         "type": "generic",
+      #         "message": "Could not create job for client-id: <CLIENT_ID>; connection-id: <SOURCE_ID>"
+      #       }
+      #     }
+      #     ```

--- a/_data/connect/response-codes/sources.yml
+++ b/_data/connect/response-codes/sources.yml
@@ -5,56 +5,165 @@
 all:
   - code: "400"
     responses:
+
+    # -------------------------- #
+    #        POST ERRORS         #
+    # -------------------------- #
+      - method: "post"
+        condition: "Invalid source `type`"
+        version: "4"
+        response-body: |
+          ```json
+          {
+             "error":"InvalidType",
+             "data":{
+                "message":"invalid source type (platform.<SOURCE_TYPE>)"
+             }
+          }
+          ```
+
       - method: "post"
         condition: "Source's `display_name` is already in use"
         version: "all"
         response-body: |
-          `"a source of name <NAME> already exists"`
+          ```json
+          {
+             "error":"InvalidName",
+             "data":{
+                "message":"non-unique name (<NAME>)"
+             }
+          }
+          ```
 
       - method: "post"
         condition: "Prohibited arguments"
-        version: "all"
+        version: "4"
         response-body: |
-          `"POST body may only include a type, a display_name and map of string properties"`
+          ```json
+          {
+             "error":"InvalidBody",
+             "data":{
+                "message":"POST body may only include a non-empty type, a non-empty display_name and map of string properties"
+             }
+          }
+          ```
 
-      - method: "put"
-        condition: "Invalid source ID"
-        version: "all"
+      - method: "post"
+        condition: "Invalid `name` property"
+        version: "4"
         response-body: |
-          `"unable to locate source(<SOURCE_ID>) for client (<ACCOUNT_ID>) to update"`
+          ```json
+          {
+             "error":"InvalidName",
+             "data":{
+                "message":"The name field must be under 50 characters, and can only contain lowercase letters, numbers, underscores, or dollar signs. It must begin with a letter or an underscore."
+             }
+          }
+          ```
 
-      - method: "put"
-        condition: "Prohibited arguments"
-        version: "all"
+      - method: "post"
+        condition: "Non-unique name property"
+        version: "4"
         response-body: |
-          `"PUT body many only include the keys: display_name and properties"`
+          ```json
+          {  
+             "error":"InvalidName",
+             "data":{  
+                "message":"non-unique name after deriving it from display_name (<DISPLAY_NAME!!!> -> <display_name>)"
+             }
+          }
+          ```
+
+      - method: "post"
+        condition: "Invalid name property"
+        version: "4"
+        response-body: |
+          ```json
+          {
+             "error":"InvalidDisplayName",
+             "data":{
+                "message":"invalid name after deriving it from display_name (#### -> )"
+             }
+          }
+          ```
+
+      - method: "post"
+        condition: "Insufficient access to source type"
+        version: "4"
+        response-body: |
+          ```json
+          {
+             "error":"AccessDenied",
+             "data":{
+                "message":"you do not have access to source type (platform.<SOURCE_TYPE>)"
+             }
+          }
+          ```
 
       - method: "post, put"
         condition: "Invalid `properties` data"
         version: "all"
         response-body: |
-          An array of the `property` names containing invalid data:
-
           ```json
           {
-             "bad_properties":[
-                "start_date",
-                "frequency_in_minutes"
-             ],
-             ...
+             "error":"InvalidProperties",
+             "data":{
+                "message":"properties do not match schema",
+                "bad_properties":[
+                   "<property_name_1>",
+                   "<property_name_2"
+                ],
+                "report_card":{<SOURCE_REPORT_CARD>}
+             }
           }
           ```
 
           May result from incorrect formatting, incorrect typing (all property values must be strings), or a property has a value that is an empty string.
 
-      - method: "delete"
+
+    # -------------------------- #
+    #        PUT ERRORS          #
+    # -------------------------- #
+
+      - method: "put"
         condition: "Prohibited arguments"
         version: "all"
         response-body: |
-          `"DELETE body must be empty"`
+          ```json
+          {
+             "error":"InvalidBody",
+             "data":{
+                "message":"PUT body many only include the keys: display_name, properties, and paused_at"
+             }
+          }
+          ```
 
-      - method: "delete"
+      - method: "put"
+        condition: "Invalid display name"
+        version: "all"
+        response-body: |
+          ```json
+          {
+             "error":"InvalidDisplayName",
+             "data":{
+                "message":"invalid display_name (<INVALID_DISPLAY_NAME>)"
+             }
+          }
+          ```
+
+    # -------------------------- #
+    #        DELETE ERRORS       #
+    # -------------------------- #
+
+      - method: "put, delete"
         condition: "Invalid source ID"
         version: "all"
         response-body: |
-          `"Unable to locate source(<SOURCE_ID>) for client (<ACCOUNT_ID>) to delete"`
+          ```json
+          {
+             "error":"InvalidId",
+             "data":{
+                "message":"source not found (<SOURCE_ID>)"
+             }
+          }
+          ```

--- a/_data/sidebars/connect.yml
+++ b/_data/sidebars/connect.yml
@@ -48,7 +48,6 @@ api:
         expand-by-default: true
         sections:
           - title: "Accounts"
-            expand-by-default: true
             subsections:
               - title: "The Account Object"
                 method: "object"
@@ -59,7 +58,6 @@ api:
                 url: "{{ api.core-objects.accounts.create.anchor }}"
 
           - title: "Sessions"
-            expand-by-default: true
             subsections:
               - title: "The Session Object"
                 method: "object"
@@ -70,7 +68,6 @@ api:
                 url: "{{ api.core-objects.sessions.create.anchor }}"
 
           - title: "Destination Types"
-            expand-by-default: true
             subsections:
               - title: "The Destination Type Object"
                 method: "object"
@@ -85,7 +82,6 @@ api:
                 url: "{{ api.core-objects.destination-types.get.anchor }}"
 
           - title: "Destinations"
-            expand-by-default: true
             subsections:
               - title: "The Destination Object"
                 method: "object"
@@ -108,7 +104,6 @@ api:
                 url: "{{ api.core-objects.destinations.delete.anchor }}"
 
           - title: "Source Types"
-            expand-by-default: true
             subsections:
               - title: "The Source Type Object"
                 method: "object"
@@ -123,7 +118,6 @@ api:
                 url: "{{ api.core-objects.source-types.get.anchor }}"
 
           - title: "Sources"
-            expand-by-default: true
             subsections:
               - title: "The Source Object"
                 method: "object"
@@ -150,7 +144,6 @@ api:
                 url: "{{ api.core-objects.sources.delete.anchor }}"
 
           - title: "Connection Checks"
-            expand-by-default: true
             subsections:
               - title: "The Connection Check Object"
                 method: "object"
@@ -161,7 +154,6 @@ api:
                 url: "{{ api.core-objects.connection-checks.get-source.anchor }}"
 
           - title: "Streams"
-            expand-by-default: true
             subsections:
               - title: "The Stream Object"
                 method: "object"
@@ -178,6 +170,20 @@ api:
               - title: "{{ api.core-objects.streams.update.title | flatify }}"
                 method: "put"
                 url: "{{ api.core-objects.streams.update.anchor }}"
+
+          - title: "Replication Jobs"
+            subsections:
+              - title: "The Replication Job Object"
+                method: "object"
+                url: "{{ api.core-objects.replication-jobs.object }}"
+
+              - title: "{{ api.core-objects.replication-jobs.post.title | flatify }}"
+                method: "post"
+                url: "{{ api.core-objects.replication-jobs.post.anchor }}"
+
+              - title: "{{ api.core-objects.replication-jobs.delete.title | flatify }}"
+                method: "delete"
+                url: "{{ api.core-objects.replication-jobs.delete.anchor }}"
 
       - title: "Data Structures"
         expand-by-default: true

--- a/_data/tooltips.yml
+++ b/_data/tooltips.yml
@@ -53,7 +53,7 @@ source: "A database, API, or other data application that Stitch replicates data 
 
 stitch-client-account: "An individual account for the Stitch web application."
 
-structure-sync: "The first step in the replication process, this process will detect the tables and columns available in the source, along with any changes to the structure of those tables and columns."
+structure-sync: "The first step in the replication process, this process takes place during the Extraction phase of a replication job. A structure sync detects the tables and columns available in the source, along with any changes to the structure of those tables and columns."
 
 table-selection: "The ability to select individual tables for replication in the Stitch interface. If table selection is unavailable, all tables and all the columns they contain will be set to replicate by default."
 

--- a/_includes/connect/api-examples.html
+++ b/_includes/connect/api-examples.html
@@ -40,11 +40,11 @@
     <!-- This value comes from _includes/connect/api-endpoint.html -->
         {% case has-multiple-versions %}
             {% when "true" %}
-                {% assign tab-id = item.key | append: "-" | append: example.type | append: "-v" | append: version.number %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | append: "-v" | append: version.number | slugify %}
             {% when "false" %}
-                {% assign tab-id = item.key | append: "-" | append: example.type %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | slugify %}
             {% else %}
-                {% assign tab-id = item.key | append: "-" | append: example.type %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | slugify %}
         {% endcase %}
 
         {% if forloop.first == true %} 
@@ -63,11 +63,11 @@
     <!-- This value comes from _includes/connect/api-endpoint.html -->
         {% case has-multiple-versions %}
             {% when "true" %}
-                {% assign tab-id = item.key | append: "-" | append: example.type | append: "-v" | append: version.number %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | append: "-v" | append: version.number | slugify %}
             {% when "false" %}
-                {% assign tab-id = item.key | append: "-" | append: example.type %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | slugify %}
             {% else %}
-                {% assign tab-id = item.key | append: "-" | append: example.type %}
+                {% assign tab-id = item.key | append: "-" | append: example.type | slugify %}
         {% endcase %}
 
         {% if forloop.first == true %}


### PR DESCRIPTION
This PR:

- Adds the Start a job and Stop a job endpoints
- Adds new attributes to the `properties` object
- Updates responses for Sources endpoints
- Updates report card and response examples
- Corrects misc. linking issues