### PR TITLE
Correct spelling on Key-based Incremental Replication Stitch Docs page

### DIFF
--- a/_replication/replication-methods/key-based-incremental-replication.md
+++ b/_replication/replication-methods/key-based-incremental-replication.md
@@ -36,7 +36,7 @@ sections:
   - title: "How {{ page.title }} works"
     anchor: "how-key-based-incremental-replication-works"
     content: |
-      When using {{ page.title }}, Stitch uses a column called a [Replication Key]({{ link.replication.rep-keys | prepend: site.baseurl }}) to identify new and updated data in a table for replication. A Replication Key is a column that exists in a source table, and must be on of the following data types:
+      When using {{ page.title }}, Stitch uses a column called a [Replication Key]({{ link.replication.rep-keys | prepend: site.baseurl }}) to identify new and updated data in a table for replication. A Replication Key is a column that exists in a source table, and must be one of the following data types:
 
       {% for data-type in site.data.taps.extraction.replication-methods.key-based-incremental.allowed-data-types %}
       - {{ data-type.type | flatify | markdownify }}


### PR DESCRIPTION
Corrected "on" to "one".