### PR TITLE
MSSQL/Add MONEY and SMALLMONEY data type support

### DIFF
--- a/_data/taps/extraction/data-types/mssql/specific.yml
+++ b/_data/taps/extraction/data-types/mssql/specific.yml
@@ -22,3 +22,9 @@
 
 - name: "datetimeoffset"
   doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql?view=sql-server-2017"
+
+- name: "money"
+  doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/money-and-smallmoney-transact-sql?view=sql-server-ver15"
+
+- name: "smallmoney"
+  doc-link: "https://docs.microsoft.com/en-us/sql/t-sql/data-types/money-and-smallmoney-transact-sql?view=sql-server-ver15"

--- a/_data/taps/extraction/data-types/mssql/v1.yml
+++ b/_data/taps/extraction/data-types/mssql/v1.yml
@@ -70,6 +70,10 @@ longvarchar:
 longnvarchar:
   stitch-type: "string"
 
+money:
+  stitch-type: "integer"
+  doc-link: &money-doc-link "https://docs.microsoft.com/en-us/sql/t-sql/data-types/money-and-smallmoney-transact-sql?view=sql-server-ver15"  
+
 nchar:
   stitch-type: "string"
   doc-link: &nchar-doc-link "https://docs.microsoft.com/en-us/sql/t-sql/data-types/nchar-and-nvarchar-transact-sql?view=sql-server-2017"
@@ -98,7 +102,11 @@ smalldatetime:
 
 smallint:
   stitch-type: "integer"
-  doc-link: *int-doc-link     
+  doc-link: *int-doc-link    
+
+smallmoney:
+  stitch-type: "integer"
+  doc-link: *money-doc-link   
 
 time:
   stitch-type: "string"


### PR DESCRIPTION
This PR adds the `MONEY` and `SMALLMONEY` data types to Microsoft SQL Server-based integrations.