### PR TITLE
Braintree - add subscription ID

### DIFF
--- a/_integration-schemas/braintree/transactions.yml
+++ b/_integration-schemas/braintree/transactions.yml
@@ -139,4 +139,8 @@ attributes:
       - name: "success"
         type: "boolean"
         description: "Indicates if the funds were disbursed successfully."
+
+  - name: "subscription_id"
+    type: "string"
+    description: "The subscription ID."     
 ---


### PR DESCRIPTION
Adds the `subscription ID` attribute to the Transactions table.