### PR TITLE
MSSQL/v1 - New date-time data types

### DIFF
--- a/_data/taps/extraction/data-types/mssql/specific.yml
+++ b/_data/taps/extraction/data-types/mssql/specific.yml
@@ -13,3 +13,12 @@
 
 - name: "varbinary"
   doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-2017"
+
+- name: "datetime2"
+  doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-2017"
+
+- name: "smalldatetime"
+  doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/smalldatetime-transact-sql?view=sql-server-2017"
+
+- name: "datetimeoffset"
+  doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql?view=sql-server-2017"

--- a/_data/taps/extraction/data-types/mssql/v1.yml
+++ b/_data/taps/extraction/data-types/mssql/v1.yml
@@ -40,6 +40,14 @@ date:
   stitch-type: "string"
   format: "date-time"
   doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/date-transact-sql?view=sql-server-2017"
+
+datetime2:
+  stitch-type: "string"
+  format: "date-time"
+
+datetimeoffset:
+  stitch-type: "string"
+  format: "date-time"
       
 decimal:
   stitch-type: "number"
@@ -83,6 +91,10 @@ rowversion:
   doc-link: &rowversion-doc-link "https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-2017"
   tooltip: |
     An auto-generated, auto-incremented, unique binary hex string used to version-stamp rows. This is synonymous with <strong>timestamp</strong>. <a href='https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-2017' target='new'>Learn more</a>.
+
+smalldatetime:
+  stitch-type: "string"
+  format: "date-time"
 
 smallint:
   stitch-type: "integer"


### PR DESCRIPTION
 This updates the docs to include three newly supported data types for v1 of the MSSQL integration: `datetime2`, `datetimeoffset`, and `smalldatetime`.

https://github.com/stitchdata/tap-mssql/pull/49