### PR TITLE
Move BQ v2 to released

### DIFF
--- a/_data/destinations/bigquery/versions.yml
+++ b/_data/destinations/bigquery/versions.yml
@@ -6,8 +6,9 @@ latest-version: "2"
 
 released-versions:
   - number: "2"
-    status: "beta"
-    date-released: "TBD"
+    status: "released"
+    date-released: "November 19, 2019"
+    # full release: "February 4, 2020"
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""
@@ -16,6 +17,6 @@ released-versions:
     status: "released"
     date-released: "November 3, 2016"
     # full release: "October 2, 2017"
-    # date-last-connection:
+    date-last-connection: "February 4, 2020"
     deprecation-date: ""
     sunset-date: ""


### PR DESCRIPTION
This PR moves the Google BigQuery v2 destination from `beta` to `released`. It also adds a `date-last-connection` value for v1.