### PR TITLE
Shopify/v1 - Results per page property

### DIFF
--- a/_developer-files/connect/api/objects/form-properties/sources/saas/shopify-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/saas/shopify-object.md
@@ -45,6 +45,12 @@ object-attributes:
   #   description: ""
   #   value: ""
 
+  # - name: "results_per_page"
+  #   type: "string"
+  #   required: "false"
+  #   description: "The amount of results to load per page."
+  #   value: "175"
+
   - name: "shop"
     type: "string"
     required: true


### PR DESCRIPTION
Added the `results_per_page` property to the connect form. I commented it out because this isn't a property that the user will touch. It's only there for the sources team to adjust for a client if they are having trouble downloading the normal amount of results at a time.