### PR TITLE
add ads_insights_dma breakdown for Facebook Ads

### DIFF
--- a/_integration-schemas/facebook-ads/ads_insights_dma.json
+++ b/_integration-schemas/facebook-ads/ads_insights_dma.json
@@ -2,23 +2,15 @@
 tap: "facebook-ads"
 version: 1.0
 
-name: "ads_insights"
+name: "ads_insights_dma"
 doc-link: https://developers.facebook.com/docs/marketing-api/insights/fields/
-singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_facebook/schemas/ads_insights.json
+singer-schema: https://github.com/singer-io/tap-facebook/blob/master/tap_facebook/schemas/ads_insights_dma.json
 description: |
-  The `ads_insights` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics.
+    The `ads_insights_dma` table contains entries for each campaign/set/ad combination for each day, along with detailed statistics, segmented by DMA (Designated Market Area).
+
+  This table contains the same fields as the [`ads_insights`](#ads_insights) table, with the exception of `dma`.
 
   **Note**: Data for deleted ads, adsets, and campaigns will not appear in this table even if the **Include data from deleted campaigns, ads, and adsets** option in the integration's settings is enabled.
-
-  #### Segmented insights data
-
-  To analyze data that's been segmented by various characteristics, consider tracking some of the other `ads_insights` tables in this integration. The following tables contain the same fields as this one (`ads_insights`), but include additional dimensions to segment the data:
-
-  - [`ads_insights_age_and_gender`](#ads_insights_age_and_gender) - Data segmented by age and gender
-  - [`ads_insights_country`](#ads_insights_country) - Data segmented by country
-  - [`ads_insights_dma`](#ads_insights_dma) - Data segmented by DMA (Designated Market Area)
-  - [`ads_insights_platform_and_device`](#ads_insights_platform_and_device) - Data segmented by platform and device
-  - [`ads_insights_region`](#ads_insights_region) - Data segmented by region
 
 replication-method: "Key-based Incremental"
 attribution-window: true
@@ -46,11 +38,16 @@ attributes:
     type: "date-time"
     primary-key: true
     replication-key: true
-    description: "The start date."
+    description: "The start date of the ad."
 
   - name: "date_stop"
     type: "date-time"
-    description: "The end date."
+    description: "The end date of the ad."
+
+  - name: "dma"
+    type: "string"
+    primary-key: true
+    description: "The DMA by which the data is segmented."
 
   - name: "ad_name"
     type: "integer"

--- a/_integration-schemas/facebook-ads/foreign-keys.md
+++ b/_integration-schemas/facebook-ads/foreign-keys.md
@@ -10,6 +10,7 @@ foreign-keys:
       - table: "ads_insights"
       - table: "ads_insights_age_and_gender"
       - table: "ads_insights_country"
+      - table: "ads_insights_dma"
       - table: "ads_insights_platform_and_device"
       - table: "ads_insights_region"
 
@@ -37,6 +38,7 @@ foreign-keys:
       - table: "ads_insights"
       - table: "ads_insights_age_and_gender"
       - table: "ads_insights_country"
+      - table: "ads_insights_dma"
       - table: "ads_insights_platform_and_device"
       - table: "ads_insights_region"
 
@@ -63,6 +65,7 @@ foreign-keys:
       - table: "ads_insights"
       - table: "ads_insights_age_and_gender"
       - table: "ads_insights_country"
+      - table: "ads_insights_dma"
       - table: "ads_insights_platform_and_device"
       - table: "ads_insights_region"
       - table: "campaigns"
@@ -80,6 +83,7 @@ foreign-keys:
       - table: "ads_insights"
       - table: "ads_insights_age_and_gender"
       - table: "ads_insights_country"
+      - table: "ads_insights_dma"
       - table: "ads_insights_platform_and_device"
       - table: "ads_insights_region"
 


### PR DESCRIPTION
This PR adds docs for the new `ads_insights_dma` table for the Facebook Ads integration.