### PR TITLE
MongoDB/v1 - Replication Keys must have a single field index

### DIFF
--- a/_includes/integrations/databases/setup/syncing.html
+++ b/_includes/integrations/databases/setup/syncing.html
@@ -96,7 +96,7 @@ You can select {{ object }}s {% unless integration.column-selection == false %}a
    {% if integration.db-type == "mongo" %}
    {% capture mongo-rep-key-notice %}
    **Missing Replication Key Fields**<br>
-   Verify that the field is both indexed and in the root of the document if it's missing from the Replication Key dropdown. Refer to the [MongoDB Replication Keys guide]({{ rep-key | prepend: site.baseurl }}) for more info.
+   Replication Keys must be in the root of the document and have a [single field index](https://docs.mongodb.com/v4.0/indexes/#single-field){:target="new"} applied. If a field is missing from the Replication Key dropdown, verify that both of these criteria are met. Refer to the [MongoDB Replication Keys guide]({{ rep-key | prepend: site.baseurl }}) for more info.
    {% endcapture %}
 
    {% include tip.html content=mongo-rep-key-notice %}

--- a/_includes/integrations/databases/verify-mongo-data-types.html
+++ b/_includes/integrations/databases/verify-mongo-data-types.html
@@ -7,7 +7,7 @@ Run this query to count how many of a single data type there are in the table’
 - `knownDataTypeId` with the Mongo BSON data type ID. You can find the data type IDs [here in Mongo’s docs](https://docs.mongodb.com/manual/reference/bson-types/#bson-types).
 
 {% highlight sql %}
-   db.nameOfCollection.count({replicationKeyField: {$type: knownDataTypeId}});
+db.nameOfCollection.count({replicationKeyField: {$type: knownDataTypeId}});
 {% endhighlight %}
 
 Next, run this query to get a count of **all** records in the table:

--- a/_includes/replication/define-rep-keys.html
+++ b/_includes/replication/define-rep-keys.html
@@ -11,9 +11,9 @@
 ## Defining Replication Keys
 
 {% if page.title contains "Mongo" %}
-After you set a collection to sync, you'll be prompted to select a Replication Key.
+After you set a collection to replicate, you'll be prompted to select a Replication Key.
 {% else %}
-After you set a table to sync and select [Incremental Replication]({{ link.replication.rep-methods | prepend: site.baseurl | append: "#incremental-replication" }}) as the Replication Method, you'll need to select a column to be used as the Replication Key for the table.
+After you set a table to replicate and select [Incremental Replication]({{ link.replication.rep-methods | prepend: site.baseurl | append: "#incremental-replication" }}) as the Replication Method, you'll need to select a column to be used as the Replication Key for the table.
 {% endif %}
 
 After you select a {{ col }} from the drop-down, click the **Update Settings** button.
@@ -22,4 +22,4 @@ After you select a {{ col }} from the drop-down, click the **Update Settings** b
 
 Changing an existing Replication Key for a {{ object }} is simple - just open up the {{ Object }} Settings page for the {{ object }} and select the new Replication Key {{ col }} from the drop-down menu.
 
-**When you change a {{ object }}'s Replication Key, Stitch will queue a full re-sync of the {{ object }}'s data**. We do this to ensure that there aren't any gaps because of the Replication Key switch.
+**When you change a {{ object }}'s Replication Key, Stitch will queue a full re-replication of the {{ object }}'s data**. We do this to ensure that there aren't any gaps because of the Replication Key switch.

--- a/_includes/replication/define-rep-keys.html
+++ b/_includes/replication/define-rep-keys.html
@@ -13,13 +13,13 @@
 {% if page.title contains "Mongo" %}
 After you set a collection to replicate, you'll be prompted to select a Replication Key.
 {% else %}
-After you set a table to replicate and select [Incremental Replication]({{ link.replication.rep-methods | prepend: site.baseurl | append: "#incremental-replication" }}) as the Replication Method, you'll need to select a column to be used as the Replication Key for the table.
+After you set a table to replicate and select [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl }}) as the Replication Method, you'll need to select a column to be used as the Replication Key for the table.
 {% endif %}
 
 After you select a {{ col }} from the drop-down, click the **Update Settings** button.
 
-### Changing Existing Replication Keys
+### Changing existing Replication Keys
 
 Changing an existing Replication Key for a {{ object }} is simple - just open up the {{ Object }} Settings page for the {{ object }} and select the new Replication Key {{ col }} from the drop-down menu.
 
-**When you change a {{ object }}'s Replication Key, Stitch will queue a full re-replication of the {{ object }}'s data**. We do this to ensure that there aren't any gaps because of the Replication Key switch.
+**Note**: When you change a {{ object }}'s Replication Key, Stitch will queue a full re-replication of the {{ object }}'s data. We do this to ensure that there aren't any gaps because of the Replication Key switch.

--- a/_includes/replication/rep-key-gotchas.html
+++ b/_includes/replication/rep-key-gotchas.html
@@ -1,28 +1,28 @@
-### Replication Key Gotchas
+### Replication Key gotchas {#replication-key-gotchas}
 
 Before selecting a Replication Key for a {% if page.title contains "Mongo"%}collection{% else %}table{% endif %}, there are a few things you should keep in mind:
 
 {% if page.title contains "Mongo" %}
-1. **Changing a collection's Replication Key requires a full re-replication of the collection**. To change the Replication Key for a Mongo collection, Stitch must perform a full re-replication of the collection.
+1. **Changing a collection's Replication Key requires a full re-replication of the collection**. To change the Replication Key for a MongoDB collection, Stitch must perform a full re-replication of the collection.
 
 2. **Stitch will not capture hard deletes.** 
 
-3. **NULL is a defined BSON data type in Mongo.** Unlike SQL, `NULLs` can actually compare to other data types and replicate without issue.
+3. **NULL is a defined BSON data type in MongoDB.** Unlike SQL, `NULLs` can actually compare to other data types and replicate without issue.
 
-4. **Mongo fields may contain more than one data type. These data types also have a hierarchy.** Fields in Mongo (even `_id`) can contain more than one data type. In addition, [Mongo "ranks" data types](https://docs.mongodb.com/manual/reference/bson-types/#bson-types), meaning that some are considered greater than others. **This can lead to problems detecting new data.**
+4. **MongoDB fields may contain more than one data type. These data types also have a hierarchy.** Fields in MongoDB (even `_id`) can contain more than one data type. In addition, [MongoDB "ranks" data types](https://docs.mongodb.com/manual/reference/bson-types/#bson-types), meaning that some are considered greater than others. **This can lead to problems detecting new data.**
 
-   While Stitch doesn't require single data types for Replication Keys, **we strongly recommend it.** We've seen a lot of data discrepancies arise from this.
+   While Stitch doesn't require single data types for Replication Keys, we strongly recommend it. We've seen a lot of data discrepancies arise from this.
 
    Here’s an example that demonstrates why this could be a problem in Stitch:
 
    1. You set a table to replicate, using a field called `_id` as the Replication Key. This field contains both `ObjectId` and `String` data types.
-   2. A historical replication of the table completes.
-   3. Because Mongo considers `ObjectId` data types to be greater than `Strings`, Stitch will record the `MAX` value as the last replicated record containing an `ObjectId` data type in the Replication Key field.
+   2. A historical replication job of the table completes.
+   3. Because MongoDB considers `ObjectId` data types to be greater than `Strings`, Stitch will record the `MAX` value as the last replicated record containing an `ObjectId` data type in the Replication Key field.
    4. New records are added to the table.
-   5. During the next replication, Stitch uses the last recorded `MAX` value - in this case, an `ObjectId` - to identify new/updated data. **Remember: only records with Replication Key values greater than or equal to this value will be selected for replication**.
-   6. Because `ObjectIds > Strings`, all records with `Strings` are considered to be less than the last recorded `MAX` value. This means Stitch won’t be able to detect these records and replicate them to your data warehouse.
+   5. During the next replication job, Stitch uses the last recorded `MAX` value - in this case, an `ObjectId` - to identify new/updated data. **Remember: only records with Replication Key values greater than or equal to this value will be selected for replication**.
+   6. Because `ObjectIds > Strings`, all records with `Strings` are considered to be less than the last recorded `MAX` value. This means Stitch won’t be able to detect these records and replicate them.
 
-   Because Stitch may be unable to correctly identify new and updated data due to how data types are sorted, it’s best to keep Replication Key fields to a single data type. See below in the **Checking for Multiple Data Types** section for guidance on verifying a field's data types.
+   Because Stitch may be unable to correctly identify new and updated data due to how data types are sorted, it’s best to keep Replication Key fields to a single data type. See below in the **Checking for multiple data types** section for guidance on verifying a field's data types.
 
 5. **Some data types may not auto-increment.** Before using the field, you should verify the field's data type **and** that it auto-increments. Otherwise, Stitch may have issues detecting new data.
 
@@ -32,9 +32,11 @@ Before selecting a Replication Key for a {% if page.title contains "Mongo"%}coll
 
 {% else %}
 - **Rows with `NULL` values in the Replication Key column will only be replicated during the first replication of an integration**. This means subsequent replications will not capture rows where the Replication Key is `NULL`. Stitch uses the Replication Key column to detect new and updated data - without it, data can't be correctly detected and replicated.
+
 - **Auto-incrementing integers are only suitable Replication Keys for Append-Only tables**. If you want to use an auto-incrementing integer column as the Replication Key for your table, ensure that the table is Append-Only. 
 
    If an auto-incrementing integer is used and existing records are updated, Stitch won't detect the new data if the values in the Replication Key column don't also change. This can lead to data discrepancies.
-- **Replication Keys for Mongo work a little differently** than they do for other integrations. Check out the [Selecting Mongo Replication Keys guide]({{ link.replication.mongo-rep-keys | prepend: site.baseurl }}) for more info.
+
+- **Replication Keys for MongoDB work a little differently** than they do for other integrations. Check out the [Selecting MongoDB Replication Keys guide]({{ link.replication.mongo-rep-keys | prepend: site.baseurl }}) for more info.
 - **Stitch will not capture hard deletes in tables that use Key-based Incremental Replication**.
 {% endif %}

--- a/_includes/replication/rep-key-gotchas.html
+++ b/_includes/replication/rep-key-gotchas.html
@@ -3,7 +3,7 @@
 Before selecting a Replication Key for a {% if page.title contains "Mongo"%}collection{% else %}table{% endif %}, there are a few things you should keep in mind:
 
 {% if page.title contains "Mongo" %}
-1. **Changing a collection's Replication Key requires a full re-sync of the collection**. To change the Replication Key for a Mongo collection, Stitch must perform a full re-sync of the collection.
+1. **Changing a collection's Replication Key requires a full re-replication of the collection**. To change the Replication Key for a Mongo collection, Stitch must perform a full re-replication of the collection.
 
 2. **Stitch will not capture hard deletes.** 
 
@@ -15,11 +15,11 @@ Before selecting a Replication Key for a {% if page.title contains "Mongo"%}coll
 
    Here’s an example that demonstrates why this could be a problem in Stitch:
 
-   1. You sync a table, using a field called `_id` as the Replication Key. This field contains both `ObjectId` and `String` data types.
-   2. A historical sync of the table completes.
+   1. You set a table to replicate, using a field called `_id` as the Replication Key. This field contains both `ObjectId` and `String` data types.
+   2. A historical replication of the table completes.
    3. Because Mongo considers `ObjectId` data types to be greater than `Strings`, Stitch will record the `MAX` value as the last replicated record containing an `ObjectId` data type in the Replication Key field.
    4. New records are added to the table.
-   5. During the next sync, Stitch uses the last recorded `MAX` value - in this case, an `ObjectId` - to identify new/updated data. **Remember: only records with Replication Key values greater than or equal to this value will be selected for replication**.
+   5. During the next replication, Stitch uses the last recorded `MAX` value - in this case, an `ObjectId` - to identify new/updated data. **Remember: only records with Replication Key values greater than or equal to this value will be selected for replication**.
    6. Because `ObjectIds > Strings`, all records with `Strings` are considered to be less than the last recorded `MAX` value. This means Stitch won’t be able to detect these records and replicate them to your data warehouse.
 
    Because Stitch may be unable to correctly identify new and updated data due to how data types are sorted, it’s best to keep Replication Key fields to a single data type. See below in the **Checking for Multiple Data Types** section for guidance on verifying a field's data types.
@@ -31,10 +31,10 @@ Before selecting a Replication Key for a {% if page.title contains "Mongo"%}coll
 {% include integrations/databases/verify-mongo-data-types.html %}
 
 {% else %}
-- **Rows with `NULL` values in the Replication Key column will only be replicated during the first sync of an integration**. This means subsequent syncs will not capture rows where the Replication Key is `NULL`. Stitch uses the Replication Key column to detect new and updated data - without it, data can't be correctly detected and replicated.
+- **Rows with `NULL` values in the Replication Key column will only be replicated during the first replication of an integration**. This means subsequent replications will not capture rows where the Replication Key is `NULL`. Stitch uses the Replication Key column to detect new and updated data - without it, data can't be correctly detected and replicated.
 - **Auto-incrementing integers are only suitable Replication Keys for Append-Only tables**. If you want to use an auto-incrementing integer column as the Replication Key for your table, ensure that the table is Append-Only. 
 
    If an auto-incrementing integer is used and existing records are updated, Stitch won't detect the new data if the values in the Replication Key column don't also change. This can lead to data discrepancies.
 - **Replication Keys for Mongo work a little differently** than they do for other integrations. Check out the [Selecting Mongo Replication Keys guide]({{ link.replication.mongo-rep-keys | prepend: site.baseurl }}) for more info.
-- **Stitch will not capture hard deletes in tables that use Incremental Replication**.
+- **Stitch will not capture hard deletes in tables that use Key-based Incremental Replication**.
 {% endif %}

--- a/_includes/replication/rep-key-recommendations.html
+++ b/_includes/replication/rep-key-recommendations.html
@@ -1,7 +1,7 @@
-### Replication Key Recommendations
+### Replication Key recommendations {#replication-key-recommendations}
 
 {% if page.title contains "Mongo" %}
-1. **Replication Key fields should contain only one data type.** While Mongo allows you to have multiple data types in a single field, we strongly recommend keeping Replication Key fields to just one. This is because of the way Mongo compares and sorts data types and how this can impact replication.
+1. **Replication Key fields should contain only one data type.** While MongoDB allows you to have multiple data types in a single field, we strongly recommend keeping Replication Key fields to just one. This is because of the way MongoDB compares and sorts data types and how this can impact replication. Refer to the [Replication Key gotchas](#replication-key-gotchas) section for more info and an example
 
 2. **Date and timestamp fields are great Replication Key candidates**. We’re big fans of using `updatedAt` or `modifiedAt`. This is the best way to ensure that both new records and updates to existing records are captured.
 
@@ -14,5 +14,6 @@
 
 {% else %}
 - **For tables where existing records are updated**: We’re big fans of using `updated_at` or `modified_at` columns as Replication Keys. This is the best way to ensure that both new records and updates to existing records are captured.
+
 - **For <a href="#" data-toggle="tooltip" data-original-title="{{ site.data.tooltips.append-only-rep }}">Append-Only</a> tables**: We recommend using a unique, auto-incrementing integer as the Replication Key for these types of tables. However, a `created_at` date or `timestamp` column may also be suitable.
 {% endif %}

--- a/_includes/replication/rep-key-requirements.html
+++ b/_includes/replication/rep-key-requirements.html
@@ -3,10 +3,10 @@
 {% if page.title contains "Mongo" %}
 Stitch uses a field you define - called a Replication Key - to identify new and updated data for replication. For Mongo connections, Stitch requires that the Replication Key field:
 
-1. be indexed, AND
+1. be single field indexed, AND
 2. exist in the **root** of the document.
 
-If you want to sync Mongo data and are going to add query parameters - which is what [Incremental Replication]({{site.baseurl}}/replication/replication-methods#incremental-replication) does - undue stress could be put on your Mongo database. By indexing the fields you want to sync, that stress can be relieved.
+If you want to replicate Mongo data and are going to add query parameters - which is what [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}) does - undue stress could be put on your Mongo database. By indexing the fields you want to replicate, that stress can be relieved.
 
 {% else %}
 

--- a/_includes/replication/rep-key-requirements.html
+++ b/_includes/replication/rep-key-requirements.html
@@ -1,22 +1,22 @@
-## Replication Key Requirements
+## Replication Key requirements {#replication-key-requirements}
 
 {% if page.title contains "Mongo" %}
-Stitch uses a field you define - called a Replication Key - to identify new and updated data for replication. For Mongo connections, Stitch requires that the Replication Key field:
+Stitch uses a field you define - called a Replication Key - to identify new and updated data for replication. For MongoDB integrations, Stitch requires that the Replication Key field:
 
 1. be single field indexed, AND
 2. exist in the **root** of the document.
 
-If you want to replicate Mongo data and are going to add query parameters - which is what [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}) does - undue stress could be put on your Mongo database. By indexing the fields you want to replicate, that stress can be relieved.
+If you want to replicate MongoDB data and are going to add query parameters - which is what [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}) does - undue stress could be put on your MongoDB database. By indexing the fields you want to replicate, that stress can be relieved.
 
 {% else %}
 
-To use [Incremental Replication]({{site.baseurl}}/replication/replication-methods#incremental-replication), a table must contain one of the following column types to be used as the Replication Key:
+To use [Key-based Incremental Replication]({{site.baseurl}}/replication/replication-methods#incremental-replication), a table must contain one of the following column types to be used as the Replication Key:
 
 - a large integer, which includes `BIGINT`, `INT` and `MEDIUMINT`
 - `datetime`
 - `timestamp`
 
-When Stitch replicates your data, it will store the last recorded maximum value in the Replication Key column and compare it against the data source - **not what's in your data warehouse** - to identify new/updated data. 
+When Stitch replicates your data, it will store the last recorded maximum value in the Replication Key column and compare it against the data source - **not what's in your destination** - to identify new/updated data. 
 
-Any row with a Replication Key value greater than or equal to the stored value is where Stitch will begin the next replication attempt.
+Any row with a Replication Key value greater than or equal to the stored value is where Stitch will begin the next replication job.
 {% endif %}

--- a/_includes/replication/rep-keys-vs-primary-keys.html
+++ b/_includes/replication/rep-keys-vs-primary-keys.html
@@ -1,4 +1,4 @@
-## Replication Keys vs. Primary Keys
+## Replication Keys and Primary Keys
 
 When it comes to replicating your data, there are a lot of ‘keys’ involved. It can be difficult to keep them all straight, but aside from Replication Keys, there’s one more you should keep in mind: Primary Keys.
 
@@ -7,7 +7,8 @@ In Stitch, Replication Keys and Primary Keys serve two different purposes:
 - **Replication Keys** are used during the Extraction phase of the replication process - or when Stitch is querying your data source - to identify new and updated data for replication.
 
   In the Stitch app, Replication Keys have a <img src="{{ site.baseurl }}/images/replication/replication-key-icon.png" alt="Replication Key icon" style="border: 0px;"> next to the column name.
-- **Primary Keys** are used during the last step of the replication process, which is when Stitch loads replicated data into your data warehouse. Primary Keys identify unique rows within a table and ensure that only the most recently updated version of that record appears in your data warehouse.
+
+- **Primary Keys** are used during the last step of the replication process, which is when Stitch loads replicated data into your destination. Primary Keys identify unique rows within a table and ensure that only the most recently updated version of that record appears in your destination.
 
   In the Stitch app, Primary Keys have a <img src="{{ site.baseurl }}/images/replication/primary-key-icon.png" alt="Primary Key icon" style="border: 0px;"> next to the column name.
 

--- a/_includes/replication/rep-keys-vs-primary-keys.html
+++ b/_includes/replication/rep-keys-vs-primary-keys.html
@@ -4,7 +4,7 @@ When it comes to replicating your data, there are a lot of ‘keys’ involved. 
 
 In Stitch, Replication Keys and Primary Keys serve two different purposes:
 
-- **Replication Keys** are used during the Extraction phaseof the replication process - or when Stitch is querying your data source - to identify new and updated data for replication.
+- **Replication Keys** are used during the Extraction phase of the replication process - or when Stitch is querying your data source - to identify new and updated data for replication.
 
   In the Stitch app, Replication Keys have a <img src="{{ site.baseurl }}/images/replication/replication-key-icon.png" alt="Replication Key icon" style="border: 0px;"> next to the column name.
 - **Primary Keys** are used during the last step of the replication process, which is when Stitch loads replicated data into your data warehouse. Primary Keys identify unique rows within a table and ensure that only the most recently updated version of that record appears in your data warehouse.

--- a/_includes/replication/reset-rep-keys.html
+++ b/_includes/replication/reset-rep-keys.html
@@ -20,9 +20,9 @@
 **Replication Keys can be reset for database and (most) SaaS integrations.**
 {% endif %}
 
-There may be times when you need to fully replicate a {{ object }} (or {{ object }}s) that usually update incrementally. If, for example, you add a new {{ col }} and want to backfill data for already-replicated rows, forcing a full re-sync of the {{ object }} will populate the {{ col }} for existing rows and replicate new records. You can do this by resetting Replication Keys.
+There may be times when you need to fully replicate a {{ object }} (or {{ object }}s) that usually update incrementally. If, for example, you add a new {{ col }} and want to backfill data for already-replicated rows, forcing a full re-replication of the {{ object }} will populate the {{ col }} for existing rows and replicate new records. You can do this by resetting Replication Keys.
 {% else %}
-If you need to backfill already-replicated rows with data from the newly syncing column, you can **reset the table's Replication Key.** This will force a full re-sync of the table, populate the column in existing rows, and replicate new records.
+If you need to backfill already-replicated rows with data from the newly selected column, you can **reset the table's Replication Key.** This will force a full re-replication of the table, populate the column in existing rows, and replicate new records.
 {% endif %}
 
 {% capture reset-rep-key %}
@@ -38,35 +38,28 @@ If you have questions or concerns about resetting Replication Keys, we encourage
 
 {% unless page.title contains "Mongo" %}### Resetting Database Integration Replication Keys{% endunless%}
 
-{% if page.title contains "Mongo" %}Mongo Replication Keys can be reset at the **integration** level only.
-{% else %}
 Replication Keys in database integrations can be reset at the **integration** or the **{{ object }}** level.
 
-- At the **integration** level, the reset will clear the replication key value for ALL {{ object }}s AND queue a full re-sync **for all {{ object }}s in the integration.**
-- At the **{{ object }}** level, the reset will clear the replication key value AND queue a full re-sync **for that {{ object }} only**.
-{% endif %}
+- At the **integration** level, the reset will clear the replication key value for ALL {{ object }}s AND queue a full re-replication **for all {{ object }}s in the integration.**
+- At the **{{ object }}** level, the reset will clear the replication key value AND queue a full re-replication **for that {{ object }} only**.
 
 To reset Replication Keys, do the following:
 
 1. Click into the integration from the {{ app.page-names.dashboard }} page.
-{% if page.title contains "Mongo"%}
-2. Click {{ app.buttons.update-int-settings }}.
-{% else %}
 2. Next:
    - **To reset the entire integration**: Click the {{ app.buttons.update-int-settings }} link and **skip to step 3**.
    - **To reset a {{ object }}**: Locate the {{ object }} you want and click into it. Click the **{{ Object }} Settings** link, located near the top right corner, and **proceed to step 3.**
-{% endif %}
 3. Scroll down to the **Reset Replication Keys** section.
 4. Click the **Reset Keys** button.
 5. When prompted, click **OK** to confirm.
 6. A **Success!** message will display at the top of the page.
 
-At this point, a full re-sync of the integration will be queued. Note that if there is a large volume of data to be replicated, it may take some time before you see the changes in your data warehouse.
+At this point, a full re-replication of the integration or {{ object }} will be queued. Note that if there is a large volume of data to be replicated, it may take some time before you see the changes in your data warehouse.
 
 {% unless page.title contains "Mongo" %}
 ### Resetting SaaS Integration Replication Keys
 
-Resetting the Replication Keys for a SaaS integration is done by changing the **Historical Sync** date in the {{ app.page-names.int-settings }} page. **When this date is changed, all saved values will be overwritten AND a full re-sync of the integration will be queued.**
+Resetting the Replication Keys for a SaaS integration is done by changing the **Historical Sync** date in the {{ app.page-names.int-settings }} page. **When this date is changed, all saved values will be overwritten AND a full re-replication of the integration will be queued.**
 
 **This feature may not be available for some integrations.** Because this approach uses date-based replication, some integrations may be incompatible. For example: Pardot doesn't support date-based replication, meaning this feature will not be available for Pardot connections.
 

--- a/_includes/replication/reset-rep-keys.html
+++ b/_includes/replication/reset-rep-keys.html
@@ -11,7 +11,7 @@
 {% if page.title contains "Replication Keys" %}
 ## Resetting Replication Keys
 {% else %}
-## Backfilling Existing Rows
+## Backfilling existing rows
 {% endif %}
 
 {% if page.title contains "Replication Keys" %}
@@ -21,22 +21,23 @@
 {% endif %}
 
 There may be times when you need to fully replicate a {{ object }} (or {{ object }}s) that usually update incrementally. If, for example, you add a new {{ col }} and want to backfill data for already-replicated rows, forcing a full re-replication of the {{ object }} will populate the {{ col }} for existing rows and replicate new records. You can do this by resetting Replication Keys.
+
 {% else %}
 If you need to backfill already-replicated rows with data from the newly selected column, you can **reset the table's Replication Key.** This will force a full re-replication of the table, populate the column in existing rows, and replicate new records.
 {% endif %}
 
 {% capture reset-rep-key %}
-Note that this process:
+This process:
 
 1. Will **delete and re-create** your destination tables with a **full re-replication of your source data**.
 2. Will lead to increased row counts which will count towards your limit.
 3. Cannot be interrupted or reversed once confirmed.
 
-If you have questions or concerns about resetting Replication Keys, we encourage you to reach out to support before proceeding.
+If you have questions or concerns about resetting Replication Keys, reach out to support before proceeding.
 {% endcapture %}
 {% include important.html first-line="**Before resetting Replication Keys:**" content=reset-rep-key %}
 
-{% unless page.title contains "Mongo" %}### Resetting Database Integration Replication Keys{% endunless%}
+{% unless page.title contains "Mongo" %}### Resetting database integration Replication Keys{% endunless%}
 
 Replication Keys in database integrations can be reset at the **integration** or the **{{ object }}** level.
 
@@ -54,14 +55,14 @@ To reset Replication Keys, do the following:
 5. When prompted, click **OK** to confirm.
 6. A **Success!** message will display at the top of the page.
 
-At this point, a full re-replication of the integration or {{ object }} will be queued. Note that if there is a large volume of data to be replicated, it may take some time before you see the changes in your data warehouse.
+At this point, a full re-replication of the integration or {{ object }} will be queued. **Note**: If there is a large volume of data to be replicated, it may take some time before you see the changes in your data warehouse.
 
 {% unless page.title contains "Mongo" %}
-### Resetting SaaS Integration Replication Keys
+### Resetting SaaS integration Replication Keys
 
-Resetting the Replication Keys for a SaaS integration is done by changing the **Historical Sync** date in the {{ app.page-names.int-settings }} page. **When this date is changed, all saved values will be overwritten AND a full re-replication of the integration will be queued.**
+Resetting the Replication Keys for a SaaS integration is done by changing the **Historical Sync** date in the {{ app.page-names.int-settings }} page. When this date is changed, all saved values will be overwritten AND a full re-replication of the integration will be queued.
 
-**This feature may not be available for some integrations.** Because this approach uses date-based replication, some integrations may be incompatible. For example: Pardot doesn't support date-based replication, meaning this feature will not be available for Pardot connections.
+**Note**: This feature may not be available for some integrations. Because this approach uses date-based replication, some integrations may be incompatible. For example: Pardot doesn't support date-based replication, meaning this feature will not be available for Pardot connections.
 
 Changing the Historical Sync date has its own set of considerations and gotchas. Please refer to the [Syncing Historical SaaS Data]({{ link.replication.saas-historical | prepend: site.baseurl }}) guide for more info.
 {% endunless %}

--- a/_replication/replication-keys/mongo-replication-keys.md
+++ b/_replication/replication-keys/mongo-replication-keys.md
@@ -11,7 +11,7 @@ weight: 2
 ---
 {% include misc/data-files.html %}
 
-Replication Keys are columns that Stitch uses to identify new and updated data for replication. As Stitch's Mongo integration uses only [Incremental Replication]({{ link.replication.rep-methods | prepend: site.baseurl | append: "#incremental-replication" }}), when you set a Mongo collection to sync, you'll also need to define a Replication Key.
+Replication Keys are columns that Stitch uses to identify new and updated data for replication. Stitch's Mongo integration uses Key-based [incremental replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}), so when you set a Mongo collection to replicate, you'll also need to define a Replication Key.
 
 Incorrectly setting a Replication Key can cause data discrepancies, latency, and high row counts. As Mongo Replication Keys have their own set of quirks, it's important to understand how they work and what makes a good key.
 

--- a/_replication/replication-keys/mongo-replication-keys.md
+++ b/_replication/replication-keys/mongo-replication-keys.md
@@ -1,9 +1,9 @@
 ---
-title: Replication Keys for Mongo Integrations
+title: Replication Keys for MongoDB Integrations
 permalink: /replication/mongo-replication-keys
 keywords: replicate, replication, replication key, keys, stitch replicates data, rp, mongo, mongodb, mongo database integration
 tags: [replication]
-summary: "Replication Keys for Mongo integrations have their own set of quirks and gotchas, owing to how Mongo itself is designed. In this guide, we'll explain what to watch out for and how to choose the best field for the job."
+summary: "Replication Keys for MongoDB integrations have their own set of quirks and gotchas, owing to how MongoDB itself is designed. In this guide, we'll explain what to watch out for and how to choose the best field for the job."
 
 content-type: "replication-keys"
 toc: true
@@ -11,7 +11,7 @@ weight: 2
 ---
 {% include misc/data-files.html %}
 
-Replication Keys are columns that Stitch uses to identify new and updated data for replication. Stitch's Mongo integration uses Key-based [incremental replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}), so when you set a Mongo collection to replicate, you'll also need to define a Replication Key.
+Replication Keys are columns that Stitch uses to identify new and updated data for replication. When you set a Mongo collection to replicate using [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl}}), you'll also need to define a Replication Key.
 
 Incorrectly setting a Replication Key can cause data discrepancies, latency, and high row counts. As Mongo Replication Keys have their own set of quirks, it's important to understand how they work and what makes a good key.
 
@@ -27,7 +27,7 @@ Incorrectly setting a Replication Key can cause data discrepancies, latency, and
 
 ## Recommendations & Gotchas
 
-While a field need only be indexed and exist in the root of the document to be a Mongo Replication Key, we have some recommendations (and things you should keep in mind) when selecting a field to be a Replication Key.
+While a field need only be indexed using a single field index and exist in the root of the document to be a MongoDB Replication Key, we have some recommendations (and things you should keep in mind) when selecting a field to be a Replication Key.
 
 {% include replication/rep-key-recommendations.html %}
 


### PR DESCRIPTION
This PR clarifies the indexing requirement for fields being used as Replication Keys.