### PR TITLE
removing a spot where we say Google twice in a row

### DIFF
--- a/_destinations/bigquery/v2/bigquery-setup-v2.md
+++ b/_destinations/bigquery/v2/bigquery-setup-v2.md
@@ -64,7 +64,7 @@ requirements:
 
       - **Enabled billing for the GCP project**. The project must have [billing enabled and an attached credit card]({{ site.data.destinations.bigquery.resource-links.enable-billing }}). This is required for Stitch to successfully load data.
 
-      - **An existing Google {{ destination.display_name }} instance in the GCP project.** Stitch will not create an instance for you.
+      - **An existing {{ destination.display_name }} instance in the GCP project.** Stitch will not create an instance for you.
 
   - item: |
       **Permissions in the GCP project that allow you to create Identity Access Management (IAM) service accounts.** Stitch uses a service account during the replication process to load data into {{ destination.display_name }}. Refer to [Google's documentation]({{ site.data.destinations.bigquery.resource-links.service-accounts }}){:target="new"} for more info about service accounts and the permissions required to create them.


### PR DESCRIPTION
Fixes this little typo: 

<img width="883" alt="Screen Shot 2020-01-22 at 3 05 16 PM" src="https://user-images.githubusercontent.com/8235584/72929898-c0272b00-3d28-11ea-9b29-ba199964dd72.png">
