### PR TITLE
Bug Fixes

### DIFF
--- a/_data-structure/system-tables/primary-keys-system-table.md
+++ b/_data-structure/system-tables/primary-keys-system-table.md
@@ -145,7 +145,7 @@ sections:
       Primary Keys for table do not match Primary Keys of incoming data
       ```
 
-      If you recieve this error, you should [reset the table(s)]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) mentioned in the error. This will queue a full re-replication of the table, which will ensure Primary Keys are correctly captured and used to de-dupe data when loading.
+      If you receive this error, you should [reset the table(s)]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}) mentioned in the error. This will queue a full re-replication of the table, which will ensure Primary Keys are correctly captured and used to de-dupe data when loading.
 ---
 {% include misc/data-files.html %}
 {% assign destination = site.destinations | where:"type",page.type | first %}

--- a/_data/app.yml
+++ b/_data/app.yml
@@ -52,7 +52,8 @@ buttons:
 ## Integration Settings
   update-int-settings: "**Settings**"
   finish-int-setup: "**All Done**"
-  reset-rep-keys: "**Reset Keys**"
+  reset-integration: "**Reset This Integration**"
+  
   tables: "**Tables to Replicate**"
   start-extraction: "**Run Extraction Now**"
   stop-extraction: "**Stop Extraction**"
@@ -70,6 +71,7 @@ buttons:
   save-table-settings: "**Update Settings**"
   update-table-settings: "**Table Settings**"
   save-int-settings: "**Save Integration**"
+  reset-rep-keys: "**Reset Table**"
 
   stop-db: "**Stop Syncing Database**"
   stop-schema: "**Stop Syncing Schema**"

--- a/_data/errors/extraction/databases/mysql.yml
+++ b/_data/errors/extraction/databases/mysql.yml
@@ -149,7 +149,7 @@ all:
 
       It can also be caused by binary log files being purged before historical replication completes or critical errors that prevent Stitch from replicating data. When this occurs, it means Stitch was unable to proceed to the binary log file before the retention period passed and the log was purged.
     fix-it: |
-      To resolve the error, you'll need to perform an integration-level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-rep-keys }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
+      To resolve the error, you'll need to perform an integration-level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-integration }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
 
       To prevent this error in the future, verify your server's log retention settings and update them if needed. Stitch recommends a minimum of 3 days, but 7 days is preferred. This ensures that you have time to resolve any issues that arise before logs age out and are purged.
 
@@ -168,7 +168,7 @@ all:
 
       Typically this will be an issue only if the server uses a very small [`max_binlog_size`](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_max_binlog_size){:target="new"} value.
     fix-it: |
-      Perform an integration-level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-rep-keys }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
+      Perform an integration-level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-integration }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
 
       We also recommend checking the value of the `max_binlog_size` server parameter and increasing it if it's too small. By default, this is set to MySQL's maximum of 1 GB (1073741824 bytes).
 

--- a/_data/errors/extraction/databases/oracle.yml
+++ b/_data/errors/extraction/databases/oracle.yml
@@ -105,7 +105,7 @@ all:
     fix-it: |
       1. Verify the current RMAN retention window length.
       2. [Increase the RMAN retention window]({{ site.baseurl }}/integrations/databases/oracle#configure-rman-backups). For example: Increase the window from 2 days to 7.
-      3. Perform an integration level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-rep-keys }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
+      3. Perform an integration level reset. To do this, open the **{{ app.page-names.int-settings }}** page and click the {{ app.buttons.reset-integration }} button. This will clear the integration's Replication Keys and queue a full re-replication of the integration.
 
   # - message: ""
   #   id: ""

--- a/_data/taps/versions/mongo.yml
+++ b/_data/taps/versions/mongo.yml
@@ -8,7 +8,7 @@ tap-name: "MongoDB"
 
 released-versions:
   - number: "1.0"
-    status: "beta"
+    status: "released"
     date-released: "November 4, 2019"
     # date-last-connection:
     deprecation-date: ""
@@ -19,6 +19,7 @@ released-versions:
     date-released: "January 11, 2016"
     date-last-connection: "November 4, 2019"
     deprecation-date: "To be determined"
+    sunset-date: ""
 
 
 # -------------------------- #

--- a/_data/taps/versions/mongo.yml
+++ b/_data/taps/versions/mongo.yml
@@ -18,8 +18,8 @@ released-versions:
     status: "deprecated"
     date-released: "January 11, 2016"
     date-last-connection: "November 4, 2019"
-    deprecation-date: "To be determined"
-    sunset-date: ""
+    deprecation-date: "November 21, 2019"
+    sunset-date: "February 2, 2020"
 
 
 # -------------------------- #

--- a/_database-integrations/mysql/amazon-rds/mysql-amazon-rds.md
+++ b/_database-integrations/mysql/amazon-rds/mysql-amazon-rds.md
@@ -134,7 +134,7 @@ setup-steps:
         content: |
           {% include integrations/databases/setup/binlog/mysql-server-id.html %}
 
-      - title: "Define the binlong retention setting"
+      - title: "Define the binlog retention setting"
         anchor: "define-binlog-retention-setting"
         content: |
           {% include integrations/databases/setup/binlog/amazon-rds/define-database-settings.html content="binlog-retention-hours" %}

--- a/_database-integrations/mysql/amazon-rds/mysql-amazon-rds.md
+++ b/_database-integrations/mysql/amazon-rds/mysql-amazon-rds.md
@@ -118,7 +118,7 @@ setup-steps:
 
           Skipping this step or disabling automatic backups will cause replication issues in Stitch.
 
-          Refer to the **Transaction Size** section of [Amazon's Importing Data into a MySQL DB Instance](https://docs.amazonaws.cn/en_us/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.Other.html){:target="new"} documentation for more info.
+          Refer to the **Transaction Size** section of [Amazon's Importing Data into a MySQL DB Instance](https://docs.aws.amazon.com/en_us/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.Other.html){:target="new"} documentation for more info.
           {% endcapture %}
           {% include note.html type="single-line" content=mysql-rds-backup-requirement %}
 

--- a/_destinations/amazon-s3/amazon-s3-overview.md
+++ b/_destinations/amazon-s3/amazon-s3-overview.md
@@ -129,7 +129,7 @@ sections:
           - Existing records - that is, records in files already in the destination - are never updated
           - Data will not be de-duped, meaning that multiple versions of the same record may exist across multiple files in the data warehouse
 
-          Because of this loading strategy, querying may require a different approach than usual. Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time. Refer to the [Querying Append-Only Tables documentation]({{ link.replication.append-only | prepend: site.baseurl }}) for more info.
+          Because of this loading strategy, querying may require a different approach than usual. Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time. Refer to the [Querying Append-Only Tables documentation]({{ link.replication.append-only-querying | prepend: site.baseurl }}) for more info.
 
         sub-subsections:
           - title: "Example: Key-based Incremental Replication"

--- a/_destinations/bigquery/v1/bigquery-overview-v1.md
+++ b/_destinations/bigquery/v1/bigquery-overview-v1.md
@@ -122,7 +122,7 @@ sections:
 
           In Append-Only replication, existing rows aren't updated. Multiple versions of a row can exist in a table, creating a log of how a row changed over time. **Note**: While this may look like a discrepancy, it is intended functionality for {{ destination.display_name }} {{ destination.this-version | prepend: "v" }} destinations.
 
-          Because of this loading strategy, querying may require [a different strategy than usual]({{ link.replication.append-only | prepend: site.baseurl }}). Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time.
+          Because of this loading strategy, querying may require [a different strategy than usual]({{ link.replication.append-only-querying | prepend: site.baseurl }}). Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time.
 
           Refer to the [Understanding loading behavior guide]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}) for more info and examples.
 

--- a/_destinations/bigquery/v2/bigquery-overview-v2.md
+++ b/_destinations/bigquery/v2/bigquery-overview-v2.md
@@ -160,7 +160,7 @@ sections:
 
           - **Append-Only**: Existing rows aren't updated. Multiple versions of a row can exist in a table, creating a log of how a row changed over time.
 
-             Because of this loading strategy, [querying may require a different strategy]({{ link.replication.append-only | prepend: site.baseurl }}) than usual. Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time.
+             Because of this loading strategy, [querying may require a different strategy]({{ link.replication.append-only-querying | prepend: site.baseurl }}) than usual. Using some of the system columns Stitch inserts into tables will enable you to locate the latest version of a record at query time.
 
           Refer to the [Understanding loading behavior guide]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}) for more info.
 

--- a/_destinations/bigquery/v2/bigquery-setup-v2.md
+++ b/_destinations/bigquery/v2/bigquery-setup-v2.md
@@ -79,7 +79,7 @@ steps:
     anchor: "create-gcp-iam-service-account"
     content: |
       {% for substep in step.substeps %}
-      - [Step 1.{{ forloop.index }}: {{ substep.title }}]({{ substep.anchor }})
+      - [Step 1.{{ forloop.index }}: {{ substep.title }}](#{{ substep.anchor }})
       {% endfor %}
 
     substeps:

--- a/_includes/integrations/webhooks/webhook-replication.html
+++ b/_includes/integrations/webhooks/webhook-replication.html
@@ -15,7 +15,9 @@ In the event that our webhook service experiences downtime, you may notice some 
 
 ### Method
 
-This version of Stitch's {{ integration.display_name }} integration uses **Append-Only** Replication. {{ site.data.tooltips.append-only-rep }} Data stored this way can provide insights and historical details about how those rows have changed over time.
+This version of Stitch's {{ integration.display_name }} integration loads data in an Append-Only fashion. {{ site.data.tooltips.append-only }} Data stored this way can provide insights and historical details about how those rows have changed over time.
+
+Refer to the [Understanding loading behavior guide]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}) for more info and examples.
 
 ### Query for the latest data
 

--- a/_includes/layout/related-articles.html
+++ b/_includes/layout/related-articles.html
@@ -32,7 +32,7 @@
 	</li>
 	{% if page.type == "bigquery" %}
 		<li>
-			<a href="{{  link.replication.append-only | prepend: site.baseurl }}">BigQuery & Append-Only Replication</a>
+			<a href="{{  link.destinations.storage.loading-behavior | prepend: site.baseurl }}">Understanding Loading Behavior</a>
 		</li>
 		<li>
 			<a href="{{ link.destinations.overviews.bigquery-pricing | prepend: site.baseurl }}">Stitch's Impact on BigQuery Costs</a>
@@ -66,7 +66,7 @@
 <!-- Webhook Integrations -->
 {% if page.permalink contains "webhooks" %}
 		<li>
-			<a href="{{ link.replication.rep-methods | prepend: site.baseurl | append:"#append-only-incremental-replication"}}">Append-Only Replication
+			<a href="{{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}">Append-Only Loading
 		</li>
 		<li>
 			<a href="{{ link.replication.append-only-querying | prepend: site.baseurl }}">Querying Append-Only Tables</a>

--- a/_integration-schemas/facebook-ads/campaigns.md
+++ b/_integration-schemas/facebook-ads/campaigns.md
@@ -78,10 +78,6 @@ attributes:
     type: "date-time"
     description: "The campaign's start time."
 
-  - name: "end_time"
-    type: "date-time"
-    description: "The campaign's end time."
-
   - name: "ads"
     type: "array"
     description: "The IDs of the ads associated with the campaign."

--- a/_integration-schemas/google-ads/account_performance_report.md
+++ b/_integration-schemas/google-ads/account_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "account_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/account-performance-report

--- a/_integration-schemas/google-ads/accounts.md
+++ b/_integration-schemas/google-ads/accounts.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "accounts"
 doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/ManagedCustomerService.ManagedCustomer

--- a/_integration-schemas/google-ads/ad_groups.md
+++ b/_integration-schemas/google-ads/ad_groups.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "ad_groups"
 doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupService.AdGroup

--- a/_integration-schemas/google-ads/ad_performance_report.md
+++ b/_integration-schemas/google-ads/ad_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "ad_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/ad-performance-report

--- a/_integration-schemas/google-ads/adgroup_performance_report.md
+++ b/_integration-schemas/google-ads/adgroup_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "adgroup_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/adgroup-performance-report

--- a/_integration-schemas/google-ads/ads.md
+++ b/_integration-schemas/google-ads/ads.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "ads"
 doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/AdGroupAdService.AdGroupAd

--- a/_integration-schemas/google-ads/age_range_performance_report.md
+++ b/_integration-schemas/google-ads/age_range_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "age_range_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/age-range-performance-report

--- a/_integration-schemas/google-ads/audience_performance_report.md
+++ b/_integration-schemas/google-ads/audience_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "audience_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/age-range-performance-report

--- a/_integration-schemas/google-ads/call_metrics_call_details_report.md
+++ b/_integration-schemas/google-ads/call_metrics_call_details_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "call_metrics_call_details_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/call-metrics-call-details-report

--- a/_integration-schemas/google-ads/campaign_performance_report.md
+++ b/_integration-schemas/google-ads/campaign_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "campaign_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/campaign-performance-report

--- a/_integration-schemas/google-ads/campaigns.md
+++ b/_integration-schemas/google-ads/campaigns.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "campaigns"
 doc-link: https://developers.google.com/adwords/api/docs/reference/v201806/CampaignService.Campaign

--- a/_integration-schemas/google-ads/click_performance_report.md
+++ b/_integration-schemas/google-ads/click_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "click_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/click-performance-report

--- a/_integration-schemas/google-ads/criteria_performance_report.md
+++ b/_integration-schemas/google-ads/criteria_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "criteria_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/criteria-performance-report

--- a/_integration-schemas/google-ads/display_keyword_performance_report.md
+++ b/_integration-schemas/google-ads/display_keyword_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "display_keyword_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/display-keyword-performance-report

--- a/_integration-schemas/google-ads/display_topics_performance_report.md
+++ b/_integration-schemas/google-ads/display_topics_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "display_topics_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/display-topics-performance-report

--- a/_integration-schemas/google-ads/final_url_report.md
+++ b/_integration-schemas/google-ads/final_url_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "final_url_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/gender-performance-report

--- a/_integration-schemas/google-ads/gender_performance_report.md
+++ b/_integration-schemas/google-ads/gender_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "gender_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/gender-performance-report

--- a/_integration-schemas/google-ads/geo_performance_report.md
+++ b/_integration-schemas/google-ads/geo_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "geo_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/geo-performance-report

--- a/_integration-schemas/google-ads/keywordless_query_report.md
+++ b/_integration-schemas/google-ads/keywordless_query_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "keywordless_query_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/keywordless-query-report

--- a/_integration-schemas/google-ads/keywords_performance_report.md
+++ b/_integration-schemas/google-ads/keywords_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "keywords_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/keywords-performance-report

--- a/_integration-schemas/google-ads/search_query_performance_report.md
+++ b/_integration-schemas/google-ads/search_query_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "search_query_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/search-query-performance-report

--- a/_integration-schemas/google-ads/video_performance_report.md
+++ b/_integration-schemas/google-ads/video_performance_report.md
@@ -1,6 +1,6 @@
 ---
 tap: "google-ads"
-version: "1.0"
+version: "1"
 
 name: "video_performance_report"
 doc-link: https://developers.google.com/adwords/api/docs/appendix/reports/video-performance-report

--- a/_integration-schemas/netsuite/Account.md
+++ b/_integration-schemas/netsuite/Account.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Account"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/account.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Account.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Account.json"
 description: |
   The `{{ table.name }}` table contains info about the accounts in the Chart of Accounts in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/AccountingPeriod.md
+++ b/_integration-schemas/netsuite/AccountingPeriod.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "AccountingPeriod"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/accountingperiod.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/AccountingPeriod.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/AccountingPeriod.json"
 description: |
   The `{{ table.name }}` table contains info about the accounting periods in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Address.md
+++ b/_integration-schemas/netsuite/Address.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Address"
 doc-link: ""
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Address.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Address.json"
 description: |
   The `{{ table.name }}` table contains info about the custom address forms in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/BillingAccount.md
+++ b/_integration-schemas/netsuite/BillingAccount.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "BillingAccount"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/billingaccount.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/BillingAccount.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/BillingAccount.json"
 description: |
   The `{{ table.name }}` table contains info about the billing accounts in your {{ integration.display_name }} account. A billing account is a record used to show all billing information for a customer or subcustomer. A billing account contains billing-specific information, including billing schedule, default payment terms, bill-to address, and currency.
 

--- a/_integration-schemas/netsuite/BillingSchedule.md
+++ b/_integration-schemas/netsuite/BillingSchedule.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "BillingSchedule"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/billingschedule.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/BillingSchedule.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/BillingSchedule.json"
 description: |
   The `{{ table.name }}` table contains info about the billing schedules in your {{ integration.display_name }} account. Billing schedules are used to define how bills for transactions are relayed to customers. In general, a billing schedule determines the frequency with which the customer is billed and the amount of each bill. However, the exact effect of a billing schedule varies depending on its type.
 

--- a/_integration-schemas/netsuite/Bin.md
+++ b/_integration-schemas/netsuite/Bin.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Bin"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/bin.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Bin.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Bin.json"
 description: |
   The `{{ table.name }}` table contains info about bins, or places in your warehouse where you store inventory items.
 

--- a/_integration-schemas/netsuite/Budget.md
+++ b/_integration-schemas/netsuite/Budget.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Budget"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/budget.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Budget.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Budget.json"
 description: |
   The `{{ table.name }}` table contains info about the budgets in your {{ integration.display_name }} account. A budget records the expected values of income and expenses for your business. Budgets can be created for specific customers, items, departments, classes, locations, or any combination of these criteria. 
 

--- a/_integration-schemas/netsuite/CalendarEvent.md
+++ b/_integration-schemas/netsuite/CalendarEvent.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CalendarEvent"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/calendarevent.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CalendarEvent.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CalendarEvent.json"
 description: |
   The `{{ table.name }}` table contains info about the scheduled activities, or events, that are on the calendar in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Classification.md
+++ b/_integration-schemas/netsuite/Classification.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Classification"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/classification.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Classification.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Classification.json"
 description: |
   The `{{ table.name }}` table contains info about the classifications in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ConsolidatedExchangeRate.md
+++ b/_integration-schemas/netsuite/ConsolidatedExchangeRate.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ConsolidatedExchangeRate"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/consolidatedexchangerate.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ConsolidatedExchangeRate.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ConsolidatedExchangeRate.json"
 description: |
   The `{{ table.name }}` table contains info about consolidated exchange rates. This is used in {{ integration.display_name }} OneWorld for consolidation purposes, ensuring currency amounts correctly roll up from child to parent subsidiaries.
 

--- a/_integration-schemas/netsuite/ContactCategory.md
+++ b/_integration-schemas/netsuite/ContactCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ContactCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/contactcategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ContactCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ContactCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the types of contacts in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ContactRole.md
+++ b/_integration-schemas/netsuite/ContactRole.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ContactRole"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/contactrole.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ContactRole.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ContactRole.json"
 description: |
   The `{{ table.name }}` table contains info about contact roles in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/CostCategory.md
+++ b/_integration-schemas/netsuite/CostCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CostCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/costcategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CostCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CostCategory.json"
 description: |
   The `{{ table.name }}` table contains info about cost categories, which are used to classify different types of costs associated with items.
 

--- a/_integration-schemas/netsuite/CouponCode.md
+++ b/_integration-schemas/netsuite/CouponCode.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CouponCode"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/couponcode.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CouponCode.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CouponCode.json"
 description: |
   The `{{ table.name }}` table contains info about the coupon codes in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/CurrencyRate.md
+++ b/_integration-schemas/netsuite/CurrencyRate.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CurrencyRate"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/currencyrate.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CurrencyRate.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CurrencyRate.json"
 description: |
   The `{{ table.name }}` table contains info about currency rate records in you {{ integration.display_name }} account. These are also known as Exchange Rate records in {{ integration.display_name }}.
 

--- a/_integration-schemas/netsuite/CustomList.md
+++ b/_integration-schemas/netsuite/CustomList.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CustomList"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customlist.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomList.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomList.json"
 description: |
   The `{{ table.name }}` table contains info about 
 

--- a/_integration-schemas/netsuite/Customer.md
+++ b/_integration-schemas/netsuite/Customer.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Customer"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customer.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Customer.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Customer.json"
 description: |
   The `{{ table.name }}` table contains info about customers.
 

--- a/_integration-schemas/netsuite/CustomerCategory.md
+++ b/_integration-schemas/netsuite/CustomerCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CustomerCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customercategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the types of customers in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/CustomerMessage.md
+++ b/_integration-schemas/netsuite/CustomerMessage.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CustomerMessage"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customermessage.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerMessage.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerMessage.json"
 description: |
   The `{{ table.name }}` table contains info about standardized customer messages in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/CustomerStatus.md
+++ b/_integration-schemas/netsuite/CustomerStatus.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "CustomerStatus"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customerstatus.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerStatus.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/CustomerStatus.json"
 description: |
   The `{{ table.name }}` table contains info about the stages for leads, prospects, and customers in your {{ integration.display_name }} sales cycle.
 

--- a/_integration-schemas/netsuite/Deleted.md
+++ b/_integration-schemas/netsuite/Deleted.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Deleted"
 doc-link: "https://system.netsuite.com/app/help/helpcenter.nl?fid=section_N3497592.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Deleted.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Deleted.json"
 description: |
   The `{{ table.name }}` table contains info about deleted records.
 

--- a/_integration-schemas/netsuite/Department.md
+++ b/_integration-schemas/netsuite/Department.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Department"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/department.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Department.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Department.json"
 description: |
   The `{{ table.name }}` table contains info about the departments in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/EntityGroup.md
+++ b/_integration-schemas/netsuite/EntityGroup.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "EntityGroup"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/entitygroup.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/EntityGroup.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/EntityGroup.json"
 description: |
   The `{{ table.name }}` table contains info about the groups in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ExpenseCategory.md
+++ b/_integration-schemas/netsuite/ExpenseCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ExpenseCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/expensecategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ExpenseCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ExpenseCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the expense categories in your {{ integration.display_name }} account. 
 

--- a/_integration-schemas/netsuite/FairValuePrice.md
+++ b/_integration-schemas/netsuite/FairValuePrice.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "FairValuePrice"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/fairvalueprice.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/FairValuePrice.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/FairValuePrice.json"
 description: |
   The `{{ table.name }}` table contains info about the fair value price list in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Folder.md
+++ b/_integration-schemas/netsuite/Folder.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Folder"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/folder.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Folder.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Folder.json"
 description: |
   The `{{ table.name }}` table contains info about the folders in your {{ integration.display_name }} File Cabinet.
 

--- a/_integration-schemas/netsuite/GiftCertificate.md
+++ b/_integration-schemas/netsuite/GiftCertificate.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "GiftCertificate"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/giftcertificate.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/GiftCertificate.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/GiftCertificate.json"
 description: |
   The `{{ table.name }}` table contains info about the gift certificates in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/GlobalAccountMapping.md
+++ b/_integration-schemas/netsuite/GlobalAccountMapping.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "GlobalAccountMapping"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/globalaccountmapping.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/GlobalAccountMapping.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/GlobalAccountMapping.json"
 description: |
   The `{{ table.name }}` table contains the global account mapping record details in your {{ integration.display_name }} account. 
 

--- a/_integration-schemas/netsuite/HcmJob.md
+++ b/_integration-schemas/netsuite/HcmJob.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "HcmJob"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/hcmjob.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/HcmJob.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/HcmJob.json"
 description: |
   {{ integration.permission-for-table | flatify }}
 

--- a/_integration-schemas/netsuite/InboundShipment.md
+++ b/_integration-schemas/netsuite/InboundShipment.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "InboundShipment"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/inboundshipment.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/InboundShipment.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/InboundShipment.json"
 description: |
   The `{{ table.name }}` table contains info about inbound shipments in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/InventoryNumber.md
+++ b/_integration-schemas/netsuite/InventoryNumber.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "InventoryNumber"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/inventorynumber.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/InventoryNumber.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/InventoryNumber.json"
 description: |
   The `{{ table.name }}` table contains info about the serial or lot numbers in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Issue.md
+++ b/_integration-schemas/netsuite/Issue.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Issue"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/issue.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Issue.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Issue.json"
 description: |
   The `{{ table.name }}` table contains info about the support cases in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ItemAccountMapping.md
+++ b/_integration-schemas/netsuite/ItemAccountMapping.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ItemAccountMapping"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/itemaccountmapping.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemAccountMapping.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemAccountMapping.json"
 description: |
   The `{{ table.name }}` table contains details about the item account mapping record in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ItemDemandPlan.md
+++ b/_integration-schemas/netsuite/ItemDemandPlan.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ItemDemandPlan"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/itemdemandplan.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemDemandPlan.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemDemandPlan.json"
 description: |
   The `{{ table.name }}` table contains info about item demand plans in your {{ integration.display_name }} account. An item demand plan transaction stores the quantity expected to be needed, during specified time periods, for an item.
 

--- a/_integration-schemas/netsuite/ItemRevision.md
+++ b/_integration-schemas/netsuite/ItemRevision.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ItemRevision"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/itemrevision.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemRevision.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemRevision.json"
 description: |
   The `{{ table.name }}` table contains info about item revisions in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ItemSupplyPlan.md
+++ b/_integration-schemas/netsuite/ItemSupplyPlan.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ItemSupplyPlan"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/itemsupplyplan.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemSupplyPlan.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ItemSupplyPlan.json"
 description: |
   The `{{ table.name }}` table contains info about the item supply plans in your {{ integration.display_name }} account. An item supply plan lists the purchase orders or work orders required to ensure that item quantity meets expected demand.
 

--- a/_integration-schemas/netsuite/Job.md
+++ b/_integration-schemas/netsuite/Job.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Job"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/job.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Job.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Job.json"
 description: |
   The `{{ table.name }}` table contains info about the projects in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/JobStatus.md
+++ b/_integration-schemas/netsuite/JobStatus.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "JobStatus"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/jobstatus.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/JobStatus.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/JobStatus.json"
 description: |
   The `{{ table.name }}` table contains info about the statuses that can be applied to projects in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/JobType.md
+++ b/_integration-schemas/netsuite/JobType.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "JobType"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/jobtype.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/JobType.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/JobType.json"
 description: |
   The `{{ table.name }}` table contains info about the types that can be applied to projects in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ManufacturingCostTemplate.md
+++ b/_integration-schemas/netsuite/ManufacturingCostTemplate.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ManufacturingCostTemplate"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/manufacturingcosttemplate.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingCostTemplate.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingCostTemplate.json"
 description: |
   The `{{ table.name }}` table contains info about the manufacturing cost templates in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ManufacturingOperationTask.md
+++ b/_integration-schemas/netsuite/ManufacturingOperationTask.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ManufacturingOperationTask"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/manufacturingoperationtask.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingOperationTask.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingOperationTask.json"
 description: |
   The `{{ table.name }}` table contains info about manufacturing operation tasks in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ManufacturingRouting.md
+++ b/_integration-schemas/netsuite/ManufacturingRouting.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ManufacturingRouting"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/manufacturingrouting.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingRouting.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ManufacturingRouting.json"
 description: |
   The `{{ table.name }}` table contains info about the manufacturing routing templates in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Message.md
+++ b/_integration-schemas/netsuite/Message.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Message"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/message.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Message.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Message.json"
 description: |
   The `{{ table.name }}` table contains info about the messages in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Note.md
+++ b/_integration-schemas/netsuite/Note.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Note"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/note.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Note.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Note.json"
 description: |
   The `{{ table.name }}` table contains info about the notes in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/NoteType.md
+++ b/_integration-schemas/netsuite/NoteType.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "NoteType"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/notetype.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/NoteType.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/NoteType.json"
 description: |
   The `{{ table.name }}` table contains info about the types that can be applied to notes in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Opportunity.md
+++ b/_integration-schemas/netsuite/Opportunity.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Opportunity"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/opportunity.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Opportunity.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Opportunity.json"
 description: |
   The `{{ table.name }}` table contains info about the opportunities in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/OtherNameCategory.md
+++ b/_integration-schemas/netsuite/OtherNameCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "OtherNameCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/othernamecategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/OtherNameCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/OtherNameCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the other name categories in your {{ integration.display_name }} account. Other name category values are used on other name records to categorize them. The list of other name records is a collection of records for people or companies who are not vendors, customers, or employees.
 

--- a/_integration-schemas/netsuite/PartnerCategory.md
+++ b/_integration-schemas/netsuite/PartnerCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PartnerCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/partnercategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PartnerCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PartnerCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the categories that can be applied to partners in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Paycheck.md
+++ b/_integration-schemas/netsuite/Paycheck.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Paycheck"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/paycheck.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Paycheck.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Paycheck.json"
 description: |
   The `{{ table.name }}` table contains info about the paycheck records in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/PaymentMethod.md
+++ b/_integration-schemas/netsuite/PaymentMethod.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PaymentMethod"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/paymentmethod.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PaymentMethod.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PaymentMethod.json"
 description: |
   The `{{ table.name }}` table contains info about the customer payment methods in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/PayrollItem.md
+++ b/_integration-schemas/netsuite/PayrollItem.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PayrollItem"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/payrollitem.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PayrollItem.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PayrollItem.json"
 description: |
   The `{{ table.name }}` table contains info about the payroll items, or payroll transaction line items, in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/PhoneCall.md
+++ b/_integration-schemas/netsuite/PhoneCall.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PhoneCall"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/payrollitem.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PhoneCall.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PhoneCall.json"
 description: |
   The `{{ table.name }}` table contains info about the phone call records in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/PriceLevel.md
+++ b/_integration-schemas/netsuite/PriceLevel.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PriceLevel"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/pricelevel.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PriceLevel.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PriceLevel.json"
 description: |
   The `{{ table.name }}` table contains info about the price level list in your {{ integration.display_name }} account. Price level defines a list of values that are used by opportunity and item records to set the price level for a specific item.
 

--- a/_integration-schemas/netsuite/PricingGroup.md
+++ b/_integration-schemas/netsuite/PricingGroup.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PricingGroup"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/pricinggroup.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PricingGroup.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PricingGroup.json"
 description: |
   The `{{ table.name }}` table contains info about the pricing groups in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ProjectTask.md
+++ b/_integration-schemas/netsuite/ProjectTask.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ProjectTask"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/projecttask.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ProjectTask.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ProjectTask.json"
 description: |
   The `{{ table.name }}` table contains info about the project tasks in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/PromotionCode.md
+++ b/_integration-schemas/netsuite/PromotionCode.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "PromotionCode"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/promotioncode.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PromotionCode.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/PromotionCode.json"
 description: |
   The `{{ table.name }}` table contains info about the promotion codes in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/ResourceAllocation.md
+++ b/_integration-schemas/netsuite/ResourceAllocation.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "ResourceAllocation"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/resourceallocation.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ResourceAllocation.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/ResourceAllocation.json"
 description: |
   The `{{ table.name }}` table contains info about resource allocations, or employee time reservations, in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/RevRecSchedule.md
+++ b/_integration-schemas/netsuite/RevRecSchedule.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "RevRecSchedule"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/revrecschedule.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/RevRecSchedule.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/RevRecSchedule.json"
 description: |
   The `{{ table.name }}` table contains info about the revenue recognition schedules in your {{ integration.display_name }} account. A revenue recognition schedule indicates the posting periods in which revenue should be recognized, and the amount to be recognized in each period, for an item sale.
 

--- a/_integration-schemas/netsuite/RevRecTemplate.md
+++ b/_integration-schemas/netsuite/RevRecTemplate.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "RevRecTemplate"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/revrectemplate.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/RevRecTemplate.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/RevRecTemplate.json"
 description: |
   The `{{ table.name }}` table contains info about the revenue recognition templates in your {{ integration.display_name }} account. A revenue recognition template indicates how revenue from associated items should be posted.
 

--- a/_integration-schemas/netsuite/SalesRole.md
+++ b/_integration-schemas/netsuite/SalesRole.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "SalesRole"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/salesrole.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SalesRole.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SalesRole.json"
 description: |
   The `{{ table.name }}` table contains info about the sales roles in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/SalesTaxItem.md
+++ b/_integration-schemas/netsuite/SalesTaxItem.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "SalesTaxItem"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/salestaxitem.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SalesTaxItem.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SalesTaxItem.json"
 description: |
   The `{{ table.name }}` table contains info about the sales tax items in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/SiteCategory.md
+++ b/_integration-schemas/netsuite/SiteCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "SiteCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/sitecategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SiteCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SiteCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the categories used to organize your website.
 

--- a/_integration-schemas/netsuite/Solution.md
+++ b/_integration-schemas/netsuite/Solution.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Solution"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/solution.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Solution.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Solution.json"
 description: |
   The `{{ table.name }}` table contains info about the solutions, or answers to customer issues, in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Subsidiary.md
+++ b/_integration-schemas/netsuite/Subsidiary.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Subsidiary"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/subsidiary.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Subsidiary.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Subsidiary.json"
 description: |
   The `{{ table.name }}` table contains info about the subsidiary records in your {{ integration.display_name }} account. A subsidiary represents a separate company within your global organization.
 

--- a/_integration-schemas/netsuite/SupportCase.md
+++ b/_integration-schemas/netsuite/SupportCase.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "SupportCase"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/supportcase.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SupportCase.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/SupportCase.json"
 description: |
   The `{{ table.name }}` table contains info about the support cases in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Task.md
+++ b/_integration-schemas/netsuite/Task.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Task"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/task.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Task.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Task.json"
 description: |
   The `{{ table.name }}` table contains info about the tasks in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/TaxGroup.md
+++ b/_integration-schemas/netsuite/TaxGroup.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "TaxGroup"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/taxgroup.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TaxGroup.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TaxGroup.json"
 description: |
   The `{{ table.name }}` table contains info about the tax groups in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/TaxType.md
+++ b/_integration-schemas/netsuite/TaxType.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "TaxType"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/taxtype.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TaxType.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TaxType.json"
 description: |
   The `{{ table.name }}` table contains info about the tax types in your {{ integration.display_name }} account. A tax type determines where the tax paid or collected is tracked on the balance sheet. The balance sheet account to which {{ integration.display_name }} posts the collection or payment of tax is called the tax control account.
 

--- a/_integration-schemas/netsuite/Term.md
+++ b/_integration-schemas/netsuite/Term.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Term"
 doc-link: ""
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Term.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Term.json"
 description: |
   The `{{ table.name }}` table contains info about the terms in your {{ integration.display_name }} account. Terms are used to specify when payment is due on customer invoices.
 

--- a/_integration-schemas/netsuite/TimeBill.md
+++ b/_integration-schemas/netsuite/TimeBill.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "TimeBill"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/timebill.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeBill.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeBill.json"
 description: |
   The `{{ table.name }}` table contains info about the time transactions in your {{ integration.display_name }} account. Also known as time bills, these transactions records the hours worked by an employee. This transaction can be used to record billable hours and invoice customers.
 

--- a/_integration-schemas/netsuite/TimeEntry.md
+++ b/_integration-schemas/netsuite/TimeEntry.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "TimeEntry"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/timeentry.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeEntry.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeEntry.json"
 description: |
   The `{{ table.name }}` table contains info about the time entries in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/TimeSheet.md
+++ b/_integration-schemas/netsuite/TimeSheet.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "TimeSheet"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/timesheet.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeSheet.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/TimeSheet.json"
 description: |
   The `{{ table.name }}` table contains info about the time sheets in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Transaction.md
+++ b/_integration-schemas/netsuite/Transaction.md
@@ -3,7 +3,7 @@ tap: "netsuite"
 version: "1.0"
 
 name: "Transaction"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Transaction.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Transaction.json"
 description: |
   The `{{ table.name }}` table contains info about transactions.
 

--- a/_integration-schemas/netsuite/UnitsType.md
+++ b/_integration-schemas/netsuite/UnitsType.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "UnitsType"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/unitstype.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/UnitsType.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/UnitsType.json"
 description: |
   The `{{ table.name }}` table contains info about the unit types, or Units of Measure, in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/Usage.md
+++ b/_integration-schemas/netsuite/Usage.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Usage"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/usage.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Usage.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Usage.json"
 description: |
   The `{{ table.name }}` table contains info about the subscription billing lines in your {{ integration.display_name }} account. For example: Money, time, cellular data, internet data, etc.
 

--- a/_integration-schemas/netsuite/Vendor.md
+++ b/_integration-schemas/netsuite/Vendor.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Vendor"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/vendor.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Vendor.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Vendor.json"
 description: |
   The `{{ table.name }}` table contains info about the vendors in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/VendorCategory.md
+++ b/_integration-schemas/netsuite/VendorCategory.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "VendorCategory"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/vendorcategory.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/VendorCategory.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/VendorCategory.json"
 description: |
   The `{{ table.name }}` table contains info about the categories that can be applied to vendors in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/WinLossReason.md
+++ b/_integration-schemas/netsuite/WinLossReason.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "WinLossReason"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/winlossreason.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/WinLossReason.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/WinLossReason.json"
 description: |
   The `{{ table.name }}` table contains info about the win/loss reasons in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/campaign.md
+++ b/_integration-schemas/netsuite/campaign.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Campaign"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/campaign.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Campaign.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Campaign.json"
 description: |
   The `{{ table.name }}` table contains info about the campaigns in your {{ integration.display_name }} account. Campaigns are used to manage marketing initiatives.
 

--- a/_integration-schemas/netsuite/charge.md
+++ b/_integration-schemas/netsuite/charge.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Charge"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/charge.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Charge.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Charge.json"
 description: |
   The `{{ table.name }}` table contains info about the charges in your {{ integration.display_name }} account, which represent billable amounts that your clients must pay.
 

--- a/_integration-schemas/netsuite/contact.md
+++ b/_integration-schemas/netsuite/contact.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Contact"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/contact.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Contact.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Contact.json"
 description: |
   The `{{ table.name }}` table contains info about contacts.
 

--- a/_integration-schemas/netsuite/custom_record.md
+++ b/_integration-schemas/netsuite/custom_record.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "customrecord_[custom_record_name]"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/customrecord.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Transaction.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Transaction.json"
 description: |
   For each custom record type in {{ integration.display_name }}, a table for that custom record type will be available for selection in Stitch.
 

--- a/_integration-schemas/netsuite/employee.md
+++ b/_integration-schemas/netsuite/employee.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Employee"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/employee.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Employee.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Employee.json"
 description: |
   The `{{ table.name }}` table contains info about the employees in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/file.md
+++ b/_integration-schemas/netsuite/file.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "File"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/file.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/File.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/File.json"
 description: |
   The `{{ table.name }}` table contains info about the files in your {{ integration.display_name }} File Cabinet.
 

--- a/_integration-schemas/netsuite/item.md
+++ b/_integration-schemas/netsuite/item.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Item"
 doc-link: ""
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Item.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Item.json"
 description: |
   The `{{ table.name }}` table contains info about items.
 

--- a/_integration-schemas/netsuite/location.md
+++ b/_integration-schemas/netsuite/location.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Location"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/location.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Location.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Location.json"
 description: |
   The `{{ table.name }}` table contains info about locations.
 

--- a/_integration-schemas/netsuite/nexus.md
+++ b/_integration-schemas/netsuite/nexus.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Nexus"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/nexus.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Nexus.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Nexus.json"
 description: |
   The `{{ table.name }}` table contains info about the tax jurisdictions - or nexus - in your {{ integration.display_name }} account. A nexus is a tax jurisdiction, usually defined at the country level. 
 

--- a/_integration-schemas/netsuite/partner.md
+++ b/_integration-schemas/netsuite/partner.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Partner"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/partner.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Partner.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Partner.json"
 description: |
   The `{{ table.name }}` table contains info about the partners in your {{ integration.display_name }} account.
 

--- a/_integration-schemas/netsuite/topic.md
+++ b/_integration-schemas/netsuite/topic.md
@@ -4,7 +4,7 @@ version: "1.0"
 
 name: "Topic"
 doc-link: "https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/record/topic.html"
-singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Topic.json"
+# singer-schema: "https://github.com/singer-io/tap-netsuite/blob/master/tap_netsuite/schemas/Topic.json"
 description: |
   The `{{ table.name }}` table contains info about the topics used to organize knowledge base solutions in your {{ integration.display_name }} account.
 

--- a/_saas-integrations/netsuite/v1/netsuite-v1.md
+++ b/_saas-integrations/netsuite/v1/netsuite-v1.md
@@ -274,7 +274,9 @@ replication-sections:
       In this section:
 
       {% for section in page.replication-sections %}
+      {% if section.title %}
       - [{{ section.title | flatify }}](#{{ section.anchor }})
+      {% endif %}
       {% endfor %}
 
   - title: "Custom records"
@@ -286,11 +288,11 @@ replication-sections:
       - title: "Table names for custom record types"
         anchor: "custom-record-types-table-names"
         content: |
-          Custom record tables are named `customrecord_[custom_record_name]`, where `[custom_record_name]` is the value of the ID field in the Custom Record Setup page in {{ integration.display_name }}.
+          Custom record tables are named `custrecord_[custom_record_name]`, where `[custom_record_name]` is the value of the ID field in the Custom Record Setup page in {{ integration.display_name }}.
 
-          For example: If a custom record were named `promo discount` in {{ integration.display_name }}, the corresponding table for those records would be named `customrecord_promo_discount`.
+          For example: If a custom record were named `promo discount` in {{ integration.display_name }}, the corresponding table for those records would be named `custrecord_promo_discount`.
 
-          If the ID field in the Custom Record Setup page is left blank, {{ integration.display_name }} will auto-assign a numerical ID to the record. In Stitch, the table for the custom record would then be something like `customrecord_123`, where `123` is the ID auto-assigned by {{ integration.display_name }}.
+          If the ID field in the Custom Record Setup page is left blank, {{ integration.display_name }} will auto-assign a numerical ID to the record. In Stitch, the table for the custom record would then be something like `custrecord_123`, where `123` is the ID auto-assigned by {{ integration.display_name }}.
 
       - title: "Replication methods for custom record types"
         anchor: "custom-record-type-replication"

--- a/_troubleshooting/data-discrepancies/data-discrepancy-troubleshooting-guide.md
+++ b/_troubleshooting/data-discrepancies/data-discrepancy-troubleshooting-guide.md
@@ -179,12 +179,12 @@ If the table in question is set to use Key-based Incremental Replication, keep i
 1. Stitch won't capture [hard deletes]({{ link.replication.key-based-incremental | prepend: site.baseurl | append: "#limitation-2--hard-deletes-unsupported" }}).
 2. Replication Key columns with `NULL` values are only replicated during an integration's initial replication job.
 3. Records that are updated over time should use a modification timestamp to ensure updates are captured.
-4. [Mongo Replication Keys]({{ link.replication.mongo-rep-keys | prepend: site.baseurl }}) have additional considerations. For example: Multiple data types in the Replication Key column can lead to missing data.
-5. BigQuery destinations only support [**Append-Only Incremental Replication**]({{ link.replication.rep-methods | prepend: site.baseurl | append:"#append-only-incremental-replication" }}). What looks like duplicate data may actually be updated records being appended to a table.
+4. [MongoDB Replication Keys]({{ link.replication.mongo-rep-keys | prepend: site.baseurl }}) have additional considerations. For example: Multiple data types in the Replication Key column can lead to missing data.
+5. Append-Only destinations. What looks like duplicate data may actually be updated records being appended to a table. Refer to the [Understanding loading behavior guide]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}) for more info and examples.
 
 ---
 
-## Contacting Support
+## Contacting support
 
 If the discrepancy can’t be explained by any of the points above, reach out to support. Depending on the type of discrepancy, we'll ask you to provide us some information that will help us investigate.
 

--- a/_webhook-integrations/webhook-integrations.md
+++ b/_webhook-integrations/webhook-integrations.md
@@ -23,14 +23,12 @@ sections:
 
       If you want to replay historical webhook data and send it to Stitch, contact that app's support for assistance.
 
-  - title: "Append-Only Replication and querying"
+  - title: "Append-Only loading and querying"
     anchor: "append-only-replication"
     content: |
-      The majority of Stitch's webhook integrations replicate data in an Append-Only fashion. {{ site.data.tooltips.append-only-rep }}
+      The majority of Stitch's webhook integrations load data in an Append-Only fashion. {{ site.data.tooltips.append-only }} Refer to the [Understanding loading behavior guide]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}) for more info and examples.
 
       While data stored using this method can provide insights and historical details about how rows change over time, grabbing the latest data does require a different querying strategy than usual. [Refer to the Querying Append-Only Tables guide for more details.]({{ link.replication.append-only-querying | prepend: site.baseurl }})
-
-      See the Replication Methods guide for [an example and in-depth explanation of Append-Only replication]({{ link.replication.rep-methods | prepend: site.baseurl | append:"##-only-incremental-replication" }}).
 
   - title: "All webhook integrations"
     anchor: "all-webhook-integrations"

--- a/sass/_layout.scss
+++ b/sass/_layout.scss
@@ -184,7 +184,8 @@ body {
       background: linear-gradient(180deg, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 90%, rgba(255,255,255,0) 100%);
       min-height: 6.35em;
       z-index: 2;
-      width: 100%;
+      width: 52em;
+      max-width: 100%;
 
       .breadcrumb-container {
         width: 100%;

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -190,9 +190,10 @@ body {
   background: linear-gradient(180deg, white 0%, white 90%, rgba(255, 255, 255, 0) 100%);
   min-height: 6.35em;
   z-index: 2;
-  width: 100%;
+  width: 52em;
+  max-width: 100%;
 }
-/* line 189, ../sass/_layout.scss */
+/* line 190, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container {
   width: 100%;
   position: absolute;
@@ -203,52 +204,52 @@ body {
   margin-bottom: 0.5em;
   font-weight: 700;
 }
-/* line 202, ../sass/_layout.scss */
+/* line 203, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .dropdown-menu li a, #main .content-column .breadbox .breadcrumb-container .dropdown-menu li.active {
   padding: 0.5em;
   color: #202020;
 }
-/* line 208, ../sass/_layout.scss */
+/* line 209, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .dropdown-menu li a:hover {
   color: #FFFFFF;
 }
-/* line 214, ../sass/_layout.scss */
+/* line 215, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container strong {
   color: #0675c1;
 }
-/* line 218, ../sass/_layout.scss */
+/* line 219, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container a {
   color: #202020;
 }
-/* line 221, ../sass/_layout.scss */
+/* line 222, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container a:hover {
   color: #888888;
   text-decoration: none;
 }
-/* line 227, ../sass/_layout.scss */
+/* line 228, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .menu-left,
 #main .content-column .breadbox .breadcrumb-container .menu-right {
   display: inline-block;
   vertical-align: bottom;
 }
-/* line 233, ../sass/_layout.scss */
+/* line 234, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .menu-left {
   font-size: 0.8rem;
   letter-spacing: 0.3px;
   width: calc(100% - 12em);
   line-height: 1.4;
 }
-/* line 240, ../sass/_layout.scss */
+/* line 241, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .menu-right {
   padding-bottom: 0.25em;
 }
-/* line 243, ../sass/_layout.scss */
+/* line 244, ../sass/_layout.scss */
 #main .content-column .breadbox .breadcrumb-container .menu-right .btn {
   width: 10em;
   min-width: fit-content;
 }
 
-/* line 253, ../sass/_layout.scss */
+/* line 254, ../sass/_layout.scss */
 .columns {
   list-style-type: none;
   list-style-position: inside;
@@ -257,14 +258,14 @@ body {
   -moz-columns: 2;
 }
 @media screen and (max-width: 1100px) {
-  /* line 253, ../sass/_layout.scss */
+  /* line 254, ../sass/_layout.scss */
   .columns {
     columns: 1;
     -webkit-columns: 1;
     -moz-columns: 1;
   }
 }
-/* line 269, ../sass/_layout.scss */
+/* line 270, ../sass/_layout.scss */
 .columns.more li:last-of-type a {
   border: 1px solid #999999;
   border-radius: 0;
@@ -284,39 +285,39 @@ body {
   margin-top: 0.5rem;
   text-transform: uppercase;
 }
-/* line 288, ../sass/_layout.scss */
+/* line 289, ../sass/_layout.scss */
 .columns.more li:last-of-type a:hover {
   background: #0675c1;
   text-decoration: none;
 }
-/* line 292, ../sass/_layout.scss */
+/* line 293, ../sass/_layout.scss */
 .columns.more li:last-of-type a:focus {
   text-decoration: none;
   background: #0675c1;
 }
 
-/* line 302, ../sass/_layout.scss */
+/* line 303, ../sass/_layout.scss */
 footer {
   text-align: left;
   color: #969696;
   margin: 2em 0;
   line-height: 1.6em;
 }
-/* line 308, ../sass/_layout.scss */
+/* line 309, ../sass/_layout.scss */
 footer .site-generation {
   float: left;
 }
-/* line 312, ../sass/_layout.scss */
+/* line 313, ../sass/_layout.scss */
 footer .links {
   float: right;
 }
-/* line 314, ../sass/_layout.scss */
+/* line 315, ../sass/_layout.scss */
 footer .links p {
   font-weight: 600;
   text-align: right;
   margin-bottom: 0px;
 }
-/* line 320, ../sass/_layout.scss */
+/* line 321, ../sass/_layout.scss */
 footer .links ul {
   list-style: none;
   padding: 0px;


### PR DESCRIPTION
This PR:

- Corrects the copy for reset table/integration buttons (ex: `Reset Keys` > `Reset Integration/Table`)
- Updates links to Append-Only guides
- Updates external AWS link to correct region documentation
- Corrects name of custom record tables in NetSuite v1
- Removes links to NetSuite repo
- Removes `end_time` attribute from Facebook `campaigns` table
- Updates the release status for MongoDB v1 to `released`
- Fixes anchor links in BigQuery migration guide
- Fixes display of schemas in Google Ads docs