### PR TITLE
MailChimp/v1 - GA release

### DIFF
--- a/_data/taps/versions/mailchimp.yml
+++ b/_data/taps/versions/mailchimp.yml
@@ -6,8 +6,9 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
-    date-released: "July 23, 2019"
+    status: "released"
+    date-released: "March 9, 2020"
+    # beta release: July 23, 2019
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_integration-schemas/mailchimp/v1/list_members.md
+++ b/_integration-schemas/mailchimp/v1/list_members.md
@@ -25,6 +25,12 @@ attributes:
     description: "The list member ID. This is the MD5 hash of the lowercase version of the list member’s email address."
     #foreign-key-id: "list-member-id"
 
+  - name: "list_id"
+    type: "string"
+    primary-key: true
+    description: "The list ID."
+    foreign-key-id: "list-id"
+
   - name: "last_changed"
     type: "date-time"
     replication-key: true
@@ -58,11 +64,6 @@ attributes:
     type: "string"
     description: "If set/detected, the subscriber’s language."
     doc-link: "https://mailchimp.com/help/view-and-edit-contact-languages/?_ga=2.133440206.1967669071.1563545438-786188311.1561484332"
-
-  - name: "list_id"
-    type: "string"
-    description: "The list ID."
-    foreign-key-id: "list-id"
 
   - name: "location"
     type: "object"


### PR DESCRIPTION
This PR:

- Puts `platform.mailchimp` into `released`
- Adds the `list_id` as a Primary Key attribute for the `list_members` table (https://github.com/singer-io/tap-mailchimp/pull/20)