### PR TITLE
Database Integrations - Limit database user table access

### DIFF
--- a/_data/taps/extraction/database-setup/user-privileges/mssql.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/mssql.yml
@@ -67,12 +67,12 @@ create-login-command: |
 create-user-command: |
   CREATE USER <stitch_username> FOR LOGIN 
 
+grant-select-on-table: |
+  GRANT SELECT ON <schema_name>.<table_name> TO <stitch_username>
+
 grant-select-command:
   all-tables: |
     GRANT SELECT to <stitch_username>
-
-  specific-tables: |
-    GRANT SELECT ON <schema_name>.<table_name> TO <stitch_username>
 
   change-tracking-tables: |
     GRANT VIEW CHANGE TRACKING ON <schema_name>.<table_name> TO <stitch_username>

--- a/_data/taps/extraction/database-setup/user-privileges/mssql.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/mssql.yml
@@ -62,17 +62,24 @@ microsoft-azure:
 # -------------------------- #
 
 create-login-command: |
-  CREATE LOGIN <stitch_username> WITH PASSWORD='<password>'
+  CREATE LOGIN <stitch_username> WITH PASSWORD='<password>';
 
 create-user-command: |
-  CREATE USER <stitch_username> FOR LOGIN 
+  CREATE USER <stitch_username> FOR LOGIN;
+  GO
 
 grant-select-on-table: |
-  GRANT SELECT ON <schema_name>.<table_name> TO <stitch_username>
+  GRANT SELECT ON <schema_name>.<table_name> TO <stitch_username>;
+  GO
+
+revoke-select: |
+  REVOKE SELECT FROM <stitch_username>
+  GO
 
 grant-select-command:
   all-tables: |
-    GRANT SELECT to <stitch_username>
+    GRANT SELECT TO <stitch_username>
 
   change-tracking-tables: |
-    GRANT VIEW CHANGE TRACKING ON <schema_name>.<table_name> TO <stitch_username>
+    GRANT VIEW CHANGE TRACKING ON <schema_name>.<table_name> TO <stitch_username>;
+    GO

--- a/_data/taps/extraction/database-setup/user-privileges/mysql.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/mysql.yml
@@ -131,3 +131,6 @@ grant-user-select-command: |
 
 grant-user-replication-command: |
   GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO '<stitch_username>'@'localhost';
+
+revoke-select: |
+  REVOKE SELECT ON *.* TO '<stitch_username>';

--- a/_data/taps/extraction/database-setup/user-privileges/mysql.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/mysql.yml
@@ -123,8 +123,11 @@ aurora-rds:
 create-user-command: |
   CREATE USER '<stitch_username>'@'localhost' IDENTIFIED BY '<password>';
 
+grant-select-on-table: |
+  GRANT SELECT ON '<database_name>'.'<table_name>' to '<stitch_username>'@'localhost';
+
 grant-user-select-command: |
   GRANT SELECT ON *.* TO '<stitch_username>';
 
 grant-user-replication-command: |
-  GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO '<stitch_username>';
+  GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO '<stitch_username>'@'localhost';

--- a/_data/taps/extraction/database-setup/user-privileges/oracle.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/oracle.yml
@@ -181,6 +181,9 @@ grant-create-session: |
 grant-select-all-tables: |
   GRANT SELECT ANY TABLE TO <stitch_username>
 
+revoke-select: |
+  REVOKE SELECT ANY TABLE FROM <stitch_username>
+
 grant-select-on-table: |
   GRANT SELECT ON <schema_name>.<table_name> to <stitch_username>
 

--- a/_data/taps/extraction/database-setup/user-privileges/oracle.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/oracle.yml
@@ -176,37 +176,37 @@ create-user-command: |
   CREATE USER STITCH IDENTIFIED BY <password>
   
 grant-create-session: |
-  GRANT CREATE SESSION TO STITCH
+  GRANT CREATE SESSION TO <stitch_username>
 
 grant-select-all-tables: |
-  GRANT SELECT ANY TABLE TO STITCH
+  GRANT SELECT ANY TABLE TO <stitch_username>
 
 grant-select-on-table: |
-  GRANT SELECT ON <schema_name>.<table_name> to STITCH
+  GRANT SELECT ON <schema_name>.<table_name> to <stitch_username>
 
 select-any-transaction: |
-  GRANT SELECT ANY TRANSACTION TO STITCH
+  GRANT SELECT ANY TRANSACTION TO <stitch_username>
 
 select-any-dictionary: |
-  GRANT SELECT ANY DICTIONARY TO STITCH
+  GRANT SELECT ANY DICTIONARY TO <stitch_username>
 
 grant-execute-catalog-role:
-  GRANT EXECUTE_CATALOG_ROLE TO STITCH
+  GRANT EXECUTE_CATALOG_ROLE TO <stitch_username>
 
 execute-dbms-logmnr:
-  GRANT EXECUTE ON DBMS_LOGMNR TO STITCH
+  GRANT EXECUTE ON DBMS_LOGMNR TO <stitch_username>
 
 execute-dbms-logmnr-d:
-  GRANT EXECUTE ON DBMS_LOGMNR_D TO STITCH
+  GRANT EXECUTE ON DBMS_LOGMNR_D TO <stitch_username>
 
 select-v-database: |
-  GRANT SELECT ON SYS.V_$DATABASE TO STITCH
+  GRANT SELECT ON SYS.V_$DATABASE TO <stitch_username>
 
 select-v-archived-log: |
-  GRANT SELECT ON SYS.V_$ARCHIVED_LOG TO STITCH
+  GRANT SELECT ON SYS.V_$ARCHIVED_LOG TO <stitch_username>
 
 select-logmnr-contents: |
-  GRANT SELECT ON SYS.V_$LOGMNR_CONTENTS TO STITCH
+  GRANT SELECT ON SYS.V_$LOGMNR_CONTENTS TO <stitch_username>
 
 grant-logmining-version-12: |
-  GRANT LOGMINING TO STITCH
+  GRANT LOGMINING TO <stitch_username>

--- a/_data/taps/extraction/database-setup/user-privileges/oracle.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/oracle.yml
@@ -23,10 +23,7 @@ defaults:
       Required to log into the {{ integration.display_name }} database.
 
     select: &select-reason |
-      Required to select data from the tables and columns you want to replicate.
-
-      - `SELECT ANY TABLE` grants `SELECT` privileges to any table in the connected database.
-      - `SELECT ON <SCHEMA.TABLE>` grants `SELECT` privileges only to the specified table.
+      Required to select data from specified tables.
 
     execute-dbms-logmnr: &execute-dbms-logmnr-reason |
       **Required to use Log-based Incremental Replication.** Allows the Stitch user to execute the `DBMS_LOGMNR` package for LogMiner.
@@ -184,8 +181,8 @@ grant-create-session: |
 grant-select-all-tables: |
   GRANT SELECT ANY TABLE TO STITCH
 
-grant-select-specific-tables: |
-  GRANT SELECT ON <SCHEMA>.<TABLE> to STITCH
+grant-select-on-table: |
+  GRANT SELECT ON <schema_name>.<table_name> to STITCH
 
 select-any-transaction: |
   GRANT SELECT ANY TRANSACTION TO STITCH

--- a/_data/taps/extraction/database-setup/user-privileges/postgres.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/postgres.yml
@@ -125,28 +125,28 @@ aurora-postgresql-rds:
 # -------------------------- #
 
 create-user-command-default: |
-  CREATE USER stitch WITH ENCRYPTED PASSWORD '<password>'
+  CREATE USER <stitch_username> WITH ENCRYPTED PASSWORD '<password>'
 
 grant-connect-on-database: |
-  GRANT CONNECT ON DATABASE <database_name> TO stitch
+  GRANT CONNECT ON DATABASE <database_name> TO <stitch_username>
 
 grant-schema-usage: |
-  GRANT USAGE ON SCHEMA <schema_name> TO stitch
+  GRANT USAGE ON SCHEMA <schema_name> TO <stitch_username>
 
 grant-select-on-table: |
-  GRANT SELECT ON <schema_name>.<table_name> TO stitch
+  GRANT SELECT ON <schema_name>.<table_name> TO <stitch_username>
 
 grant-select-on-tables: |
-  GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO stitch
+  GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO <stitch_username>
 
 alter-default-schema-privileges: |
-  ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO stitch
+  ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO <stitch_username>
 
 rds-grant-replication: |
-  GRANT rds_replication TO stitch
+  GRANT rds_replication TO <stitch_username>
 
 postgresql-create-replication-role: |
   CREATE ROLE replication REPLICATION LOGIN
 
 postgresql-grant-replication-role: |
-  GRANT replication TO stitch
+  GRANT replication TO <stitch_username>

--- a/_data/taps/extraction/database-setup/user-privileges/postgres.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/postgres.yml
@@ -133,6 +133,9 @@ grant-connect-on-database: |
 grant-schema-usage: |
   GRANT USAGE ON SCHEMA <schema_name> TO stitch
 
+grant-select-on-table: |
+  GRANT SELECT ON <schema_name>.<table_name> TO stitch
+
 grant-select-on-tables: |
   GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO stitch
 

--- a/_data/taps/extraction/database-setup/user-privileges/postgres.yml
+++ b/_data/taps/extraction/database-setup/user-privileges/postgres.yml
@@ -139,6 +139,9 @@ grant-select-on-table: |
 grant-select-on-tables: |
   GRANT SELECT ON ALL TABLES IN SCHEMA <schema_name> TO <stitch_username>
 
+revoke-select: |
+  REVOKE SELECT ON ALL TABLES IN SCHEMA <schema_name> FROM <stitch_username>
+
 alter-default-schema-privileges: |
   ALTER DEFAULT PRIVILEGES IN SCHEMA <schema_name> GRANT SELECT ON TABLES TO <stitch_username>
 

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -303,6 +303,7 @@ troubleshooting:
 ## Replication
   postgres-hot-standby: /troubleshooting/postgres-hot-standby-settings-replication
   salesforce-too-many-columns: /troubleshooting/salesforce-replication-too-many-columns
+  source-database-access-level-issue: /troubleshooting/too-many-tables-to-load-database-integration
 
 ## Error Notifications
   errors: /troubleshooting/error-notifications

--- a/_includes/integrations/databases/setup/db-users/mssql.html
+++ b/_includes/integrations/databases/setup/db-users/mssql.html
@@ -25,17 +25,13 @@ Depending on your setup and the access you grant to the Stitch database user, yo
    {{ site.data.taps.extraction.database-setup.user-privileges.mssql.create-user-command | strip }}
    ```
 
-2. Grant the Stitch user `SELECT` privileges. To grant `SELECT` privileges to all tables in the database, run this command:
+2. Grant the Stitch user `SELECT` privileges by running this command for every table you want to replicate: 
 
    ```sql
-   {{ site.data.taps.extraction.database-setup.user-privileges.mssql.grant-select-command.all-tables | strip }}
+   {{ site.data.taps.extraction.database-setup.user-privileges.mssql.grant-select-on-table | strip }}
    ```
 
-   If you want to limit the Stitch user to specific tables, run this command instead:
-
-   ```sql
-   {{ site.data.taps.extraction.database-setup.user-privileges.mssql.grant-select-command.specific-tables | strip }}
-   ```
+   Limiting access to only the tables you want to replicate ensures that the integration can complete discovery (a structure sync) in a timely manner. If you encounter issues in Stitch where tables aren't displaying, try limiting the Stitch database user's table access.
 
 {% unless integration.log-based-replication-master-instance == false %}
    **Note:** Column-level permissions are not supported for use with Log-based Incremental Replication. Restricting access to columns will cause replication issues.

--- a/_includes/integrations/databases/setup/db-users/mysql.html
+++ b/_includes/integrations/databases/setup/db-users/mysql.html
@@ -6,15 +6,15 @@
    {{ site.data.taps.extraction.database-setup.user-privileges.mysql.create-user-command | flatify | rstrip }}
    ```
 
-   Replace `[password]` with a secure password. {% if integration.ssh == true %}If using SSH, this can be different than the SSH password.{% endif %}
+   Replace `<password>` with a secure password. {% if integration.ssh == true %}If using SSH, this can be different than the SSH password.{% endif %}
 
-3. Grant the Stitch user `SELECT` privileges on the database:
+3. Grant the Stitch user `SELECT` privileges by running this command for every table you want to replicate: 
 
    ```sql
-   {{ site.data.taps.extraction.database-setup.user-privileges.mysql.grant-user-select-command | flatify | rstrip }}
+   {{ site.data.taps.extraction.database-setup.user-privileges.mysql.grant-select-on-table | flatify | rstrip }}
    ```
 
-   To restrict the Stitch user from accessing data in specific objects, you can instead run `GRANT` commands that only allow access to the data you permit.
+   Limiting access to only the tables you want to replicate ensures that the integration can complete discovery (a structure sync) in a timely manner. If you encounter issues in Stitch where tables aren't displaying, try limiting the Stitch database user's table access.
 
 {% unless integration.log-based-replication-master-instance == false %}
    **Note:** Column-level permissions are not supported for use with Log-based Incremental Replication. Restricting access to columns will cause replication issues.

--- a/_includes/integrations/databases/setup/db-users/oracle.html
+++ b/_includes/integrations/databases/setup/db-users/oracle.html
@@ -12,19 +12,13 @@
    {{ site.data.taps.extraction.database-setup.user-privileges.oracle.grant-create-session | flatify | rstrip }}
    ```
 
-4. Grant the Stitch user `SELECT` privileges. This can be done one of two ways: Granting access to all tables, or only granting access to specific tables you want to replicate.
+4. Grant the Stitch user `SELECT` privileges by running this command for every table you want to replicate:
 
-   - To grant Stitch access **to all tables**, run:
+   ```sql
+   {{ site.data.taps.extraction.database-setup.user-privileges.oracle.grant-select-on-table | flatify | rstrip }}
+   ```
 
-     ```sql
-     {{ site.data.taps.extraction.database-setup.user-privileges.oracle.grant-select-all-tables | flatify | rstrip }}
-     ```
-
-   - To grant Stitch access **to specific tables**, run the following command for each table you want to replicate. Replace `<SCHEMA>` and `<TABLE>` with the name of the schema and table, respectively:
-
-     ```sql
-     {{ site.data.taps.extraction.database-setup.user-privileges.oracle.grant-select-specific-tables | flatify | rstrip }}
-     ```
+   Limiting access to only the tables you want to replicate ensures that the integration can complete discovery (a structure sync) in a timely manner. If you encounter issues in Stitch where tables aren't displaying, try limiting the Stitch database user's table access.
 
 {% capture log-based-replication-privileges %}
 If you want to use Log-based Incremental Replication, you'll also need to grant additional permissions to the Stitch user:

--- a/_includes/integrations/databases/setup/db-users/oracle.html
+++ b/_includes/integrations/databases/setup/db-users/oracle.html
@@ -1,6 +1,6 @@
 
 1. If you aren't already, log into your database as a user with `CREATE USER` and `GRANT` privileges.
-2. Run the following command to create the Stitch database user, replacing `<password>` with a secure password:
+2. Run the following command to create the Stitch database user, replacing `<stitch_username>` with the name of the database user and `<password>` with a secure password:
 
    ```sql
    {{ site.data.taps.extraction.database-setup.user-privileges.oracle.create-user-command | flatify | rstrip }}

--- a/_includes/integrations/databases/setup/db-users/postgres.html
+++ b/_includes/integrations/databases/setup/db-users/postgres.html
@@ -6,25 +6,25 @@ Your organization may require a different process, but the simplest way to creat
 **Note**: The user performing this step should also own the schema(s) that Stitch is being granted access to.
 
 1. Log into your database.
-2. Create a database user named `stitch`, replacing `<password>` with a password:
+2. Create the database user, replacing `<stitch_username>` with the name of the database user and `<password>` with a password:
 
    ```sql
    {{ postgres-setup.create-user-command-default | strip }}
    ```
 
-3. Grant the `stitch` user `CONNECT` privileges to the database, replacing `<database_name>` with the name of a database you want to connect Stitch to:
+3. Grant the database user `CONNECT` privileges to the database, replacing `<database_name>` with the name of a database you want to connect Stitch to:
 
    ```sql
    {{ postgres-setup.grant-connect-on-database | strip }}
    ```
 
-4. Grant the `stitch` user schema usage privileges, replacing `<schema_name>` with the name of a schema you want to replicate data from:
+4. Grant the database user schema usage privileges, replacing `<schema_name>` with the name of a schema you want to replicate data from:
 
    ```sql
    {{ postgres-setup.grant-schema-usage | strip }}
    ```
 
-5. Grant the `stitch` user `SELECT` privileges by running this command for every table you want to replicate: 
+5. Grant the database user `SELECT` privileges by running this command for every table you want to replicate: 
 
    ```sql
    {{ postgres-setup.grant-select-on-table | strip }}
@@ -33,7 +33,7 @@ Your organization may require a different process, but the simplest way to creat
    Limiting access to only the tables you want to replicate ensures that the integration can complete discovery (a structure sync) in a timely manner. If you encounter issues in Stitch where tables aren't displaying, try limiting the Stitch database user's table access.
 
 
-6. Alter the schema's default privileges to grant `SELECT` privileges on tables to `stitch`. This is required to ensure that objects created in the schema after connecting to Stitch will remain accessible to the `stitch` user:
+6. Alter the schema's default privileges to grant `SELECT` privileges on tables to the database user. This is required to ensure that objects created in the schema after connecting to Stitch will remain accessible to the `stitch` user:
 
    ```sql
    {{ postgres-setup.alter-default-schema-privileges | strip }}

--- a/_includes/integrations/databases/setup/db-users/postgres.html
+++ b/_includes/integrations/databases/setup/db-users/postgres.html
@@ -24,11 +24,14 @@ Your organization may require a different process, but the simplest way to creat
    {{ postgres-setup.grant-schema-usage | strip }}
    ```
 
-5. Grant the `stitch` user `SELECT` privileges on the tables in the schema:
+5. Grant the `stitch` user `SELECT` privileges by running this command for every table you want to replicate: 
 
    ```sql
-   {{ postgres-setup.grant-select-on-tables | strip }}
+   {{ postgres-setup.grant-select-on-table | strip }}
    ```
+
+   Limiting access to only the tables you want to replicate ensures that the integration can complete discovery (a structure sync) in a timely manner. If you encounter issues in Stitch where tables aren't displaying, try limiting the Stitch database user's table access.
+
 
 6. Alter the schema's default privileges to grant `SELECT` privileges on tables to `stitch`. This is required to ensure that objects created in the schema after connecting to Stitch will remain accessible to the `stitch` user:
 

--- a/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
+++ b/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
@@ -1,5 +1,5 @@
 ---
-title: Unable to Load Tables due to Source Database Access Level
+title: Unable to Load Tables Due to Source Database Access Level
 keywords: tables to replicate, unable to load tables, table issues
 permalink: /troubleshooting/too-many-tables-to-load-database-integration
 summary: "Mitigate issues with tables displaying in the Tables to Replicate tab by limiting the authorizing database user's access to source tables."

--- a/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
+++ b/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
@@ -1,0 +1,79 @@
+---
+title: Unable to Load Tables due to Source Database Access Level
+keywords: tables to replicate, unable to load tables, table issues
+permalink: /troubleshooting/too-many-tables-to-load-database-integration
+summary: "Mitigate issues with tables displaying in the Tables to Replicate tab by limiting the authorizing database user's access to source tables."
+layout: general
+toc: false
+
+key: "source-database-access-level-issue"
+
+type: "database-integration, replication"
+promote: "false"
+
+intro: |
+  If you're encountering issues with Stitch displaying tables in the **Tables to Replicate** tab for a database integration, the root cause may the number of tables the authorizing database user has access to in the source database.
+
+sections:
+  - title: "Symptoms"
+    anchor: "symptoms"
+    content: |
+      - A blank **Tables to Replicate** tab with an **Unable to load tables** error
+      - An extraction error similar to the following:
+
+        ```shell
+        main - INFO Exit status is: Discovery succeeded. Tap failed with code -9. Target succeeded.
+        ```
+
+  - title: "Cause"
+    anchor: "cause"
+    content: |
+      The first phase in the replication process is called **Extraction**. The start of every extraction is called **discovery**, and at this time, Stitch detects the tables and columns available in the source. These are the same tables and columns that the Stitch database user - or the database user in the integration's **{{ app.page-names.int-details }}** page - has access to.
+
+      If the authorizing database user has access to a large number of databases and tables, discovery may take some time. To ensure discovery can complete in a timely manner, we recommend limiting the database user's access only to the tables you want to replicate.
+
+      Refer to the [Basic concepts and system overview]({{ link.getting-started.basic-concepts | prepend: site.baseurl | append: "#system-architecture" }}) guide for more info about Stitch's replication process.
+
+  - title: "Solution"
+    anchor: "solution"
+    databases:
+      - name: "Microsoft SQL Server"
+        type: "mssql"
+      - name: "MySQL"
+        type: "mysql"
+      - name: "PostgreSQL"
+        type: "postgres"
+      - name: "Oracle"
+        type: "oracle"
+    content: |
+      Limit the authorizing database user's access only to the tables you want to replicate.
+
+      To see which database user Stitch is using to connect to the database:
+
+      1. Click into the integration from the {{ app.page-names.dashboard }}.
+      2. Click the **Settings** tab.
+      3. Locate the **User** or **Username** field.
+
+      To limit this database user's table access:
+
+      1. Log into your database as a user with the ability to grant privileges.
+      2. Locate your database in the table below.
+      3. Run the appropriate command on every table you want to replicate, replacing `<database_name>`, `<schema_name>`, `<table_name>`, and `<stitch_username>` with the name of the database, schema, table, and database user, respectively:
+
+         <table class="attribute-list">
+         {% for database in section.databases %}
+         <tr>
+         <td width="20%; fixed" align="right">
+         <strong>{{ database.name }}</strong>
+         </td>
+         <td>
+         <code>{{ site.data.taps.extraction.database-setup.user-privileges[database.type]grant-select-on-table | replace:"<","&lt;" | flatify | strip }}</code>
+         </td>
+         </tr>
+         {% endfor %}
+         </table>
+
+         **Note**: These commands will work for any database integration backed by one of the databases mentioned above. For example: The command for MySQL will also work on Amazon RDS MySQL, Amazon RDS Aurora MySQL, MariaDB, etc.
+      
+---
+{% include misc/data-files.html %}


### PR DESCRIPTION
This PR:

- Updates the setup instructions for database integrations that require a database user to recommend only granting access to table the user wants to replicate
- Adds a guide about the issues that might be encountered due to a large number of tables being accessed during discovery