### PR TITLE
Update NetSuite Deprecation

### DIFF
--- a/_data/taps/versions/netsuite.yml
+++ b/_data/taps/versions/netsuite.yml
@@ -15,4 +15,4 @@ released-versions:
     date-released: "October 15, 2015"
     date-last-connection: "May 8, 2019"
     deprecated: true
-    deprecation-date: "August 15, 2019"
+    deprecation-date: "May 21, 2019"


### PR DESCRIPTION
This changes the deprecation date for 10-15-2015 to reflect the actual deprecation date rather than the integration's sunset date.