### PR TITLE
Shopify - Order Refunds table replication note

### DIFF
--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -89,9 +89,9 @@ replication-sections:
   - title: "Order Refunds table replication"
   - anchor: "order-refunds"
   - content: |
-      The Order Refunds file gets queried at every single order ID in the table. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in the table. With Stich's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replications of your other selected tables, consider creating a separate integration for only the Order Refunds table.
+      The `order_refunds` table gets queried at every single order ID in the table. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in your account. With Stitch's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replication of your other selected tables, consider creating a separate integration for only the `order_refunds` table.
 
-      Note that depending on how much {{ integration.display_name }} data you have, creating a separate integration for your Order Refunds table may negatively affect your API quota.
+      Note that creating a separate integration for your `order_refunds` table may negatively affect your {{ integration.display_name }} API quota.
       
 
 # -------------------------- #

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -89,7 +89,9 @@ replication-sections:
   - title: "Order Refunds table replication"
   - anchor: "order-refunds"
   - content: |
-      The Order Refunds table is a Key-based Incremental file that gets queried for every single order ID. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in the table. With Stich's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replications of your other selected tables, consider creating a separate integration for only the Order Refunds table.
+      The Order Refunds file gets queried at every single order ID in the table. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in the table. With Stich's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replications of your other selected tables, consider creating a separate integration for only the Order Refunds table.
+
+      Note that depending on how much {{ integration.display_name }} data you have, creating a separate integration for your Order Refunds table may negatively affect your API quota.
       
 
 # -------------------------- #

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -86,12 +86,12 @@ setup-steps:
 # -------------------------- #
 
 replication-sections:  
-  - title: "Order Refunds table replication"
+  - title: "Replicating order refunds"
   - anchor: "order-refunds"
   - content: |
-      The `order_refunds` table gets queried at every single order ID in the table. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in your account. With Stitch's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replication of your other selected tables, consider creating a separate integration for only the `order_refunds` table.
+      To extract order refund data, Stitch queries every order in your account. If you have the `order_refunds` table selected for replication, the process can potentially be very slow depending on how many orders and refunds exist in your {{ integration.display_name }} account. As tables are extracted one at a time, this could cause extraction to not proceed for days at a time. To ensure timely replication of your other selected tables, consider creating a separate integration for only the `order_refunds` table.
 
-      Note that creating a separate integration for your `order_refunds` table may negatively affect your {{ integration.display_name }} API quota.
+      **Note**: Creating a separate integration for your `order_refunds` table may negatively affect your {{ integration.display_name }} API quota.
       
 
 # -------------------------- #

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -81,6 +81,16 @@ setup-steps:
       4. Click {{ app.buttons.finish-int-setup }}.
   - title: "track data"
 
+# -------------------------- #
+#     Replication Details    #
+# -------------------------- #
+
+replication-sections:  
+  - title: "Order Refunds table replication"
+  - anchor: "order-refunds"
+  - content: |
+      The Order Refunds table is a Key-based Incremental file that gets queried for every single order ID. If you have this table selected for replication, the process can potentially be very slow depending on how many refunds exist in the table. With Stich's replication process, this could cause other tables to not be replicated for days to weeks at a time. To ensure timely replications of your other selected tables, consider creating a separate integration for only the Order Refunds table.
+      
 
 # -------------------------- #
 #     Integration Tables     #


### PR DESCRIPTION
Added a replication section:
- suggests creating a separate integration for the order refunds table since it's queried at every single ID