### PR TITLE
Updated Oracle RDS and assoc. links

### DIFF
--- a/_database-integrations/oracle/oracle-rds/oracle-rds-v1.md
+++ b/_database-integrations/oracle/oracle-rds/oracle-rds-v1.md
@@ -29,6 +29,7 @@ tap-name: "Oracle"
 repo-url: "https://github.com/singer-io/tap-oracle"
 
 # this-version: "1.0"
+has-specific-data-types: true
 
 hosting-type: "amazon"
 
@@ -270,39 +271,11 @@ replication-sections:
 
       Refer to the [Log-based Incremental Replication documentation]({{ link.replication.log-based-incremental | prepend: site.baseurl }}) for a more detailed explanation, examples, and the limitations associated with this replication method.
 
-  - title: "Data typing and LogMiner (Log-based Incremental Replication)"
-    anchor: "data-typing-logminer-replication"
+  - title: "Data types"
+    anchor: "data-types"
     content: |
-      {{ integration.display_name }}'s LogMiner packages supports the data types listed in the table below. Refer to [{{ integration.display_name }}'s documentation]({{ site.data.taps.links[integration.name]logminer-supported-datatypes }}){:target="new"} for more info.
+      {% include replication/templates/data-types/integration-specific-data-types.html specific-types=true display-intro=true version="1.0" version-column-headers=false %}
 
-      **Only columns with the data types listed below are able to be selected and replicated through Stitch**. Columns with data types not in this list will show as `UNSUPPORTED` in Stitch. For reference, you can view the code for data typing in Stitch's {{ integration.display_name }} integrations in the [Singer {{ integration.display_name }} GitHub repository](https://github.com/singer-io/tap-oracle/blob/master/tap_oracle/__init__.py){:target="new"}.
-
-      {% assign attributes="name|stored-as" | split:"|" %}
-
-      <table class="attribute-list">
-      <tr>
-      <td width="40%; fixed" align="right">
-      <strong>{{ integration.display_name }} data type</strong>
-      </td>
-      <td>
-      <strong>Stitch data type mapping</strong>
-      </td>
-      </tr>
-      {% for data-type in site.data.taps.extraction.data-types[integration.db-type]logminer.supported %}
-      <tr>
-      {% for attribute in attributes %}
-      {% assign attribute-number = forloop.index %}
-      {% if forloop.first == true %}
-      <td width="40%; fixed" align="right">
-      {% else %}
-      <td>
-      {% endif %}
-      {{ data-type[attribute] | upcase }}{% if attribute-number == 2 and data-type.formatted-as %} (formatted as {{ data-type.formatted-as | upcase }}){% endif %}
-      </td>
-      {% endfor %}
-      </tr>
-      {% endfor %}
-      </table>
 ---
 {% assign integration = page %}
 {% include misc/data-files.html %}

--- a/_database-integrations/oracle/oracle-v1.md
+++ b/_database-integrations/oracle/oracle-v1.md
@@ -159,7 +159,7 @@ setup-steps:
 
           If the result to the query in [Step 3.1](#verify-current-archiving-mode) is `NOARCHIVELOG`, then you'll need to enable `ARCHIVELOG` mode. **Skip to [Step 3.3](#configure-rman-backups) if the result was `ARCHIVELOG`.**
 
-          1. Shut down the database instance. The database and any associated instances must be shut down before the datbase's archiving mode can be changed.
+          1. Shut down the database instance. The database and any associated instances must be shut down before the database's archiving mode can be changed.
 
              ```sql
              SHUTDOWN IMMEDIATE

--- a/_includes/integrations/databases/setup/binlog/configure-server-settings-intro.html
+++ b/_includes/integrations/databases/setup/binlog/configure-server-settings-intro.html
@@ -3,7 +3,7 @@
 {% when 'oracle' %}
 
 {% capture log-based-notice %}
-Some data types may not be supported for Log-based Incremental Replication. Refer to the [Data typing and LogMiner section](#data-typing-logminer-replication) for more info.
+Some data types may not be supported for Log-based Incremental Replication. Refer to the [Data types section](#data-types) for more info.
 {% endcapture %}
 
 {% include note.html first-line="**Note: Log-based Incremental Replication**" content=log-based-notice %}


### PR DESCRIPTION
Updated Oracle RDS page to be in line with vanilla Oracle page

Updated link to "Datatypes" on both pages