### PR TITLE
Chargebee schema updates + orders

### DIFF
--- a/_integration-schemas/chargebee/20-05-2019/addons.md
+++ b/_integration-schemas/chargebee/20-05-2019/addons.md
@@ -1,6 +1,6 @@
 ---
 tap: "chargebee"
-version: "1"
+version: "20-05-2019"
 key: "addon"
 
 name: "addons"
@@ -184,8 +184,4 @@ attributes:
     type: "string"
     description: |
       Applicable only for quantity type addons. This specifies the type of quantity. For example: If the addon price is `$10` and `agent` is the unit, it will be displayed as `$10/agent`.
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
 ---

--- a/_integration-schemas/chargebee/20-05-2019/coupons.md
+++ b/_integration-schemas/chargebee/20-05-2019/coupons.md
@@ -1,0 +1,129 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "coupon"
+
+name: "coupons"
+doc-link: "https://apidocs.chargebee.com/docs/api/coupons"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/coupons.json"
+description: |
+  The `{{ table.name }}` table contains info about the coupons in your {{ integration.display_name }} account.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List coupons"
+    doc-link: "https://apidocs.chargebee.com/docs/api/coupons#list_coupons"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The coupon ID."
+    foreign-key-id: "coupon-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the coupon was last updated."
+
+  - name: "addon_constraint"
+    type: "string"
+    description: |
+      The addons the coupon can be applied to. Possible values are:
+
+      - `none`
+      - `all`
+      - `specific`
+      - `not_applicable`
+
+  - name: "apply_discount_on"
+    type: "string"
+    description: ""
+
+  - name: "apply_on"
+    type: "string"
+    description: |
+      The invoice items for which this coupon needs to be applied. Possible values are:
+
+      - `invoice_amount`: The coupon will be applied to the total invoice amount.
+      - `each_specified_item`: the discount will be applied to each specified plan and addon item.
+
+  - name: "archived_at"
+    type: "date-time"
+    description: "The time when the coupon was archived."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time when the coupon was created."
+
+  - name: "discount_amount"
+    type: "number"
+    description: "When `discount_type: fixed_amount`, this value will be the discount value in cents."
+
+  - name: "discount_percentage"
+    type: "number"
+    description: "When `discount_type: percentage`, this value will be the discount value percentage."
+
+  - name: "discount_type"
+    type: "string"
+    description: |
+      The type of discount. Possible values are:
+
+      - `fixed_amount`
+      - `percentage`
+
+  - name: "duration_month"
+    type: "integer"
+    description: |
+      When `duration_type: limited_period`, this value will be the duration in months the coupon can be applied.
+
+  - name: "duration_type"
+    type: "string"
+    description: |
+      The duration the coupon is applicable. Possible values are:
+
+      - `one_time`
+      - `forever`
+      - `limited_period`
+
+  - name: "max_redemptions"
+    type: "integer"
+    description: "The maximum number of times the coupon can be redeemed."
+
+  - name: "name"
+    type: "string"
+    description: "The display name used in web interface for identifying the coupon."
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "plan_constraint"
+    type: "string"
+    description: |
+      The plans the coupon can be applied to. Possible values are:
+
+      - `none`
+      - `all`
+      - `specific`
+      - `not_applicable`
+
+  - name: "redemptions"
+    type: "integer"
+    description: "The number of times the coupon has been redeemed."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the coupon. Each update of the coupon results in an incremental change of this value. **Note**: This attribute will be present only if the coupon has been updated after 2016-09-28."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the coupon. Possible values are:
+
+      - `active`
+      - `expired`
+      - `archived`
+      - `deleted`
+---

--- a/_integration-schemas/chargebee/20-05-2019/credit_notes.md
+++ b/_integration-schemas/chargebee/20-05-2019/credit_notes.md
@@ -1,0 +1,452 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "credit-note"
+
+name: "credit_notes"
+doc-link: "https://apidocs.chargebee.com/docs/api/credit_notes"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/credit_notes.json"
+description: |
+  The `{{ table.name }}` table contains info about the credit notes in your {{ integration.display_name }} account. A credit note is a document that specifies the money owed by a business to a customer.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List credit notes"
+    doc-link: "https://apidocs.chargebee.com/docs/api/credit_notes#list_credit_notes"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The credit note ID."
+    foreign-key-id: "credit-note-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the credit note was last updated."
+
+  - name: "allocations"
+    type: "array"
+    description: "Details about invoice allocations made from the credit note."
+    subattributes:
+      - name: "allocated_amount"
+        type: "integer"
+        description: "The amount of the allocation, in cents."
+
+      - name: "allocated_at"
+        type: "date-time"
+        description: "The time the allocation occurred."
+
+      - name: "invoice_date"
+        type: "date-time"
+        description: "The closing date of the invoice."
+
+      - name: "invoice_id"
+        type: "string"
+        description: "The invoice ID."
+        foreign-key-id: "invoice-id"
+
+      - name: "invoice_status"
+        type: "string"
+        description: |
+          The current status of the invoice. Possible values are:
+
+          - `paid`
+          - `posted`
+          - `payment_due`
+          - `not_paid`
+          - `voided`
+          - `pending`
+
+  - name: "amount_allocated"
+    type: "integer"
+    description: "The amount allocated to invoices."
+
+  - name: "amount_available"
+    type: "integer"
+    description: "The yet to be used credits of this credit note."
+
+  - name: "amount_refunded"
+    type: "integer"
+    description: "The refunds issued from this credit note."
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code (ISO 4217 format) for the credit note."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer associated with the credit note."
+    foreign-key-id: "customer-id"
+
+  - name: "date"
+    type: "date-time"
+    description: "The date the credit note was issued."
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indicates whether the credit note was deleted or not."
+
+  - name: "discounts"
+    type: "array"
+    description: "Details about the discounts applied to the credit note."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The discount amount, in cents."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the discount line item."
+
+      - name: "entity_id"
+        type: "string"
+        description: "The ID of the entity the discount amount is based on. This value will only be present if `entity_type` is `item_level_coupon` or `document_level_coupon`."
+        foreign-key-id: "coupon-id"
+
+      - name: "entity_type"
+        type: "string"
+        description: &discount-line-item |
+          The type of the discount line item. Possible values are:
+
+          - `item_level_coupon`: Represents item-level coupons applied to the invoice.
+          - `document_level_coupon`: Represents document-level coupons applied to the document.
+          - `promotional_credits`: Represents promotional credits in the invoice.
+          - `prorated_credits`: Represents credit adjustments in the invoice.
+
+  - name: "line_item_discounts"
+    type: "array"
+    description: "The list of discount(s) applied for each line item of the invoice."
+    subattributes:
+      - name: "coupon_id"
+        type: "string"
+        description: "The coupon ID."
+        foreign-key-id: "coupon-id"
+
+      - name: "discount_amount"
+        type: "integer"
+        description: "The discount amount, in cents."
+
+      - name: "discount_type"
+        type: "string"
+        description: *discount-line-item
+
+      - name: "line_item_id"
+        type: "string"
+        description: "The ID of the line item for which the discount is applicable."
+        foreign-key-id: "line-item-id"
+
+  - name: "line_item_taxes"
+    type: "array"
+    description: "The list of taxes applied on line items."
+    subattributes:
+      - name: "is_non_compliance_tax"
+        type: "boolean"
+        description: "Indicates the non-compliance tax should not be reported to the tax jurisdiction."
+
+      - name: "is_partial_tax_applied"
+        type: "boolean"
+        description: "Indicates whether tax is applied only on a portion of the line item or not."
+
+      - name: "line_item_id"
+        type: "string"
+        description: "The ID of the line item for which the tax is applicable."
+        foreign-key-id: "line-item-id"
+
+      - name: "tax_amount"
+        type: "integer"
+        description: "The tax amount, in cents."
+
+      - name: "tax_juris_code"
+        type: "string"
+        description: "The tax jurisdiction code."
+
+      - name: "tax_juris_name"
+        type: "string"
+        description: "The name of the tax jurisdiction."
+
+      - name: "tax_juris_type"
+        type: "string"
+        description: |
+          The type of tax jurisdiction. Possible values are:
+
+          - `country`
+          - `federal`
+          - `state`
+          - `county`
+          - `city`
+          - `special`
+          - `unincorporated` (Combined tax of state and country)
+          - `other`
+
+      - name: "tax_name"
+        type: "string"
+        description: "The name of the tax applied."
+
+      - name: "tax_rate"
+        type: "number"
+        description: "The rate of tax used to calculate the tax amount."
+
+      - name: "taxable_amount"
+        type: "integer"
+        description: "The actual portion of the line item that is taxable, in cents."
+
+  - name: "line_item_tiers"
+    type: "array"
+    description: "The list of tiers applicable for the line item."
+    subattributes:
+      - name: "ending_unit"
+        type: "integer"
+        description: "The upper limit of a range of units for the tier."
+
+      - name: "line_item_id"
+        type: "string"
+        description: "The line item ID."
+        foreign-key-id: "line-item-id"
+
+      - name: "quantity_used"
+        type: "integer"
+        description: "The number of units purchased in a range."
+
+      - name: "starting_unit"
+        type: "integer"
+        description: "The lower limit of a range of units for the tier."
+
+      - name: "unit_amount"
+        type: "integer"
+        description: "The price of the tier if the charge model is `stairstep`, or the price of each unit in the tier if the charge model is `tiered` or `volume`."
+
+  - name: "line_items"
+    type: "array"
+    description: "The line items in the credit note."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The total amount of the line item, calculated as `unit_amount x quantity`."
+
+      - name: "date_from"
+        type: "date-time"
+        description: "The start date of the line item."
+
+      - name: "date_to"
+        type: "date-time"
+        description: "The end date of the line item."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the line item."
+
+      - name: "discount_amount"
+        type: "integer"
+        description: "The discount amount applied to the line item, in cents."
+
+      - name: "entity_id"
+        type: "string"
+        description: |
+          The ID of the entity the line item is based on.
+
+      - name: "entity_type"
+        type: "string"
+        description: |
+          The modelled entity (plan, addon, etc.) this line item is based on. Possible values are:
+
+          - `plan_setup`: The line item is based on a plan setup charge. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+          - `plan`: The line item is based on a plan entity. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+          - `addon`: The line item is based on an addon entity. The `entity_id` will specify the addon ID ([`addons: id`](#addons)).
+          - `adhoc`: The line item is not modelled. The `entity_id` attribute will be `null`.
+
+      - name: "id"
+        type: "string"
+        description: "The line item ID."
+        foreign-key-id: "line-item-id"
+
+      - name: "is_taxed"
+        type: "boolean"
+        description: "Indicates whether the line item is taxed or not."
+
+      - name: "item_level_discount_amount"
+        type: "integer"
+        description: "The item level discount amount for the line item, in cents."
+
+      - name: "pricing_model"
+        type: "string"
+        description: |
+          Indicates how the charges for the line item are calculated. Possible values are:
+
+          - `flat_fee`: Charges single price on a recurring basis.
+          - `per_unit`: Charges the price for each unit of the plan for the subscription on a recurring basis.
+          - `tiered`: Charges different per unit price for the quantity purchased from every tier.
+          - `volume`: Charges the per unit price for the total quantity purchased based on the tier under which it falls.
+          - `stairstep`: Charges a price for a range.
+
+      - name: "quantity"
+        type: "integer"
+        description: "The quantity of the recurring item, represented by the line item."
+
+      - name: "subscription_id"
+        type: "string"
+        description: "The ID of the subscription associated with the line item."
+        foreign-key-id: "subscription-id"
+
+      - name: "tax_amount"
+        type: "integer"
+        description: "The tax amount of the line item, in cents."
+
+      - name: "tax_exempt_reason"
+        type: "string"
+        description: |
+          The reason or category for why the line item is excluded from the taxable amount. Possible values are:
+
+          - `tax_not_configured`
+          - `region_non_taxable`
+          - `export`
+          - `customer_exempt`
+          - `zero_rated`
+          - `reverse_charge`
+          - `high_value_physical_good`
+
+      - name: "tax_rate"
+        type: "number"
+        description: "The rate of tax used to calculate tax for the line item."
+
+      - name: "unit_amount"
+        type: "integer"
+        description: "The unit amount of the line item, in cents."
+
+  - name: "linked_refunds"
+    type: "array"
+    description: "Details about refunds issued from the credit note."
+    subattributes:
+      - name: "applied_amount"
+        type: "integer"
+        description: "The transaction amount applied to the invoice."
+
+      - name: "applied_at"
+        type: "date-time"
+        description: "The time the amount was applied."
+
+      - name: "txn_amount"
+        type: "integer"
+        description: "The total amount of the transaction."
+
+      - name: "txn_date"
+        type: "date-time"
+        description: "The date the transaction occured."
+
+      - name: "txn_id"
+        type: "string"
+        description: "the transaction ID."
+        foreign-key-id: "transaction-id"
+
+      - name: "txn_status"
+        type: "string"
+        description: |
+          The status of the transaction. Possible values are:
+
+          - `in_progress`
+          - `success`
+          - `voided`
+          - `failure`
+          - `timeout`
+          - `needs_attention`
+
+  - name: "price_type"
+    type: "string"
+    description: |
+      The price type of the credit note. Possible values are:
+
+      - `tax_exclusive`
+      - `tax_inclusive`
+
+  - name: "reason_code"
+    type: "string"
+    description: |
+      The reason for issuing the credit note. Possible values include:
+
+      - `write_off`
+      - `subscription_change`
+      - `subscription_cancellation`
+      - `subscription_pause`
+      - `chargeback`
+      - `product_unsatisfactory`
+      - `service_unsatisfactory`
+      - `order_change`
+      - `order_cancellation`
+      - `waiver`
+      - `other`
+      - `fraudulent`
+
+  - name: "reference_invoice_id"
+    type: "string"
+    description: "The ID of the invoice against which the credit note is issued."
+    foreign-key-id: "invoice-id"
+
+  - name: "refunded_at"
+    type: "date-time"
+    description: "The time when the credit note was fully used."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the credit note. Each update of the credit note results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
+
+  - name: "round_off_amount"
+    type: "integer"
+    description: "The credit note rounded-off amount, in cents."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the credit note. Possible values include:
+
+      - `adjusted`
+      - `refunded`
+      - `refund_due`
+      - `voided`
+
+  - name: "sub_total"
+    type: "integer"
+    description: "The credit note subtotal, in cents."
+
+  - name: "subscription_id"
+    type: "string"
+    description: "The ID of the subscription associated with the credit note."
+    foreign-key-id: "subscription-id"
+
+  - name: "taxes"
+    type: "array"
+    description: "The tax lines of the credit note."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The tax amount, in cents."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the tax item."
+
+      - name: "name"
+        type: "string"
+        description: "The name of the tax applied. For example: `GST`"
+
+  - name: "total"
+    type: "integer"
+    description: "The total credit amount in cents."
+
+  - name: "type"
+    type: "string"
+    description: |
+      The credit note type. Possible values are:
+
+      - `adjustment`
+      - `refundable`
+
+  - name: "vat_number"
+    type: "string"
+    description: "The VAT number of the customer for whom the credit note is raised."
+
+  - name: "voided_at"
+    type: "date-time"
+    description: "The time when the credit note was voided."
+---

--- a/_integration-schemas/chargebee/20-05-2019/customers.md
+++ b/_integration-schemas/chargebee/20-05-2019/customers.md
@@ -1,6 +1,6 @@
 ---
 tap: "chargebee"
-version: "1"
+version: "20-05-2019"
 key: "customers"
 
 name: "customers"
@@ -39,10 +39,6 @@ attributes:
       - `on`: When an invoice is created, an automatic attempt to charge the customer's payment method is made.
       - `off`: Automatic collection of charges will not be made.
 
-  - name: "backup_payment_source_id"
-    type: "string"
-    description: ""
-    
   - name: "balances"
     type: "array"
     description: "The list of balances for the customer."
@@ -415,52 +411,4 @@ attributes:
   - name: "vat_number"
     type: "string"
     description: "The VAT number for the customer."
-
-  - name: "vat_number_status"
-    type: "string"
-    description: ""
-    
-  - name: "vat_number_validated_time"
-    type: "date-time"
-    description: ""  
-
-  - name: "entity_code"
-    type: "string"
-    description: ""
-    
-  - name: "exempt_number"
-    type: "string"
-    description: ""  
-
-   - name: "created_from_ip"
-    type: "string"
-    description: ""  
-
-  - name: "is_location_valid"
-    type: "boolean"
-    description: ""  
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""
-    
-  - name: "customer_type"
-    type: "string"
-    description: ""
-
-  - name: "exemption_details"
-    type: "string"
-    description: ""
-
-  - name: "fraud_flag"
-    type: "string"
-    description: ""
-
-  - name: "meta_data"
-    type: "string"
-    description: ""
-    
-  - name: "registered_for_gst"
-    type: "boolean"
-    description: ""    
 ---

--- a/_integration-schemas/chargebee/20-05-2019/events.md
+++ b/_integration-schemas/chargebee/20-05-2019/events.md
@@ -1,0 +1,2216 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "event"
+
+name: "events"
+doc-link: "https://apidocs.chargebee.com/docs/api/events"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/events.json"
+description: |
+  The `{{ table.name }}` table contains info about the events that have occurred on your {{ integration.display_name }} site. Event records contain data about affected resources and additional details, such as when the change occurred. This can be used to create a log of events for a record and analyze how it has changed over time.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List events"
+    doc-link: "https://apidocs.chargebee.com/docs/api/events#list_events"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The event ID."
+    foreign-key-id: "event-id"
+
+  - name: "occurred_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the event occurred."
+
+  - name: "api_version"
+    type: "string"
+    description: "The Chargebee API Version used for rendering this event content. Possible values are `v1` or `v2`."
+
+  - name: "content"
+    type: "object"
+    description: |
+      The data associated with the event. The attributes in this object will vary depending on the event type. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_types){:target="new"} for a list of possible event types.
+    subattributes:
+      - name: "coupon"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `coupon_created`
+          - `coupon_updated`
+          - `coupon_deleted`
+          - `coupon_set_created`
+          - `coupon_set_updated`
+          - `coupon_set_deleted`
+          - `coupon_codes_added`
+          - `coupon_codes_deleted`
+          - `coupon_codes_updated`
+        subattributes:
+          - name: "id"
+            type: "string"
+            description: "The coupon ID."
+            foreign-key-id: "coupon-id"
+
+          - name: "addon_constraint"
+            type: "string"
+            description: |
+              The addons the coupon can be applied to. Possible values are:
+
+              - `none`
+              - `all`
+              - `specific`
+              - `not_applicable`
+
+          - name: "apply_discount_on"
+            type: "string"
+            description: ""
+
+          - name: "apply_on"
+            type: "string"
+            description: |
+              The invoice items for which this coupon needs to be applied. Possible values are:
+
+              - `invoice_amount`: The coupon will be applied to the total invoice amount.
+              - `each_specified_item`: the discount will be applied to each specified plan and addon item.
+
+          - name: "archived_at"
+            type: "date-time"
+            description: "The time when the coupon was archived."
+
+          - name: "created_at"
+            type: "date-time"
+            description: "The time when the coupon was created."
+
+          - name: "discount_amount"
+            type: "number"
+            description: "When `discount_type: fixed_amount`, this value will be the discount value in cents."
+
+          - name: "discount_percentage"
+            type: "number"
+            description: "When `discount_type: percentage`, this value will be the discount value percentage."
+
+          - name: "discount_type"
+            type: "string"
+            description: |
+              The type of discount. Possible values are:
+
+              - `fixed_amount`
+              - `percentage`
+
+          - name: "duration_month"
+            type: "integer"
+            description: |
+              When `duration_type: limited_period`, this value will be the duration in months the coupon can be applied.
+
+          - name: "duration_type"
+            type: "string"
+            description: |
+              The duration the coupon is applicable. Possible values are:
+
+              - `one_time`
+              - `forever`
+              - `limited_period`
+
+          - name: "max_redemptions"
+            type: "integer"
+            description: "The maximum number of times the coupon can be redeemed."
+
+          - name: "name"
+            type: "string"
+            description: "The display name used in web interface for identifying the coupon."
+
+          - name: "object"
+            type: "string"
+            description: ""
+
+          - name: "plan_constraint"
+            type: "string"
+            description: |
+              The plans the coupon can be applied to. Possible values are:
+
+              - `none`
+              - `all`
+              - `specific`
+              - `not_applicable`
+
+          - name: "redemptions"
+            type: "integer"
+            description: "The number of times the coupon has been redeemed."
+
+          - name: "resource_version"
+            type: "integer"
+            description: "The version number of the coupon. Each update of the coupon results in an incremental change of this value. **Note**: This attribute will be present only if the coupon has been updated after 2016-09-28."
+
+          - name: "status"
+            type: "string"
+            description: |
+              The status of the coupon. Possible values are:
+
+              - `active`
+              - `expired`
+              - `archived`
+              - `deleted`
+
+          - name: "updated_at"
+            type: "date-time"
+            description: "The time the coupon was last updated."
+
+      - name: "customer"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `card_added`
+          - `card_updated`
+          - `card_expiry_reminder`
+          - `card_expired`
+          - `card_deleted`
+          - `customer_created`
+          - `customer_changed`
+          - `customer_deleted`
+          - `customer_moved_out`
+          - `customer_moved_in`
+          - `hierarchy_created`
+          - `hierarchy_deleted`
+          - `promotional_credits_added`
+          - `promotional_credits_deducted`
+          - `subscription_created`
+          - `subscription_started`
+          - `subscription_trial_end_reminder`
+          - `subscription_activated`
+          - `subscription_changed`
+          - `subscription_cancellation_scheduled`
+          - `subscription_cancellation_reminder`
+          - `subscription_cancelled`
+          - `subscription_reactivated`
+          - `subscription_renewed`
+          - `subscription_scheduled_cancellation_removed`
+          - `subscription_changes_scheduled`
+          - `subscription_scheduled_changes_removed`
+          - `subscription_shipping_address_updated`
+          - `subscription_deleted`
+          - `subscription_paused`
+          - `subscription_pause_scheduled`
+          - `subscription_scheduled_pause_removed`
+          - `subscription_resumed`
+          - `subscription_resumption_scheduled`
+          - `subscription_scheduled_resumption_removed`
+          - `subscription_renewal_reminder`
+          - `payment_source_added`
+          - `payment_source_updated`
+          - `payment_source_deleted`
+          - `payment_succeeded`
+          - `payment_failed`
+          - `payment_refunded`
+          - `payment_initiated`
+          - `refund_initiated`
+          - `virtual_bank_account_added`
+          - `virtual_bank_account_updated`
+          - `virtual_bank_account_deleted`
+        subattributes:
+          - name: "id"
+            type: "string"
+            description: "The customer ID."
+            foreign-key-id: "customer-id"
+
+          - name: "allow_direct_debit"
+            type: "boolean"
+            description: "Indicates whether the customer can pay via direct debit or not."
+
+          - name: "auto_collection"
+            type: "string"
+            description: |
+              Indicates whether payments need to be automatically collected for the customer. Possible values are:
+
+              - `on`: When an invoice is created, an automatic attempt to charge the customer's payment method is made.
+              - `off`: Automatic collection of charges will not be made.
+
+          - name: "balances"
+            type: "array"
+            description: "The list of balances for the customer."
+            subattributes:
+              - name: "currency_code"
+                type: "string"
+                description: "The currency code in ISO 4217 for the balance."
+
+              - name: "excess_payments"
+                type: "integer"
+                description: "The total unused payments associated with the customer."
+
+              - name: "promotional_credits"
+                type: "integer"
+                description: "The promotional credits balance for the customer."
+
+              - name: "refundable_credits "
+                type: "integer"
+                description: "The refundable credits balance for the customer."
+
+              - name: "unbilled_charges"
+                type: "integer"
+                description: "The total unbilled charges for the customer."
+
+          - name: "billing_address"
+            type: "object"
+            description: "The billing address for the customer."
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: "The city."
+
+              - name: "company"
+                type: "string"
+                description: "The company."
+
+              - name: "country"
+                type: "string"
+                description: "The country."
+
+              - name: "email"
+                type: "string"
+                description: "The email."
+
+              - name: "first_name"
+                type: "string"
+                description: "The first name."
+
+              - name: "last_name"
+                type: "string"
+                description: "The last name."
+
+              - name: "line1"
+                type: "string"
+                description: "The first line of the address."
+
+              - name: "line2"
+                type: "string"
+                description: "The second line of the address."
+
+              - name: "line3"
+                type: "string"
+                description: "The third line of the address."
+
+              - name: "phone"
+                type: "string"
+                description: "The phone number."
+
+              - name: "state"
+                type: "string"
+                description: "The state or province."
+
+              - name: "state_code"
+                type: "string"
+                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
+
+              - name: "validation_status"
+                type: "string"
+                description: |
+                  The address verification status. Possible values are:
+
+                  - `not_validated`
+                  - `valid`
+                  - `partially_valid`
+                  - `invalid`
+
+              - name: "zip"
+                type: "string"
+                description: "The zip or postal code."
+
+          - name: "billing_date"
+            type: "boolean"
+            description: "**Applicable when calendar billing (with customer specific billing date support) is enabled**. When set, renewals of all the monthly and yearly subscriptions of this customer will be aligned to this date."
+
+          - name: "billing_date_mode"
+            type: "string"
+            description: |
+              Indicates whether this customer's `billing_date` value is derived as per configurations or its specifically set (overriden). When specifically set, the `billing_date` will not be reset even when all of the monthly/yearly subscriptions are cancelled.
+
+              Possible values are:
+
+              - `using_defaults`: The `billing_date` value is set based on configured defaults.
+              - `manually_set`: The `billing_date` is specifically set.
+
+          - name: "billing_day_of_week"
+            type: "boolean"
+            description: |
+              **Applicable when calendar billing (with customer specific billing date support) is enabled**. When set, renewals of all the weekly subscriptions of this customer will be aligned to this week day.
+
+              Possible values are:
+
+              - `monday`
+              - `tuesday`
+              - `wednesday`
+              - `thursday`
+              - `friday`
+              - `saturday`
+              - `sunday`
+
+          - name: "billing_day_of_week_mode"
+            type: "string"
+            description: |
+              Indicates whether this customer's `billing_day_of_week` value is derived as per configurations or its specifically set (overriden). When specifically set, the `billing_day_of_week` will not be reset even when all of the weekly subscriptions are cancelled.
+
+              Possible values are:
+
+              - `using_defaults`: The `billing_day_of_week` value is set based on configured defaults.
+              - `manually_set`: The `billing_day_of_week` is specifically set.
+
+          - name: "card_status"
+            type: "string"
+            description: ""
+
+          - name: "cf_company_id"
+            type: "integer"
+            description: ""
+
+          - name: "company"
+            type: "string"
+            description: "The name of the company associated with the customer."
+
+          - name: "consolidated_invoicing"
+            type: "boolean"
+            description: "**Applicable when consolidated invoicing is enabled**. Indicates whether invoice consolidation should happen during subscription renewals. Needs to be set only if this value is different from the defaults configured."
+
+          - name: "contacts"
+            type: "array"
+            description: "A list of contacts associated with the customer."
+            subattributes:
+              - name: "email"
+                type: "string"
+                description: "The contact's email."
+
+              - name: "enabled"
+                type: "boolean"
+                description: "Indicates whether the contacted is enabled (`true`) or disabled (`false`)."
+
+              - name: "first_name"
+                type: "string"
+                description: "The first name of the contact."
+
+              - name: "id"
+                type: "string"
+                description: "The contact ID."
+
+              - name: "label"
+                type: "string"
+                description: "The label/tag provided for the contact."
+
+              - name: "last_name"
+                type: "string"
+                description: "The last name of the contact."
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+              - name: "phone"
+                type: "string"
+                description: "The phone number of the contact."
+
+              - name: "send_account_email"
+                type: "string"
+                description: "Indicates whether account emails are enabled for the contact."
+
+              - name: "send_billing_email"
+                type: "string"
+                description: "Indicates whether billing emails are enabled for the contact."
+
+          - name: "created_at"
+            type: "date-time"
+            description: "The time the customer was created."
+
+          - name: "deleted"
+            type: "boolean"
+            description: "Indicates whether the customer has been deleted or not."
+
+          - name: "email"
+            type: "string"
+            description: "The customer's email address."
+
+          - name: "excess_payments"
+            type: "integer"
+            description: "The total unused payments associated with the customer."
+
+          - name: "first_name"
+            type: "string"
+            description: "The first name of the customer."
+
+          - name: "invoice_notes"
+            type: "string"
+            description: "Invoice notes associated with the customer."
+
+          - name: "last_name"
+            type: "string"
+            description: "The last name of the customer."
+
+          - name: "locale"
+            type: "string"
+            description: "Determines which region-specific language {{ integration.display_name }} uses to communicate with the customer."
+
+          - name: "net_term_days"
+            type: "integer"
+            description: "The number of days within which the customer has to make payment for invoices."
+
+          - name: "object"
+            type: "string"
+            description: ""
+
+          - name: "payment_method"
+            type: "object"
+            description: "The primary payment source for the customer."
+            subattributes:
+              - name: "gateway"
+                type: "string"
+                description: |
+                  The name of the gateway the payment is associated with. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/customers#customer_payment_method_gateway){:target="new"} for a full list of possible values.
+                doc-link: "https://apidocs.chargebee.com/docs/api/customers#customer_payment_method_gateway"
+
+              - name: "gateway_account_id"
+                type: "string"
+                description: "The gateway account the payment method is stored with."
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+              - name: "reference_id"
+                type: "string"
+                description: |
+                  The reference ID.
+
+                  - For **Amazon** and **PayPal**, this will be the billing agreement ID.
+                  - For **GoCardless direct debit**, this will be the mandate ID.
+                  - For **card payments**, this will be the ID provided by the gateway/card vault for the specific payment method.
+
+              - name: "status"
+                type: "string"
+                description: |
+                  The current status of the payment method. Possible values include:
+
+                  - `valid`
+                  - `expiring`
+                  - `expired`
+                  - `invalid`
+                  - `pending_verification`
+
+              - name: "type"
+                type: "string"
+                description: |
+                  The type of the payment source. Possible values include:
+
+                  - `card` (Includes credit and debit cards)
+                  - `paypal_express_checkout`
+                  - `amazon_payments`
+                  - `direct_debit`
+                  - `generic`
+                  - `alipay`
+                  - `unionpay`
+                  - `apple_pay`
+                  - `wechat_pay`
+
+          - name: "phone"
+            type: "string"
+            description: "The customer's phone number."
+
+          - name: "pii_cleared"
+            type: "string"
+            description: |
+              Indicates whether the customer's personal info has been cleared. Possible values are:
+
+              - `active`
+              - `scheduled_for_clear`
+              - `cleared`
+
+          - name: "preferred_currency_code"
+            type: "string"
+            description: "**Applicable if the {{ integration.display_name }} Multicurrency feature is enabled.** The currency code of the customer's preferred currency (ISO 4217 format)."
+
+          - name: "primary_payment_source_id"
+            type: "string"
+            description: "The ID of the primary payment source for the customer."
+
+          - name: "promotional_credits"
+            type: "integer"
+            description: "The promotional credits balance of the customer."
+
+          - name: "referral_urls"
+            type: "array"
+            description: "A list of referral URLs for the customer."
+            subattributes:
+              - name: "created_at"
+                type: "date-time"
+                description: "The time the referral URL was created."
+
+              - name: "external_customer_id"
+                type: "string"
+                description: "The ID of the external customer in the referral system."
+
+              - name: "referral_account_id"
+                type: "string"
+                description: "The ID of the referral account."
+
+              - name: "referral_campaign_id"
+                type: "string"
+                description: "The ID of the referral campaign."
+
+              - name: "referral_external_account_id"
+                type: "string"
+                description: "The ID of the external referral account."
+
+              - name: "referral_sharing_url"
+                type: "string"
+                description: "The referral sharing URL for the customer."
+
+              - name: "referral_system"
+                type: "string"
+                description: |
+                  The URL for the referral system account. Possible values are:
+
+                  - `referral_candy`
+                  - `referral_saasquatch`
+                  - `friendbuy`
+
+              - name: "updated_at"
+                type: "date-time"
+                description: "The time the referral URL was last updated."
+
+          - name: "refundable_credits"
+            type: "integer"
+            description: "The refundable credits balance of the customer."
+
+          - name: "resource_version"
+            type: "integer"
+            description: "The version number of the customer. Each update of the customer results in an incremental change of this value. **Note**: This attribute will be present only if the customer has been updated after 2016-09-28."
+
+          - name: "taxability"
+            type: "string"
+            description: |
+              Indicates if the customer is liable for tax. Possible values are:
+
+              - `taxable`
+              - `exempt`
+
+          - name: "unbilled_charges"
+            type: "integer"
+            description: "The total unbilled charges for the customer."
+
+          - name: "updated_at"
+            type: "date-time"
+            description: "The time the customer was last updated."
+
+          - name: "vat_number"
+            type: "string"
+            description: "The VAT number for the customer."
+
+      - name: "invoice"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `invoice_generated`
+          - `invoice_updated`
+          - `invoice_deleted`
+          - `pending_invoice_created`
+          - `pending_invoice_updated`
+          - `payment_failed`
+          - `payment_initiated`
+          - `payment_refunded`
+          - `refund_initiated`
+          - `subscription_created`
+          - `subscription_started`
+          - `subscription_activated`
+          - `subscription_changed`
+          - `subscription_cancelled`
+          - `subscription_reactivated`
+          - `subscription_renewed`
+          - `subscription_paused`
+          - `subscription_resumed`
+        subattributes:
+          - name: "id"
+            type: "string"
+            description: "The invoice ID."
+            foreign-key-id: "invoice-id"
+
+          - name: "updated_at"
+            type: "date-time"
+            description: "The time the invoice was last updated."
+
+          - name: "adjustment_credit_notes"
+            type: "array"
+            description: "Details about the adjustments created for the invoice."
+            subattributes: &credit-note
+              - name: "cn_date"
+                type: "date-time"
+                description: "The date at which the credit note was created."
+
+              - name: "cn_id"
+                type: "string"
+                description: "The credit note ID."
+                foreign-key-id: "credit-note-id"
+
+              - name: "cn_reason_code"
+                type: "string"
+                description: &cn-reason-code |
+                  The reason for the credit note. Possible values are:
+
+                  - `write_off`
+                  - `subscription_change`
+                  - `subscription_cancellation`
+                  - `subscription_pause`
+                  - `chargeback`
+                  - `product_unsatisfactory`
+                  - `service_unsatisfactory`
+                  - `order_change`
+                  - `order_cancellation`
+                  - `waiver`
+                  - `other`
+                  - `fraudulent`
+
+              - name: "cn_status"
+                type: "string"
+                description: &cn-status |
+                  The status of the credit note. Possible values are:
+
+                  - `adjusted`
+                  - `refunded`
+                  - `refund_due`
+                  - `voided`
+
+              - name: "cn_total"
+                type: "integer"
+                description: "The total amount of the credit note."
+
+          - name: "amount_adjusted"
+            type: "integer"
+            description: "The total adjusted amount made against the invoice."
+
+          - name: "amount_due"
+            type: "integer"
+            description: "The total amount to be collected, include the invoice's payments in progress."
+
+          - name: "amount_paid"
+            type: "integer"
+            description: "The total payments received for the invoice."
+
+          - name: "amount_to_collect"
+            type: "integer"
+            description: "The total amount to be collected."
+
+          - name: "applied_credits"
+            type: "array"
+            description: "The refundable credits applied on the invoice."
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: "The applied amount, in cents."
+
+              - name: "applied_at"
+                type: "date-time"
+                description: "The time the credit was applied."
+
+              - name: "cn_date"
+                type: "date-time"
+                description: "The date the credit was created."
+
+              - name: "cn_id"
+                type: "string"
+                description: "The credit ID."
+                foreign-key-id: "credit-note-id"
+
+              - name: "cn_reason_code"
+                type: "string"
+                description: *cn-reason-code
+
+              - name: "cn_status"
+                type: "string"
+                description: *cn-status
+
+          - name: "base_currency_code"
+            type: "string"
+            description: ""
+
+          - name: "billing_address"
+            type: "object"
+            description: "The billing address for the invoice."
+            subattributes: &address
+              - name: "city"
+                type: "string"
+                description: "The city."
+
+              - name: "company"
+                type: "string"
+                description: "The company."
+
+              - name: "country"
+                type: "string"
+                description: "The country."
+
+              - name: "email"
+                type: "string"
+                description: "The email."
+
+              - name: "first_name"
+                type: "string"
+                description: "The first name."
+
+              - name: "last_name"
+                type: "string"
+                description: "The last name."
+
+              - name: "line1"
+                type: "string"
+                description: "The first line of the address."
+
+              - name: "line2"
+                type: "string"
+                description: "The second line of the address."
+
+              - name: "line3"
+                type: "string"
+                description: "The third line of the address."
+
+              - name: "phone"
+                type: "string"
+                description: "The phone number."
+
+              - name: "state"
+                type: "string"
+                description: "The state or province."
+
+              - name: "state_code"
+                type: "string"
+                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
+
+              - name: "validation_status"
+                type: "string"
+                description: |
+                  The address verification status. Possible values are:
+
+                  - `not_validated`
+                  - `valid`
+                  - `partially_valid`
+                  - `invalid`
+
+              - name: "zip"
+                type: "string"
+                description: "The zip or postal code."
+
+          - name: "credits_applied"
+            type: "integer"
+            description: "The total credits applied against the invoice."
+
+          - name: "currency_code"
+            type: "string"
+            description: "The currency code (ISO 4217 format) for the invoice."
+
+          - name: "customer_id"
+            type: "string"
+            description: "The ID of the customer the invoice is for."
+            foreign-key-id: "customer-id"
+
+          - name: "date"
+            type: "date-time"
+            description: |
+              Closing date of the invoice. Typically this is the date on which invoice is generated. If "wait & notify to send invoices enabled for usage based billing" is enabled in {{ integration.display_name }}, this will not be the same as date on which invoice was actually sent to customer.
+
+          - name: "deleted"
+            type: "boolean"
+            description: "Indicates if the invoice has been deleted or not."
+
+          - name: "discounts"
+            type: "array"
+            description: "Details about the discounts applied to the invoice."
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: "The discount amount, in cents."
+
+              - name: "description"
+                type: "string"
+                description: "The description of the discount line item."
+
+              - name: "entity_id"
+                type: "string"
+                description: "The ID of the entity the discount amount is based on. This value will only be present if `entity_type` is `item_level_coupon` or `document_level_coupon`."
+                foreign-key-id: "coupon-id"
+
+              - name: "entity_type"
+                type: "string"
+                description: &discount-line-item |
+                  The type of the discount line item. Possible values are:
+
+                  - `item_level_coupon`: Represents item-level coupons applied to the invoice.
+                  - `document_level_coupon`: Represents document-level coupons applied to the document.
+                  - `promotional_credits`: Represents promotional credits in the invoice.
+                  - `prorated_credits`: Represents credit adjustments in the invoice.
+
+          - name: "due_date"
+            type: "date-time"
+            description: "The due date of the invoice."
+
+          - name: "dunning_status"
+            type: "string"
+            description: |
+              The current dunning status of the invoice. Possible values are:
+
+              - `in_progress`
+              - `exhausted`
+              - `stopped`
+              - `success`
+
+          - name: "exchange_rate"
+            type: "number"
+            description: ""
+
+          - name: "expected_payment_date"
+            type: "date-time"
+            description: "The expected payment date recorded for the invoice."
+
+          - name: "first_invoice"
+            type: "boolean"
+            description: "Indicates if this is the first invoice raised for the subscription. If this is a non-recurring invoice, it indicates if this is the first invoice for the customer."
+
+          - name: "has_advance_charges"
+            type: "boolean"
+            description: "Indicates if there are any advanced charges present in the invoice."
+
+          - name: "is_gifted"
+            type: "boolean"
+            description: "Indicates if the invoice is gifted or not."
+
+          - name: "issued_credit_notes"
+            type: "array"
+            description: "A list of credit notes issued for the invoice."
+            subattributes: *credit-note
+
+          - name: "line_item_discounts"
+            type: "array"
+            description: "The list of discounts applied for each line item in the invoice."
+            subattributes:
+              - name: "coupon_id"
+                type: "string"
+                description: "The coupon ID."
+                foreign-key-id: "coupon-id"
+
+              - name: "discount_amount"
+                type: "integer"
+                description: "The amount of the discount."
+
+              - name: "discount_type"
+                type: "string"
+                description: |
+                  The type of discount. Possible values are:
+
+                  - `fixed_amount`
+                  - `percentage`
+
+              - name: "line_item_id"
+                type: "string"
+                description: "The ID of the line item the discount was applied to."
+                foreign-key-id: "line-item-id"
+
+          - name: "line_item_taxes"
+            type: "array"
+            description: "The list of taxes applied on line items."
+            subattributes:
+              - name: "line_item_id"
+                type: "string"
+                description: "The ID of the line item for which the tax is applicable."
+                foreign-key-id: "line-item-id"
+
+              - name: "tax_amount"
+                type: "integer"
+                description: "The tax amount, in cents."
+
+              - name: "tax_juris_code"
+                type: "string"
+                description: "The tax jurisdiction code."
+
+              - name: "tax_juris_name"
+                type: "string"
+                description: "The name of the tax jurisdiction."
+
+              - name: "tax_juris_type"
+                type: "string"
+                description: |
+                  The type of tax jurisdiction. Possible values are:
+
+                  - `country`
+                  - `federal`
+                  - `state`
+                  - `county`
+                  - `city`
+                  - `special`
+                  - `unincorporated` (Combined tax of state and country)
+                  - `other`
+
+              - name: "tax_name"
+                type: "string"
+                description: "The name of the tax applied."
+
+              - name: "tax_rate"
+                type: "number"
+                description: "The rate of tax used to calculate the tax amount."
+
+          - name: "line_items"
+            type: "array"
+            description: "The line items in the invoice."
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: "The total amount of the line item, calculated as `unit_amount x quantity`."
+
+              - name: "date_from"
+                type: "date-time"
+                description: "The start date of the line item."
+
+              - name: "date_to"
+                type: "date-time"
+                description: "The end date of the line item."
+
+              - name: "description"
+                type: "string"
+                description: "The description of the line item."
+
+              - name: "discount_amount"
+                type: "integer"
+                description: "The discount amount applied to the line item, in cents."
+
+              - name: "entity_id"
+                type: "string"
+                description: |
+                  The ID of the entity the line item is based on.
+
+              - name: "entity_type"
+                type: "string"
+                description: |
+                  The modelled entity (plan, addon, etc.) this line item is based on. Possible values are:
+
+                  - `plan_setup`: The line item is based on a plan setup charge. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+                  - `plan`: The line item is based on a plan entity. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+                  - `addon`: The line item is based on an addon entity. The `entity_id` will specify the addon ID ([`addons: id`](#addons)).
+                  - `adhoc`: The line item is not modelled. The `entity_id` attribute will be `null`.
+
+              - name: "id"
+                type: "string"
+                description: "The line item ID."
+                foreign-key-id: "line-item-id"
+
+              - name: "is_taxed"
+                type: "boolean"
+                description: "Indicates whether the line item is taxed or not."
+
+              - name: "item_level_discount_amount"
+                type: "integer"
+                description: "The item level discount amount for the line item, in cents."
+
+              - name: "pricing_model"
+                type: "string"
+                description: |
+                  Indicates how the charges for the line item are calculated. Possible values are:
+
+                  - `flat_fee`: Charges single price on a recurring basis.
+                  - `per_unit`: Charges the price for each unit of the plan for the subscription on a recurring basis.
+                  - `tiered`: Charges different per unit price for the quantity purchased from every tier.
+                  - `volume`: Charges the per unit price for the total quantity purchased based on the tier under which it falls.
+                  - `stairstep`: Charges a price for a range.
+
+              - name: "quantity"
+                type: "integer"
+                description: "The quantity of the recurring item, represented by the line item."
+
+              - name: "subscription_id"
+                type: "string"
+                description: "The ID of the subscription associated with the line item."
+                foreign-key-id: "subscription-id"
+
+              - name: "tax_amount"
+                type: "integer"
+                description: "The tax amount of the line item, in cents."
+
+              - name: "tax_exempt_reason"
+                type: "string"
+                description: |
+                  The reason or category for why the line item is excluded from the taxable amount. Possible values are:
+
+                  - `tax_not_configured`
+                  - `region_non_taxable`
+                  - `export`
+                  - `customer_exempt`
+                  - `zero_rated`
+                  - `reverse_charge`
+                  - `high_value_physical_good`
+
+              - name: "tax_rate"
+                type: "number"
+                description: "The rate of tax used to calculate tax for the line item."
+
+              - name: "unit_amount"
+                type: "integer"
+                description: "The unit amount of the line item, in cents."
+
+          - name: "linked_orders"
+            type: "array"
+            description: "A list of orders associated with the invoice."
+            subattributes:
+              - name: "batch_id"
+                type: "string"
+                description: "The batch ID."
+
+              - name: "created_at"
+                type: "date-time"
+                description: "the time the order was created."
+
+              - name: "fulfillment_status"
+                type: "string"
+                description: "The fulfillment status of an order as reflected in the shipping/order management application. Typical statuses include `Shipped`, `Awaiting Shipment`, `Not fulfilled`, etc."
+
+              - name: "id"
+                type: "string"
+                description: "The order ID."
+
+              - name: "reference_id"
+                type: "string"
+                description: "This attribute can be used to map the orders in the shipping/order management application to the orders in {{ integration.display_name }}. The `reference_id` generally is same as the order id in the third party application."
+
+              - name: "status"
+                type: "string"
+                description: |
+                  The status of the order. Possible values include:
+
+                  - `new`
+                  - `processing`
+                  - `complete`
+                  - `cancelled`
+                  - `voided`
+                  - `queued`
+                  - `awaiting_shipment`
+                  - `on_hold`
+                  - `delivered`
+                  - `shipped`
+                  - `partially_delivered`
+                  - `returned`
+
+          - name: "linked_payments"
+            type: "array"
+            description: "The list of payment transactions for the invoice."
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: "The transaction amount applied to the invoice."
+
+              - name: "applied_at"
+                type: "date-time"
+                description: "The time the amount was applied."
+
+              - name: "txn_amount"
+                type: "integer"
+                description: "The total amount of the transaction."
+
+              - name: "txn_date"
+                type: "date-time"
+                description: "The date the transaction occured."
+
+              - name: "txn_id"
+                type: "string"
+                description: "the transaction ID."
+                foreign-key-id: "transaction-id"
+
+              - name: "txn_status"
+                type: "string"
+                description: |
+                  The status of the transaction. Possible values are:
+
+                  - `in_progress`
+                  - `success`
+                  - `voided`
+                  - `failure`
+                  - `timeout`
+                  - `needs_attention`
+
+          - name: "net_term_days"
+            type: "integer"
+            description: "The number of days within which the invoice has to be paid."
+
+          - name: "new_sales_amount"
+            type: "integer"
+            description: ""
+
+          - name: "next_retry_at"
+            type: "date-time"
+            description: "A timestamp indicating when the next attempt to collect payment for this invoice will occur."
+
+          - name: "notes"
+            type: "array"
+            description: |
+              The list of notes associated with the invoice. If entity_type & entity_id are not present, then it is general notes (i.e Notes input provided under **Customize Invoice** action in {{ integration.display_name }} web interface).
+            subattributes:
+              - name: "entity_id"
+                type: "string"
+                description: "The entity ID."
+
+              - name: "entity_type"
+                type: "string"
+                description: |
+                  The type of entity the note belongs to. Possible values are:
+
+                  - [`plan`](#plans)
+                  - [`addon`](#addons)
+                  - [`coupon`](#coupons)
+                  - [`subscription`](#subscriptions)
+                  - [`customer`](#customers)
+
+              - name: "note"
+                type: "string"
+                description: "The content of the note."
+
+          - name: "object"
+            type: "string"
+            description: ""
+
+          - name: "paid_at"
+            type: "date-time"
+            description: "The time the invoice was paid."
+
+          - name: "po_number"
+            type: "string"
+            description: "The number of the purchase order associated with the invoice."
+
+          - name: "price_type"
+            type: "string"
+            description: |
+              The price type of the invoice. Possible values are:
+
+                - `tax_exclusive`
+                - `tax_inclusive`
+
+          - name: "recurring"
+            type: "boolean"
+            description: "Indicates if the invoice belongs to a subscription or not."
+
+          - name: "resource_version"
+            type: "integer"
+            description: "The version number of the invoice. Each update of the invoice results in an incremental change of this value. **Note**: This attribute will be present only if the invoice has been updated after 2016-09-28."
+
+          - name: "round_off_amount"
+            type: "integer"
+            description: "The invoice rounded-off amount, in cents."
+
+          - name: "shipping_address"
+            type: "object"
+            description: "The shipping address for the invoice."
+            subattributes: *address
+
+          - name: "status"
+            type: "string"
+            description: |
+              The status of the invoice. Possible values are:
+
+              - `paid`
+              - `posted`
+              - `payment_due`
+              - `not_paid`
+              - `voided`
+              - `pending`
+
+          - name: "sub_total"
+            type: "integer"
+            description: "The subtotal of the invoice, in cents."
+
+          - name: "subscription_id"
+            type: "string"
+            description: "The ID of the subscription associated with the invoice."
+            foreign-key-id: "subscription-id"
+
+          - name: "tax"
+            type: "integer"
+            description: "The total tax amount for the invoice, in cents."
+
+          - name: "taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: "The tax amount, in cents."
+
+              - name: "description"
+                type: "string"
+                description: "The description of the tax item."
+
+              - name: "name"
+                type: "string"
+                description: "The name of the tax applied. For example: `GST`"
+
+          - name: "term_finalized"
+            type: "boolean"
+            description: "Indicates if the invoice line item terms are finalized or not."
+
+          - name: "total"
+            type: "integer"
+            description: "The total invoiced amount, in cents."
+
+          - name: "vat_number"
+            type: "string"
+            description: "The VAT number."
+
+          - name: "voided_at"
+            type: "date-time"
+            description: "The time the invoice was voided."
+
+          - name: "write_off_amount"
+            type: "integer"
+            description: "The amount written off against the invoice, in cents."
+
+      - name: "plan"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `plan_created`
+          - `plan_updated`
+          - `plan_deleted`
+
+        subattributes:
+          - name: "billing_cycles"
+            type: "integer"
+            description: "The number of billing cycles the subscription is active."
+
+          - name: "charge_model"
+            type: "string"
+            description: |
+              Defines how the recurring charges for the subscription are calculated. Possible values are:
+
+              - `flat_fee`
+              - `per_unit`
+              - `tiered`
+              - `volume`
+              - `stairstep`
+
+          - name: "description"
+            type: "string"
+            description: "The description of the plan to show in hosted pages and the customer portal."
+
+          - name: "free_quantity"
+            type: "integer"
+            description: "The free quantity the subscriptions of the plan will have. Only quantities more than this value will be charged for the subscription."
+
+          - name: "id"
+            type: "string"
+            description: "The plan ID."
+            foreign-key-id: "plan-id"
+
+          - name: "invoice_notes"
+            type: "string"
+            description: "Invoice notes associated with the subscription."
+
+          - name: "name"
+            type: "string"
+            description: "The display name of the plan."
+
+          - name: "period"
+            type: "integer"
+            description: |
+              Defines the billing frequency for the plan. Used with `period_unit` to create a billing schedule for the plan.
+
+              For example: If `period_unit: week` and `period: 3`, billing would occur every `3 weeks`.
+
+          - name: "period_unit"
+            type: "string"
+            description: |
+              The time unit for the billing period. Used with `period` to create a billing schedule for the plan.
+
+              For example: If `period_unit: week` and `period: 3`, billing would occur every `3 weeks`.
+
+              Possible values are:
+
+              - `day`
+              - `week`
+              - `month`
+              - `year`
+
+          - name: "price"
+            type: "integer"
+            description: "The price of the plan."
+
+          - name: "redirect_url"
+            type: "string"
+            description: "The URL to redirect on successful checkout."
+
+          - name: "setup_cost"
+            type: "integer"
+            description: "The one-time setup fee charged as part of the first invoice for the plan."
+
+          - name: "sku"
+            type: "string"
+            description: "Ssed as Product name/code in your third party accounting application. {{ integration.display_name }} will use it as an alternate name in your accounting application."
+
+          - name: "status"
+            type: "string"
+            description: |
+              The plan state. Possible values are:
+
+              - `active`
+              - `archived`
+
+          - name: "tax_profile_id"
+            type: "string"
+            description: "The ID of the tax profile for the plan."
+
+          - name: "taxable"
+            type: "boolean"
+            description: "Indicates if the plan is taxable or not."
+
+          - name: "trial_period"
+            type: "integer"
+            description: |
+              The free time window for the customer to try the product. Used with `trial_period_unit` to create the free trial period.
+
+              For example: If `trial_period: day` and `trial_period_unit: 14`, the trial period would be `14 days`.
+
+          - name: "trial_period_unit"
+            type: "string"
+            description: |
+              The time unit for the trial period. Used with `trial_period` to create the free trial period.
+
+              For example: If `trial_period: day` and `trial_period_unit: 14`, the trial period would be `14 days`.
+
+              Possible values are:
+
+              - `day`
+              - `month`
+
+          - name: "updated_at"
+            type: "date-time"
+            description: "The time the plan was last updated."
+
+      - name: "subscription"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `customer_deleted`
+          - `payment_succeeded`
+          - `payment_failed`
+          - `payment_refunded`
+          - `payment_initiated`
+          - `refund_initiated`
+          - `subscription_created`
+          - `subscription_started`
+          - `subscription_trial_end_reminder`
+          - `subscription_activated`
+          - `subscription_changed`
+          - `subscription_cancellation_scheduled`
+          - `subscription_cancellation_reminder`
+          - `subscription_cancelled`
+          - `subscription_reactivated`
+          - `subscription_renewed`
+          - `subscription_scheduled_cancellation_removed`
+          - `subscription_changes_scheduled`
+          - `subscription_scheduled_changes_removed`
+          - `subscription_shipping_address_updated`
+          - `subscription_deleted`
+          - `subscription_paused`
+          - `subscription_pause_scheduled`
+          - `subscription_scheduled_pause_removed`
+          - `subscription_resumed`
+          - `subscription_resumption_scheduled`
+          - `subscription_scheduled_resumption_removed`
+          - `subscription_renewal_reminder`
+        subattributes:
+          - name: "activated_at"
+            type: "date-time"
+            description: "The time at which the subscription moved from `in_trial` to `active`."
+
+          - name: "addons"
+            type: "array"
+            description: "Details about the addon(s) associated with the subscription."
+            subattributes:
+              - name: "id"
+                type: "string"
+                description: "The addon ID."
+                foreign-key-id: "addon-id"
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+              - name: "quantity"
+                type: "integer"
+                description: "**Applicable only for the quantity based addons.** The quantity."
+
+              - name: "remaining_billing_cycles"
+                type: "integer"
+                description: "The number of billing cycles this addon will be attached to subscription."
+
+              - name: "trial_end"
+                type: "date-time"
+                description: "The time at which the trial ends for the addon."
+
+              - name: "unit_price"
+                type: "integer"
+                description: &addon-unit-price |
+                  The amount that will override the addon's default price. The plan's billing frequency will not be considered for overriding. E.g. If the plan's billing frequency is every 3 months, and if the price override amount is $10, $10 will be used, and not $30 (i.e $10*3).
+
+          - name: "affiliate_token"
+            type: "string"
+            description: "A unique tracking token for the subscription."
+
+          - name: "auto_collection"
+            type: "string"
+            description: |
+              Defines whether payments need to be collected automatically for this subscription. Possible values are:
+
+              - `on`
+              - `off`
+
+          - name: "base_currency_code"
+            type: "string"
+            description: "The base currency code for the subscription in ISO 4217 format."
+
+          - name: "billing_period"
+            type: "integer"
+            description: |
+              Defines the billing frequency for the subscription. Used with `billing_period_unit`, this determines how the customer is billed for the subscription.
+
+              For example: If `billing_period_unit: week` and `billing_period: 3`, the customer would be billed every `3 weeks`.
+
+          - name: "billing_period_unit"
+            type: "string"
+            description: |
+              Defines the billing period for the subscription. Used with `billing_period`, this determines how the customer is billed for the subscription.
+
+              For example: If `billing_period_unit: week` and `billing_period: 3`, the customer would be billed every `3 weeks`.
+
+              Possible values are:
+
+              - `day`
+              - `week`
+              - `month`
+              - `year`
+
+          - name: "cancel_reason"
+            type: "string"
+            description: |
+              The possible reason the subscription might be cancelled. Possible values are:
+
+              - `not_paid`
+              - `no_card`
+              - `fraud_review_failed`
+              - `non_compliant_eu_customer`
+              - `tax_calculation_failed`
+              - `currency_incompatible_with_gateway`
+              - `non_compliant_customer`
+
+          - name: "cancelled_at"
+            type: "date-time"
+            description: "The time at which subscription was cancelled or is set to be cancelled."
+
+          - name: "charged_event_based_addons"
+            type: "array"
+            description: "A list of event-based addons that have already been charged."
+            subattributes:
+              - name: "id"
+                type: "string"
+                description: "The addon ID."
+                foreign-key-id: "addon-id"
+
+              - name: "last_charged_at"
+                type: "date-time"
+                description: "The time when the addon was last charged for the subscription."
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+          - name: "coupon"
+            type: "string"
+            description: ""
+
+          - name: "coupons"
+            type: "array"
+            description: "Details about the coupon(s) associated with the subscription."
+            subattributes:
+              - name: "applied_count"
+                type: "integer"
+                description: "The number of times the coupon has been applied for the subscription."
+
+              - name: "apply_till"
+                type: "date-time"
+                description: "**Applicable for `limited month` coupons.** The date till the coupon is to be applied."
+
+              - name: "coupon_code"
+                type: "string"
+                description: "The coupon code used to redeem the coupon."
+
+              - name: "coupon_id"
+                type: "string"
+                description: "The coupon ID."
+                foreign-key-id: "coupon-id"
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+          - name: "created_at"
+            type: "date-time"
+            description: "The time the subscription was created."
+
+          - name: "currency_code"
+            type: "string"
+            description: "The currency code for the subscription in ISO 4217 format."
+
+          - name: "current_term_end"
+            type: "date-time"
+            description: "The end of the current billing term for the subscription, after which the subscription will be immediately renewed."
+
+          - name: "current_term_start"
+            type: "date-time"
+            description: "The start of the current billing term for the subscription."
+
+          - name: "customer_id"
+            type: "string"
+            description: "The ID of the customer associated with the subscription."
+            foreign-key-id: "customer-id"
+
+          - name: "deleted"
+            type: "boolean"
+            description: "Indicates if the subscription has been deleted or not."
+
+          - name: "due_invoices_count"
+            type: "integer"
+            description: "The total number of invoices that are due for payment."
+
+          - name: "event_based_addons"
+            type: "array"
+            description: "A list of non-recurring addons associated with the subscription that will be charged on the occurrence of a specified event."
+            subattributes:
+              - name: "charge_once"
+                type: "boolean"
+                description: "If enabled, the addon will be charged only at the first occurrence of the event."
+
+              - name: "id"
+                type: "string"
+                description: "The addon ID."
+                foreign-key-id: "addon-id"
+
+              - name: "object"
+                type: "string"
+                description: ""
+
+              - name: "on_event"
+                type: "string"
+                description: "The event on which the addon will be charged."
+
+              - name: "quantity"
+                type: "integer"
+                description: "**Applicable only for the quantity based addons**. The addon quantity."
+
+              - name: "unit_price"
+                type: "integer"
+                description: *addon-unit-price
+
+          - name: "exchange_rate"
+            type: "number"
+            description: "The exchange rate used for base currency conversion."
+
+          - name: "has_scheduled_changes"
+            type: "boolean"
+            description: "If true, there are subscription changes scheduled on next renewal."
+
+          - name: "id"
+            type: "string"
+            description: "The subscription ID."
+            foreign-key-id: "subscription-id"
+
+          - name: "invoice_notes"
+            type: "string"
+            description: "The invoice notes for the subscription."
+
+          - name: "mrr"
+            type: "integer"
+            description: "The monthly recurring revenue for the subscription, in cents."
+
+          - name: "next_billing_at"
+            type: "date-time"
+            description: "The date on which the next billing occurs."
+
+          - name: "object"
+            type: "string"
+            description: ""
+
+          - name: "payment_source_id"
+            type: "string"
+            description: "The ID of the payment source associated with the subscription."
+            foreign-key-id: "payment-source-id"
+
+          - name: "plan_amount"
+            type: "integer"
+            description: ""
+
+          - name: "plan_free_quantity"
+            type: "integer"
+            description: "The units of the item that will be free with the plan associated with the subscription."
+
+          - name: "plan_id"
+            type: "string"
+            description: "The ID of the plan associated with the subscription."
+            foreign-key-id: "plan-id"
+
+          - name: "plan_quantity"
+            type: "integer"
+            description: "The plan quantity for the subscription."
+
+          - name: "plan_unit_price"
+            type: "integer"
+            description: "The amount that will override the plan's default price."
+
+          - name: "po_number"
+            type: "string"
+            description: "The purchase order number associated with the subscription."
+
+          - name: "referral_info"
+            type: "object"
+            description: "The referral details for the subscription, if applicable."
+            subattributes:
+              - name: "account_id"
+                type: "string"
+                description: "The referral account ID."
+
+              - name: "campaign_id"
+                type: "string"
+                description: "The referral campaign ID."
+
+              - name: "coupon_code"
+                type: "string"
+                description: "The referral coupon code."
+
+              - name: "destination_url"
+                type: "string"
+                description: "The destination URL for the campaign."
+
+              - name: "external_campaign_id"
+                type: "string"
+                description: "The campaign ID in an external reference system."
+
+              - name: "external_reference_id"
+                type: "string"
+                description: "The reference ID in an external reference system."
+
+              - name: "friend_offer_type"
+                type: "string"
+                description: |
+                  The friend offer type for the referral campaign. Possible values are:
+
+                  - `none`
+                  - `coupon`
+                  - `coupon_code`
+
+              - name: "notify_referral_system"
+                type: "string"
+                description: |
+                  Indicates whether referral purchases should be notified to the referral system. Possible values are:
+
+                  - `none`
+                  - `first_paid_conversion`
+                  - `all_invoices`
+
+              - name: "post_purchase_widget_enabled"
+                type: "boolean"
+                description: "Indicates if a post purchase widget is enabled for the campaign."
+
+              - name: "referral_code"
+                type: "string"
+                description: "The referral code."
+
+              - name: "referral_status"
+                type: "string"
+                description: ""
+
+              - name: "referrer_id"
+                type: "string"
+                description: "The referrer ID."
+
+              - name: "referrer_reward_type"
+                type: "string"
+                description: |
+                  The referrer reward type for the referral campaign. Possible values are:
+
+                  - `none`
+                  - `referral_direct_reward`
+                  - `custom_promotional_credit`
+                  - `custom_revenue_percent_based`
+
+              - name: "reward_status"
+                type: "string"
+                description: |
+                  The reward status for the referral subscription. Possible values are:
+
+                  - `pending`
+                  - `paid`
+                  - `invalid`
+
+          - name: "remaining_billing_cycles"
+            type: "integer"
+            description: "The number of billing cycles the subscription will run."
+
+          - name: "resource_version"
+            type: "integer"
+            description: "The version number of the subscription. Each update of the subscription results in an incremental change of this value. **Note**: This attribute will be present only if the resource has been updated after 2016-09-28."
+
+          - name: "shipping_address"
+            type: "object"
+            description: "The shipping address for the subscription."
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: "The city."
+
+              - name: "company"
+                type: "string"
+                description: "The company."
+
+              - name: "country"
+                type: "string"
+                description: "The country."
+
+              - name: "email"
+                type: "string"
+                description: "The email."
+
+              - name: "first_name"
+                type: "string"
+                description: "The first name."
+
+              - name: "last_name"
+                type: "string"
+                description: "The last name."
+
+              - name: "line1"
+                type: "string"
+                description: "The first line of the address."
+
+              - name: "line2"
+                type: "string"
+                description: "The second line of the address."
+
+              - name: "line3"
+                type: "string"
+                description: "The third line of the address."
+
+              - name: "phone"
+                type: "string"
+                description: "The phone number."
+
+              - name: "state"
+                type: "string"
+                description: "The state or province."
+
+              - name: "state_code"
+                type: "string"
+                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
+
+              - name: "validation_status"
+                type: "string"
+                description: |
+                  The address verification status. Possible values are:
+
+                  - `not_validated`
+                  - `valid`
+                  - `partially_valid`
+                  - `invalid`
+
+              - name: "zip"
+                type: "string"
+                description: "The zip or postal code."
+
+          - name: "start_date"
+            type: "date-time"
+            description: |
+              **Applicable only when `status: future`**. The scheduled start time of the future subscription.
+
+          - name: "started_at"
+            type: "date-time"
+            description: |
+              The time when the subscription started. This value will be `null` for future subscriptions.
+
+          - name: "status"
+            type: "string"
+            description: |
+              The current status of the subscription. Possible values are:
+
+              - `future`
+              - `in_trial`
+              - `active`
+              - `non_renewing`
+              - `paused`
+              - `cancelled`
+
+          - name: "trial_end"
+            type: "date-time"
+            description: |
+              The end of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
+
+          - name: "trial_start"
+            type: "date-time"
+            description: |
+              The start of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
+
+          - name: "updated_at"
+            type: "date-time"
+            description: "The time the subscription was last updated."
+
+      - name: "transaction"
+        type: "object"
+        description: |
+          Applicable when `events.event_type` is one of the following:
+
+          - `authorization_succeeded`
+          - `authorization_voided`
+          - `payment_succeeded`
+          - `payment_failed`
+          - `payment_refunded`
+          - `payment_initiated`
+          - `refund_initiated`
+          - `transaction_created`
+          - `transaction_updated`
+          - `transaction_deleted`
+        subattributes:
+            - name: "amount"
+              type: "integer"
+              description: "The amount for the transaction."
+
+            - name: "amount_unused"
+              type: "integer"
+              description: "**Applicable only for payments.** The unused amount present for the transaction."
+
+            - name: "base_currency_code"
+              type: "string"
+              description: ""
+
+            - name: "currency_code"
+              type: "string"
+              description: "The currency code for the transaction, in ISO 4217 format."
+
+            - name: "customer_id"
+              type: "string"
+              description: "The ID of the customer associated with the transaction."
+              foreign-key-id: "customer-id"
+
+            - name: "date"
+              type: "date-time"
+              description: "The date the transaction occurred."
+
+            - name: "deleted"
+              type: "boolean"
+              description: "Indicates if the transaction has been deleted."
+
+            - name: "error_code"
+              type: "string"
+              description: "The error code received from the payment gateway on failure."
+
+            - name: "error_text"
+              type: "string"
+              description: "The error message received from the payment gateway on failure."
+
+            - name: "exchange_rate"
+              type: "number"
+              description: ""
+
+            - name: "fraud_flag"
+              type: "string"
+              description: |
+                Indicates whether or not the transaction has been identified as fraudulent. Possible values are:
+
+                - `safe`
+                - `suspicious`
+                - `fraudulent`
+
+            - name: "fraud_reason"
+              type: "string"
+              description: "A short description why the transaction was marked as fraudulent or suspicious."
+
+            - name: "gateway"
+              type: "string"
+              description: "The name of the gateway used to process the transaction."
+
+            - name: "gateway_account_id"
+              type: "string"
+              description: "The account ID of the gateway used to process the transaction."
+
+            - name: "id"
+              type: "string"
+              description: "The transaction ID."
+              foreign-key-id: "transaction-id"
+
+            - name: "id_at_gateway"
+              type: "string"
+              description: "The ID with which the transaction is referred in the `gateway`."
+
+            - name: "linked_credit_notes"
+              type: "array"
+              description: "**Applicable only for refund transactions.** The list of credit notes the transaction is associated with."
+              subattributes:
+                - name: "applied_amount"
+                  type: "integer"
+                  description: "The transaction amount applied to the invoice."
+
+                - name: "applied_at"
+                  type: "date-time"
+                  description: "The time the credit note was applied."
+
+                - name: "cn_date"
+                  type: "date-time"
+                  description: "The date the credit note was created."
+
+                - name: "cn_id"
+                  type: "string"
+                  description: "The credit note ID."
+                  foreign-key-id: "credit-note-id"
+
+                - name: "cn_reason_code"
+                  type: "string"
+                  description: |
+                    The reason for the credit note. Possible values are:
+
+                    - `write_off`
+                    - `subscription_change`
+                    - `subscription_cancellation`
+                    - `subscription_pause`
+                    - `chargeback`
+                    - `product_unsatisfactory`
+                    - `service_unsatisfactory`
+                    - `order_change`
+                    - `order_cancellation`
+                    - `waiver`
+                    - `other`
+                    - `fraudulent`
+
+                - name: "cn_reference_invoice_id"
+                  type: "string"
+                  description: "The invoice ID."
+                  foreign-key-id: "invoice-id"
+
+                - name: "cn_status"
+                  type: "string"
+                  description: |
+                    The status of the credit note. Possible values are:
+
+                    - `adjusted`
+                    - `refunded`
+                    - `refund_due`
+                    - `voided`
+
+                - name: "cn_total"
+                  type: "integer"
+                  description: "The total amount of the credit note."
+
+            - name: "linked_invoices"
+              type: "array"
+              description: "**Applicable only for payment transactions.** The list of invoices the transaction has been applied to."
+              subattributes:
+                - name: "applied_amount"
+                  type: "integer"
+                  description: "The transaction amount applied to the invoice."
+
+                - name: "applied_at"
+                  type: "date-time"
+                  description: "The time at which the transaction was applied."
+
+                - name: "invoice_date"
+                  type: "date-times"
+                  description: "The date the invoice was issued."
+
+                - name: "invoice_id"
+                  type: "string"
+                  description: "The invoice ID."
+                  foreign-key-id: "invoice-id"
+
+                - name: "invoice_status"
+                  type: "string"
+                  description: |
+                    The current status of the invoice. Possible values are:
+
+                    - `paid`
+                    - `posted`
+                    - `payment_due`
+                    - `not_paid`
+                    - `voided`
+                    - `pending`
+
+                - name: "invoice_total"
+                  type: "integer"
+                  description: "The total amount of the invoice."
+
+            - name: "linked_refunds"
+              type: "array"
+              description: "**Applicable only for payment transactions.** The list of refunds issued for the payment transaction."
+              subattributes:
+                - name: "txn_amount"
+                  type: "integer"
+                  description: "The total amount of the transaction."
+
+                - name: "txn_date"
+                  type: "date-time"
+                  description: "The date the transaction occured."
+
+                - name: "txn_id"
+                  type: "string"
+                  description: "the transaction ID."
+                  foreign-key-id: "transaction-id"
+
+                - name: "txn_status"
+                  type: "string"
+                  description: |
+                    The status of the transaction. Possible values are:
+
+                    - `in_progress`
+                    - `success`
+                    - `voided`
+                    - `failure`
+                    - `timeout`
+                    - `needs_attention`
+
+            - name: "masked_card_number"
+              type: "string"
+              description: "**Applicable only when `payment_method: card`.** The masked card number used for the transaction."
+
+            - name: "object"
+              type: "string"
+              description: ""
+
+            - name: "payment_method"
+              type: "string"
+              description: |
+                The payment method for the transaction. Possible values are:
+
+                - `card`
+                - `cash`
+                - `check`
+                - `chargeback`
+                - `bank_transfer`
+                - `amazon_payments`
+                - `paypal_express_checkout`
+                - `direct_debit`
+                - `alipay`
+                - `unionpay`
+                - `apple_pay`
+                - `wechat_pay`
+                - `ach_credit`
+                - `other`
+
+            - name: "payment_source_id"
+              type: "string"
+              description: "The ID of the payment source used for the transaction."
+              foreign-key-id: "payment-source-id"
+
+            - name: "reference_number"
+              type: "string"
+              description: "The reference number for the transaction."
+
+            - name: "reference_transaction_id"
+              type: "string"
+              description: "**Applicable only when `type` is `refund` or `payment_reversal`.** The reference payment ID."
+              foreign-key-id: "transaction-id"
+
+            - name: "refunded_txn_id"
+              type: "string"
+              description: "**Applicable only when `type: refund`**. The ID of the original transaction that was refunded."
+              foreign-key-id: "transaction-id"
+
+            - name: "resource_version"
+              type: "integer"
+              description: "The version number of the transaction. Each update of the transaction results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
+
+            - name: "reversal_txn_id"
+              type: "string"
+              description: "**Applicable only when `type: payment_reversal`**. The ID of the original transaction that was reversed."
+
+            - name: "settled_at"
+              type: "date-time"
+              description: "The time at which the final status of the transaction has been marked."
+
+            - name: "status"
+              type: "string"
+              description: |
+                The status of the transaction. Possible values are:
+
+                - `in_progress`
+                - `success`
+                - `voided`
+                - `failure`
+                - `timeout`
+                - `needs_attention`
+
+            - name: "subscription_id"
+              type: "string"
+              description: "The ID of the subscription associated with the transaction."
+              foreign-key-id: "subscription-id"
+
+            - name: "type"
+              type: "string"
+              description: |
+                The type of the transaction. Possible values are:
+
+                - `authorization`
+                - `payment`
+                - `refund`
+                - `payment_reversal`
+
+            - name: "updated_at"
+              type: "date-time"
+              description: "The time the transaction was last updated."
+
+            - name: "validated_at"
+              type: "date-time"
+              description: ""
+
+  - name: "event_type"
+    type: "string"
+    description: |
+      The event type. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_types){:target="new"} for a full list of possible event types.
+    doc-link: "https://apidocs.chargebee.com/docs/api/events#event_types"
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "source"
+    type: "string"
+    description: |
+      The source of the event. Possible values are:
+
+      - `admin_console`
+      - `api`
+      - `scheduled_job`
+      - `hosted_page`
+      - `portal`
+      - `system`
+      - `none`
+      - `js_api`
+      - `migration`
+      - `bulk_operation`
+      - `external_service`
+
+  - name: "user"
+    type: "string"
+    description: "The event created by the user."
+
+  - name: "webhook_status"
+    type: "string"
+    description: |
+      The current status of the webhook for this event. Possible values are:
+
+      - `not_configured`
+      - `scheduled`
+      - `succeeded`
+      - `re_scheduled`
+      - `failed`
+      - `skipped`
+      - `not_applicable`
+    doc-link: "https://apidocs.chargebee.com/docs/api/events#event_webhooks"
+---

--- a/_integration-schemas/chargebee/20-05-2019/foreign-keys.md
+++ b/_integration-schemas/chargebee/20-05-2019/foreign-keys.md
@@ -1,7 +1,7 @@
 ---
 tap-reference: "chargebee"
 
-version: "1"
+version: "20-05-2019"
 
 foreign-keys:
   - id: "addon-id"
@@ -63,9 +63,6 @@ foreign-keys:
         join-on: "entity_id"
       - table: "subscriptions"
         subattribute: "coupons"
-      - table: "orders"
-        subattribute: "line_item_discounts"
-        join-on: "coupon_id"  
 
   - id: "credit-note-id"
     attribute: "cn_id"
@@ -85,9 +82,6 @@ foreign-keys:
         subattribute: "adjustment_applied_credits"
       - table: "invoices"
         subattribute: "linked_credit_notes"
-      - table: "orders"
-        subattribute: "linked_credit_notes"
-        join-on: id  
 
   - id: "customer-id"
     attribute: "customer_id"
@@ -116,11 +110,6 @@ foreign-keys:
       - table: "gifts"
         subattribute: "gift_receiver"
         join-on: "customer_id"
-      - table: "gifts"
-        subattribute: "gifter"
-        join-on: "customer_id"
-      - table: "orders"
-        join-on: "customer_id"  
 
   - id: "line-item-id"
     attribute: "line_item_id"
@@ -150,12 +139,6 @@ foreign-keys:
         subattribute: "line_item_tiers"
       - table: "invoices"
         subattribute: "line_items"
-      - table: "orders"
-        subattribute: "line_item_discounts"
-        join-on: "line_item_id"
-      - table: "orders"
-        subattribute: "line_item_tax"
-        join-on: "line_item_id"    
 
   - id: "invoice-id"
     attribute: "invoice_id"
@@ -180,11 +163,6 @@ foreign-keys:
         join-on: "cn_reference_invoice_id"
       - table: "transactions"
         subattribute: "linked_payments"
-      - table: "gifts"
-        subattribute: "gifter"
-        join-on: "invoice_id"
-      - table: "orders"
-        join-on: "invoice_id" 
 
   - id: "plan-id"
     attribute: "plan_id"
@@ -242,11 +220,6 @@ foreign-keys:
       - table: "subscriptions"
         join-on: "id"
       - table: "transactions"
-      - table: "gifts"
-        subattribute: "gift_receiver"
-        join-on "subscription_id"
-      - table: "orders"
-        join-on: "subscription_id"  
 
   - id: "transaction-id"
     attribute: "txn_id"
@@ -280,20 +253,5 @@ foreign-keys:
         join-on: "reference_transaction_id"
       - table: "transactions"
         join-on: "refunded_txn_id"
-
-  - id: "order-id"
-    attribute: "id"
-    table: "orders"
-    all-foreign-keys:
-      - table: "orders"
-        join-on: "id"
-
-  - id: "gift-id"
-    attribute: "id"
-    table: "gifts"
-    all-foreign-keys:
-      - table: "gifts"
-        join-on: "id"
-      - table: "orders"
-        join-on: "gift_id"          
+     
 ---

--- a/_integration-schemas/chargebee/20-05-2019/invoices.md
+++ b/_integration-schemas/chargebee/20-05-2019/invoices.md
@@ -1,0 +1,656 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "invoice"
+
+name: "invoices"
+doc-link: "https://apidocs.chargebee.com/docs/api/invoices"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/invoices.json"
+description: |
+  The `{{ table.name }}` table contains info about the invoices in your {{ integration.display_name }} account. Invoices are statements containing charges, adjustments, and any discounts for a subscription specific to a term.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List invoices"
+    doc-link: "https://apidocs.chargebee.com/docs/api/invoices#list_invoices"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The invoice ID."
+    foreign-key-id: "invoice-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the invoice was last updated."
+
+  - name: "adjustment_credit_notes"
+    type: "array"
+    description: "Details about the adjustments created for the invoice."
+    subattributes: &credit-note
+      - name: "cn_date"
+        type: "date-time"
+        description: "The date at which the credit note was created."
+
+      - name: "cn_id"
+        type: "string"
+        description: "The credit note ID."
+        foreign-key-id: "credit-note-id"
+
+      - name: "cn_reason_code"
+        type: "string"
+        description: &cn-reason-code |
+          The reason for the credit note. Possible values are:
+
+          - `write_off`
+          - `subscription_change`
+          - `subscription_cancellation`
+          - `subscription_pause`
+          - `chargeback`
+          - `product_unsatisfactory`
+          - `service_unsatisfactory`
+          - `order_change`
+          - `order_cancellation`
+          - `waiver`
+          - `other`
+          - `fraudulent`
+
+      - name: "cn_status"
+        type: "string"
+        description: &cn-status |
+          The status of the credit note. Possible values are:
+
+          - `adjusted`
+          - `refunded`
+          - `refund_due`
+          - `voided`
+
+      - name: "cn_total"
+        type: "integer"
+        description: "The total amount of the credit note."
+
+  - name: "amount_adjusted"
+    type: "integer"
+    description: "The total adjusted amount made against the invoice."
+
+  - name: "amount_due"
+    type: "integer"
+    description: "The total amount to be collected, include the invoice's payments in progress."
+
+  - name: "amount_paid"
+    type: "integer"
+    description: "The total payments received for the invoice."
+
+  - name: "amount_to_collect"
+    type: "integer"
+    description: "The total amount to be collected."
+
+  - name: "applied_credits"
+    type: "array"
+    description: "The refundable credits applied on the invoice."
+    subattributes:
+      - name: "applied_amount"
+        type: "integer"
+        description: "The applied amount, in cents."
+
+      - name: "applied_at"
+        type: "date-time"
+        description: "The time the credit was applied."
+
+      - name: "cn_date"
+        type: "date-time"
+        description: "The date the credit was created."
+
+      - name: "cn_id"
+        type: "string"
+        description: "The credit ID."
+        foreign-key-id: "credit-note-id"
+
+      - name: "cn_reason_code"
+        type: "string"
+        description: *cn-reason-code
+
+      - name: "cn_status"
+        type: "string"
+        description: *cn-status
+
+  - name: "base_currency_code"
+    type: "string"
+    description: ""
+
+  - name: "billing_address"
+    type: "object"
+    description: "The billing address for the invoice."
+    subattributes: &address
+      - name: "city"
+        type: "string"
+        description: "The city."
+
+      - name: "company"
+        type: "string"
+        description: "The company."
+
+      - name: "country"
+        type: "string"
+        description: "The country."
+
+      - name: "email"
+        type: "string"
+        description: "The email."
+
+      - name: "first_name"
+        type: "string"
+        description: "The first name."
+
+      - name: "last_name"
+        type: "string"
+        description: "The last name."
+
+      - name: "line1"
+        type: "string"
+        description: "The first line of the address."
+
+      - name: "line2"
+        type: "string"
+        description: "The second line of the address."
+
+      - name: "line3"
+        type: "string"
+        description: "The third line of the address."
+
+      - name: "phone"
+        type: "string"
+        description: "The phone number."
+
+      - name: "state"
+        type: "string"
+        description: "The state or province."
+
+      - name: "state_code"
+        type: "string"
+        description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
+
+      - name: "validation_status"
+        type: "string"
+        description: |
+          The address verification status. Possible values are:
+
+          - `not_validated`
+          - `valid`
+          - `partially_valid`
+          - `invalid`
+
+      - name: "zip"
+        type: "string"
+        description: "The zip or postal code."
+
+  - name: "credits_applied"
+    type: "integer"
+    description: "The total credits applied against the invoice."
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code (ISO 4217 format) for the invoice."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer the invoice is for."
+    foreign-key-id: "customer-id"
+
+  - name: "date"
+    type: "date-time"
+    description: |
+      Closing date of the invoice. Typically this is the date on which invoice is generated. If "wait & notify to send invoices enabled for usage based billing" is enabled in {{ integration.display_name }}, this will not be the same as date on which invoice was actually sent to customer.
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indicates if the invoice has been deleted or not."
+
+  - name: "discounts"
+    type: "array"
+    description: "Details about the discounts applied to the invoice."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The discount amount, in cents."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the discount line item."
+
+      - name: "entity_id"
+        type: "string"
+        description: "The ID of the entity the discount amount is based on. This value will only be present if `entity_type` is `item_level_coupon` or `document_level_coupon`."
+        foreign-key-id: "coupon-id"
+
+      - name: "entity_type"
+        type: "string"
+        description: &discount-line-item |
+          The type of the discount line item. Possible values are:
+
+          - `item_level_coupon`: Represents item-level coupons applied to the invoice.
+          - `document_level_coupon`: Represents document-level coupons applied to the document.
+          - `promotional_credits`: Represents promotional credits in the invoice.
+          - `prorated_credits`: Represents credit adjustments in the invoice.
+
+  - name: "due_date"
+    type: "date-time"
+    description: "The due date of the invoice."
+
+  - name: "dunning_status"
+    type: "string"
+    description: |
+      The current dunning status of the invoice. Possible values are:
+
+      - `in_progress`
+      - `exhausted`
+      - `stopped`
+      - `success`
+
+  - name: "exchange_rate"
+    type: "number"
+    description: ""
+
+  - name: "expected_payment_date"
+    type: "date-time"
+    description: "The expected payment date recorded for the invoice."
+
+  - name: "first_invoice"
+    type: "boolean"
+    description: "Indicates if this is the first invoice raised for the subscription. If this is a non-recurring invoice, it indicates if this is the first invoice for the customer."
+
+  - name: "has_advance_charges"
+    type: "boolean"
+    description: "Indicates if there are any advanced charges present in the invoice."
+
+  - name: "is_gifted"
+    type: "boolean"
+    description: "Indicates if the invoice is gifted or not."
+
+  - name: "issued_credit_notes"
+    type: "array"
+    description: "A list of credit notes issued for the invoice."
+    subattributes: *credit-note
+
+  - name: "line_item_discounts"
+    type: "array"
+    description: "The list of discounts applied for each line item in the invoice."
+    subattributes:
+      - name: "coupon_id"
+        type: "string"
+        description: "The coupon ID."
+        foreign-key-id: "coupon-id"
+
+      - name: "discount_amount"
+        type: "integer"
+        description: "The amount of the discount."
+
+      - name: "discount_type"
+        type: "string"
+        description: |
+          The type of discount. Possible values are:
+
+          - `fixed_amount`
+          - `percentage`
+
+      - name: "line_item_id"
+        type: "string"
+        description: "The ID of the line item the discount was applied to."
+        foreign-key-id: "line-item-id"
+
+  - name: "line_item_taxes"
+    type: "array"
+    description: "The list of taxes applied on line items."
+    subattributes:
+      - name: "line_item_id"
+        type: "string"
+        description: "The ID of the line item for which the tax is applicable."
+        foreign-key-id: "line-item-id"
+
+      - name: "tax_amount"
+        type: "integer"
+        description: "The tax amount, in cents."
+
+      - name: "tax_juris_code"
+        type: "string"
+        description: "The tax jurisdiction code."
+
+      - name: "tax_juris_name"
+        type: "string"
+        description: "The name of the tax jurisdiction."
+
+      - name: "tax_juris_type"
+        type: "string"
+        description: |
+          The type of tax jurisdiction. Possible values are:
+
+          - `country`
+          - `federal`
+          - `state`
+          - `county`
+          - `city`
+          - `special`
+          - `unincorporated` (Combined tax of state and country)
+          - `other`
+
+      - name: "tax_name"
+        type: "string"
+        description: "The name of the tax applied."
+
+      - name: "tax_rate"
+        type: "number"
+        description: "The rate of tax used to calculate the tax amount."
+
+  - name: "line_items"
+    type: "array"
+    description: "The line items in the invoice."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The total amount of the line item, calculated as `unit_amount x quantity`."
+
+      - name: "date_from"
+        type: "date-time"
+        description: "The start date of the line item."
+
+      - name: "date_to"
+        type: "date-time"
+        description: "The end date of the line item."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the line item."
+
+      - name: "discount_amount"
+        type: "integer"
+        description: "The discount amount applied to the line item, in cents."
+
+      - name: "entity_id"
+        type: "string"
+        description: |
+          The ID of the entity the line item is based on.
+
+      - name: "entity_type"
+        type: "string"
+        description: |
+          The modelled entity (plan, addon, etc.) this line item is based on. Possible values are:
+
+          - `plan_setup`: The line item is based on a plan setup charge. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+          - `plan`: The line item is based on a plan entity. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
+          - `addon`: The line item is based on an addon entity. The `entity_id` will specify the addon ID ([`addons: id`](#addons)).
+          - `adhoc`: The line item is not modelled. The `entity_id` attribute will be `null`.
+
+      - name: "id"
+        type: "string"
+        description: "The line item ID."
+        foreign-key-id: "line-item-id"
+
+      - name: "is_taxed"
+        type: "boolean"
+        description: "Indicates whether the line item is taxed or not."
+
+      - name: "item_level_discount_amount"
+        type: "integer"
+        description: "The item level discount amount for the line item, in cents."
+
+      - name: "pricing_model"
+        type: "string"
+        description: |
+          Indicates how the charges for the line item are calculated. Possible values are:
+
+          - `flat_fee`: Charges single price on a recurring basis.
+          - `per_unit`: Charges the price for each unit of the plan for the subscription on a recurring basis.
+          - `tiered`: Charges different per unit price for the quantity purchased from every tier.
+          - `volume`: Charges the per unit price for the total quantity purchased based on the tier under which it falls.
+          - `stairstep`: Charges a price for a range.
+
+      - name: "quantity"
+        type: "integer"
+        description: "The quantity of the recurring item, represented by the line item."
+
+      - name: "subscription_id"
+        type: "string"
+        description: "The ID of the subscription associated with the line item."
+        foreign-key-id: "subscription-id"
+
+      - name: "tax_amount"
+        type: "integer"
+        description: "The tax amount of the line item, in cents."
+
+      - name: "tax_exempt_reason"
+        type: "string"
+        description: |
+          The reason or category for why the line item is excluded from the taxable amount. Possible values are:
+
+          - `tax_not_configured`
+          - `region_non_taxable`
+          - `export`
+          - `customer_exempt`
+          - `zero_rated`
+          - `reverse_charge`
+          - `high_value_physical_good`
+
+      - name: "tax_rate"
+        type: "number"
+        description: "The rate of tax used to calculate tax for the line item."
+
+      - name: "unit_amount"
+        type: "integer"
+        description: "The unit amount of the line item, in cents."
+
+  - name: "linked_orders"
+    type: "array"
+    description: "A list of orders associated with the invoice."
+    subattributes:
+      - name: "batch_id"
+        type: "string"
+        description: "The batch ID."
+
+      - name: "created_at"
+        type: "date-time"
+        description: "the time the order was created."
+
+      - name: "fulfillment_status"
+        type: "string"
+        description: "The fulfillment status of an order as reflected in the shipping/order management application. Typical statuses include `Shipped`, `Awaiting Shipment`, `Not fulfilled`, etc."
+
+      - name: "id"
+        type: "string"
+        description: "The order ID."
+
+      - name: "reference_id"
+        type: "string"
+        description: "This attribute can be used to map the orders in the shipping/order management application to the orders in {{ integration.display_name }}. The `reference_id` generally is same as the order id in the third party application."
+
+      - name: "status"
+        type: "string"
+        description: |
+          The status of the order. Possible values include:
+
+          - `new`
+          - `processing`
+          - `complete`
+          - `cancelled`
+          - `voided`
+          - `queued`
+          - `awaiting_shipment`
+          - `on_hold`
+          - `delivered`
+          - `shipped`
+          - `partially_delivered`
+          - `returned`
+
+  - name: "linked_payments"
+    type: "array"
+    description: "The list of payment transactions for the invoice."
+    subattributes:
+      - name: "applied_amount"
+        type: "integer"
+        description: "The transaction amount applied to the invoice."
+
+      - name: "applied_at"
+        type: "date-time"
+        description: "The time the amount was applied."
+
+      - name: "txn_amount"
+        type: "integer"
+        description: "The total amount of the transaction."
+
+      - name: "txn_date"
+        type: "date-time"
+        description: "The date the transaction occured."
+
+      - name: "txn_id"
+        type: "string"
+        description: "the transaction ID."
+        foreign-key-id: "transaction-id"
+
+      - name: "txn_status"
+        type: "string"
+        description: |
+          The status of the transaction. Possible values are:
+
+          - `in_progress`
+          - `success`
+          - `voided`
+          - `failure`
+          - `timeout`
+          - `needs_attention`
+
+  - name: "net_term_days"
+    type: "integer"
+    description: "The number of days within which the invoice has to be paid."
+
+  - name: "new_sales_amount"
+    type: "integer"
+    description: ""
+
+  - name: "next_retry_at"
+    type: "date-time"
+    description: "A timestamp indicating when the next attempt to collect payment for this invoice will occur."
+
+  - name: "notes"
+    type: "array"
+    description: |
+      The list of notes associated with the invoice. If entity_type & entity_id are not present, then it is general notes (i.e Notes input provided under **Customize Invoice** action in {{ integration.display_name }} web interface).
+    subattributes:
+      - name: "entity_id"
+        type: "string"
+        description: "The entity ID."
+
+      - name: "entity_type"
+        type: "string"
+        description: |
+          The type of entity the note belongs to. Possible values are:
+
+          - [`plan`](#plans)
+          - [`addon`](#addons)
+          - [`coupon`](#coupons)
+          - [`subscription`](#subscriptions)
+          - [`customer`](#customers)
+
+      - name: "note"
+        type: "string"
+        description: "The content of the note."
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "paid_at"
+    type: "date-time"
+    description: "The time the invoice was paid."
+
+  - name: "po_number"
+    type: "string"
+    description: "The number of the purchase order associated with the invoice."
+
+  - name: "price_type"
+    type: "string"
+    description: |
+      The price type of the invoice. Possible values are:
+
+        - `tax_exclusive`
+        - `tax_inclusive`
+
+  - name: "recurring"
+    type: "boolean"
+    description: "Indicates if the invoice belongs to a subscription or not."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the invoice. Each update of the invoice results in an incremental change of this value. **Note**: This attribute will be present only if the invoice has been updated after 2016-09-28."
+
+  - name: "round_off_amount"
+    type: "integer"
+    description: "The invoice rounded-off amount, in cents."
+
+  - name: "shipping_address"
+    type: "object"
+    description: "The shipping address for the invoice."
+    subattributes: *address
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the invoice. Possible values are:
+
+      - `paid`
+      - `posted`
+      - `payment_due`
+      - `not_paid`
+      - `voided`
+      - `pending`
+
+  - name: "sub_total"
+    type: "integer"
+    description: "The subtotal of the invoice, in cents."
+
+  - name: "subscription_id"
+    type: "string"
+    description: "The ID of the subscription associated with the invoice."
+    foreign-key-id: "subscription-id"
+
+  - name: "tax"
+    type: "integer"
+    description: "The total tax amount for the invoice, in cents."
+
+  - name: "taxes"
+    type: "array"
+    description: ""
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The tax amount, in cents."
+
+      - name: "description"
+        type: "string"
+        description: "The description of the tax item."
+
+      - name: "name"
+        type: "string"
+        description: "The name of the tax applied. For example: `GST`"
+
+  - name: "term_finalized"
+    type: "boolean"
+    description: "Indicates if the invoice line item terms are finalized or not."
+
+  - name: "total"
+    type: "integer"
+    description: "The total invoiced amount, in cents."
+
+  - name: "vat_number"
+    type: "string"
+    description: "The VAT number."
+
+  - name: "voided_at"
+    type: "date-time"
+    description: "The time the invoice was voided."
+
+  - name: "write_off_amount"
+    type: "integer"
+    description: "The amount written off against the invoice, in cents."
+---

--- a/_integration-schemas/chargebee/20-05-2019/payment_sources.md
+++ b/_integration-schemas/chargebee/20-05-2019/payment_sources.md
@@ -1,0 +1,253 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "payment-source"
+
+name: "payment_sources"
+doc-link: "https://apidocs.chargebee.com/docs/api/payment_sources"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/payment_sources.json"
+description: |
+  The `{{ table.name }}` table contains info about customer payment sources.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List payment sources"
+    doc-link: "https://apidocs.chargebee.com/docs/api/payment_sources#list_payment_sources"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The payment source ID."
+    foreign-key-id: "payment-source-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the payment source was last updated."
+
+  - name: "amazon_payment"
+    type: "object"
+    description: "Amazon payment details associated with the payment source."
+    subattributes:
+      - name: "agreement_id"
+        type: "string"
+        description: "The billing agreement ID."
+
+      - name: "email"
+        type: "string"
+        description: "The email address associated with the Amazon payment account."
+
+  - name: "bank_account"
+    type: "object"
+    description: "The bank account details, direct debit, or ACH agreement/mandate associated with the payment source."
+    subattributes:
+      - name: "account_holder_type"
+        type: "string"
+        description: |
+          **Applicable to Stripe ACH users only**. Indicates the account holder type. Possible values are:
+
+          - `individual`
+          - `company`
+
+      - name: "account_type"
+        type: "string"
+        description: |
+          **Applicable to Authorze.net ACH users only**. Indicates the type of account. Possible values are:
+
+          - `checking`
+          - `savings`
+
+      - name: "bank_name"
+        type: "string"
+        description: "The name of the account holder's bank."
+
+      - name: "echeck_type"
+        type: "string"
+        description: |
+          **Applicable to Authorze.net ACH users only**. Indicates the type of eCheck. Possible values are:
+
+          - `web`
+          - `ppd`
+
+      - name: "last4"
+        type: "string"
+        description: "The last four digits of the bank account number."
+
+      - name: "mandate_id"
+        type: "string"
+        description: ""
+
+      - name: "name_on_account"
+        type: "string"
+        description: "The account holder's name on the bank account."
+
+  - name: "card"
+    type: "object"
+    description: "Card details associated with the payment source."
+    subattributes:
+      - name: "billing_addr1"
+        type: "string"
+        description: "The first line of the billing address."
+
+      - name: "billing_addr2"
+        type: "string"
+        description: "The second line of the billing address."
+
+      - name: "billing_city"
+        type: "string"
+        description: "The billing city."
+
+      - name: "billing_country"
+        type: "string"
+        description: "The billing country."
+
+      - name: "billing_state"
+        type: "string"
+        description: "The billing state."
+
+      - name: "billing_state_code"
+        type: "string"
+        description: "The ISO 3166-2 state/province code without the country prefix. Currently supported by {{ integration.display_name }} for USA, Canada and India."
+
+      - name: "billing_zip"
+        type: "string"
+        description: "The billing zip or postal code."
+
+      - name: "brand"
+        type: "string"
+        description: |
+          The card brand. Possible values are:
+
+          - `visa`
+          - `mastercard`
+          - `american_express`
+          - `discover`
+          - `jcb`
+          - `diners_club`
+          - `other`
+
+      - name: "expiry_month"
+        type: "integer"
+        description: "The card's expiry month."
+
+      - name: "expiry_year"
+        type: "integer"
+        description: "The card's expiry year."
+
+      - name: "first_name"
+        type: "string"
+        description: "The first name of the cardholder."
+
+      - name: "funding_type"
+        type: "string"
+        description: |
+          The card's funding type. Possible values are:
+
+          - `credit`
+          - `debit`
+          - `prepaid`
+          - `not_known`
+
+      - name: "iin"
+        type: "string"
+        description: "The Issuer Identification Number, or the first six digits of the card number."
+
+      - name: "last4"
+        type: "string"
+        description: "The last four digits of the card number."
+
+      - name: "last_name"
+        type: "string"
+        description: "The last name of the card holder."
+
+      - name: "masked_number"
+        type: "string"
+        description: "The masked credit card number."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time the payment source was created."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer associated with the payment source."
+    foreign-key-id: "customer-id"
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indicates if the payment source has been deleted or not."
+
+  - name: "gateway"
+    type: "string"
+    description: |
+      The name of the gateway the payment source is stored with. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/payment_sources#payment_source_gateway){:target="new"} for a full list of possible values.
+
+  - name: "gateway_account_id"
+    type: "string"
+    description: "The gateway account the payment source is stored with."
+
+  - name: "ip_address"
+    type: "string"
+    description: "The IP address from where the payment source is created or updated. Used primarily for EU VAT validation."
+
+  - name: "issuing_country"
+    type: "string"
+    description: "The two-letter ISO country code."
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "paypal"
+    type: "object"
+    description: "PayPal Express Checkout details associated with the payment source."
+    subattributes:
+      - name: "agremeent_id"
+        type: "string"
+        description: "The billing agreement ID."
+
+      - name: "email"
+        type: "string"
+        description: "The email address associated with PayPal Express Checkout."
+
+  - name: "reference_id"
+    type: "string"
+    description: |
+      The reference ID.
+
+      - For **Amazon** and **PayPal**, this will be the billing agreement ID.
+      - For **GoCardless direct debit**, this will be the mandate ID.
+      - For **card payments**, this will be the ID provided by the gateway/card vault for the specific payment method.
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the payment source. Each update of the payment source results in an incremental change of this value. **Note**: This attribute will be present only if the payment source has been updated after 2016-09-28."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The current status of the payment method. Possible values include:
+
+      - `valid`
+      - `expiring`
+      - `expired`
+      - `invalid`
+      - `pending_verification`
+
+  - name: "type"
+    type: "string"
+    description: |
+      The type of the payment source. Possible values include:
+
+      - `card` (Includes credit and debit cards)
+      - `paypal_express_checkout`
+      - `amazon_payments`
+      - `direct_debit`
+      - `generic`
+      - `alipay`
+      - `unionpay`
+      - `apple_pay`
+      - `wechat_pay`
+---

--- a/_integration-schemas/chargebee/20-05-2019/plans.md
+++ b/_integration-schemas/chargebee/20-05-2019/plans.md
@@ -1,6 +1,6 @@
 ---
 tap: "chargebee"
-version: "1"
+version: "20-05-2019"
 key: "plan"
 
 name: "plans"
@@ -129,8 +129,4 @@ attributes:
 
       - `day`
       - `month`
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
 ---

--- a/_integration-schemas/chargebee/20-05-2019/subscriptions.md
+++ b/_integration-schemas/chargebee/20-05-2019/subscriptions.md
@@ -1,6 +1,6 @@
 ---
 tap: "chargebee"
-version: "1"
+version: "20-05-2019"
 key: "subscription"
 
 name: "subscriptions"
@@ -476,8 +476,4 @@ attributes:
     type: "date-time"
     description: |
       The start of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
 ---

--- a/_integration-schemas/chargebee/20-05-2019/transactions.md
+++ b/_integration-schemas/chargebee/20-05-2019/transactions.md
@@ -1,0 +1,309 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "transaction"
+
+name: "transactions"
+doc-link: "https://apidocs.chargebee.com/docs/api/transactions"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/transactions.json"
+description: |
+  The `{{ table.name }}` table contains info about the transactions that have occurred in your {{ integration.display_name }} account.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List transactions"
+    doc-link: "https://apidocs.chargebee.com/docs/api/transactions#list_transactions"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The transaction ID."
+    foreign-key-id: "transaction-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the transaction was last updated."
+
+  - name: "amount"
+    type: "integer"
+    description: "The amount for the transaction."
+
+  - name: "amount_unused"
+    type: "integer"
+    description: "**Applicable only for payments.** The unused amount present for the transaction."
+
+  - name: "base_currency_code"
+    type: "string"
+    description: ""
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code for the transaction, in ISO 4217 format."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer associated with the transaction."
+    foreign-key-id: "customer-id"
+
+  - name: "date"
+    type: "date-time"
+    description: "The date the transaction occurred."
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indicates if the transaction has been deleted."
+
+  - name: "error_code"
+    type: "string"
+    description: "The error code received from the payment gateway on failure."
+
+  - name: "error_text"
+    type: "string"
+    description: "The error message received from the payment gateway on failure."
+
+  - name: "exchange_rate"
+    type: "number"
+    description: ""
+
+  - name: "fraud_flag"
+    type: "string"
+    description: |
+      Indicates whether or not the transaction has been identified as fraudulent. Possible values are:
+
+      - `safe`
+      - `suspicious`
+      - `fraudulent`
+
+  - name: "fraud_reason"
+    type: "string"
+    description: "A short description why the transaction was marked as fraudulent or suspicious."
+
+  - name: "gateway"
+    type: "string"
+    description: "The name of the gateway used to process the transaction."
+
+  - name: "gateway_account_id"
+    type: "string"
+    description: "The account ID of the gateway used to process the transaction."
+
+  - name: "id_at_gateway"
+    type: "string"
+    description: "The ID with which the transaction is referred in the `gateway`."
+
+  - name: "linked_credit_notes"
+    type: "array"
+    description: "**Applicable only for refund transactions.** The list of credit notes the transaction is associated with."
+    subattributes:
+      - name: "applied_amount"
+        type: "integer"
+        description: "The transaction amount applied to the invoice."
+
+      - name: "applied_at"
+        type: "date-time"
+        description: "The time the credit note was applied."
+
+      - name: "cn_date"
+        type: "date-time"
+        description: "The date the credit note was created."
+
+      - name: "cn_id"
+        type: "string"
+        description: "The credit note ID."
+        foreign-key-id: "credit-note-id"
+
+      - name: "cn_reason_code"
+        type: "string"
+        description: |
+          The reason for the credit note. Possible values are:
+
+          - `write_off`
+          - `subscription_change`
+          - `subscription_cancellation`
+          - `subscription_pause`
+          - `chargeback`
+          - `product_unsatisfactory`
+          - `service_unsatisfactory`
+          - `order_change`
+          - `order_cancellation`
+          - `waiver`
+          - `other`
+          - `fraudulent`
+
+      - name: "cn_reference_invoice_id"
+        type: "string"
+        description: "The invoice ID."
+        foreign-key-id: "invoice-id"
+
+      - name: "cn_status"
+        type: "string"
+        description: |
+          The status of the credit note. Possible values are:
+
+          - `adjusted`
+          - `refunded`
+          - `refund_due`
+          - `voided`
+
+      - name: "cn_total"
+        type: "integer"
+        description: "The total amount of the credit note."
+
+  - name: "linked_invoices"
+    type: "array"
+    description: "**Applicable only for payment transactions.** The list of invoices the transaction has been applied to."
+    subattributes:
+      - name: "applied_amount"
+        type: "integer"
+        description: "The transaction amount applied to the invoice."
+
+      - name: "applied_at"
+        type: "date-time"
+        description: "The time at which the transaction was applied."
+
+      - name: "invoice_date"
+        type: "date-times"
+        description: "The date the invoice was issued."
+
+      - name: "invoice_id"
+        type: "string"
+        description: "The invoice ID."
+        foreign-key-id: "invoice-id"
+
+      - name: "invoice_status"
+        type: "string"
+        description: |
+          The current status of the invoice. Possible values are:
+
+          - `paid`
+          - `posted`
+          - `payment_due`
+          - `not_paid`
+          - `voided`
+          - `pending`
+
+      - name: "invoice_total"
+        type: "integer"
+        description: "The total amount of the invoice."
+
+  - name: "linked_refunds"
+    type: "array"
+    description: "**Applicable only for payment transactions.** The list of refunds issued for the payment transaction."
+    subattributes:
+      - name: "txn_amount"
+        type: "integer"
+        description: "The total amount of the transaction."
+
+      - name: "txn_date"
+        type: "date-time"
+        description: "The date the transaction occured."
+
+      - name: "txn_id"
+        type: "string"
+        description: "the transaction ID."
+        foreign-key-id: "transaction-id"
+
+      - name: "txn_status"
+        type: "string"
+        description: |
+          The status of the transaction. Possible values are:
+
+          - `in_progress`
+          - `success`
+          - `voided`
+          - `failure`
+          - `timeout`
+          - `needs_attention`
+
+  - name: "masked_card_number"
+    type: "string"
+    description: "**Applicable only when `payment_method: card`.** The masked card number used for the transaction."
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "payment_method"
+    type: "string"
+    description: |
+      The payment method for the transaction. Possible values are:
+
+      - `card`
+      - `cash`
+      - `check`
+      - `chargeback`
+      - `bank_transfer`
+      - `amazon_payments`
+      - `paypal_express_checkout`
+      - `direct_debit`
+      - `alipay`
+      - `unionpay`
+      - `apple_pay`
+      - `wechat_pay`
+      - `ach_credit`
+      - `other`
+
+  - name: "payment_source_id"
+    type: "string"
+    description: "The ID of the payment source used for the transaction."
+    foreign-key-id: "payment-source-id"
+
+  - name: "reference_number"
+    type: "string"
+    description: "The reference number for the transaction."
+
+  - name: "reference_transaction_id"
+    type: "string"
+    description: "**Applicable only when `type` is `refund` or `payment_reversal`.** The reference payment ID."
+    foreign-key-id: "transaction-id"
+
+  - name: "refunded_txn_id"
+    type: "string"
+    description: "**Applicable only when `type: refund`**. The ID of the original transaction that was refunded."
+    foreign-key-id: "transaction-id"
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the transaction. Each update of the transaction results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
+
+  - name: "reversal_txn_id"
+    type: "string"
+    description: "**Applicable only when `type: payment_reversal`**. The ID of the original transaction that was reversed."
+
+  - name: "settled_at"
+    type: "date-time"
+    description: "The time at which the final status of the transaction has been marked."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the transaction. Possible values are:
+
+      - `in_progress`
+      - `success`
+      - `voided`
+      - `failure`
+      - `timeout`
+      - `needs_attention`
+
+  - name: "subscription_id"
+    type: "string"
+    description: "The ID of the subscription associated with the transaction."
+    foreign-key-id: "subscription-id"
+
+  - name: "type"
+    type: "string"
+    description: |
+      The type of the transaction. Possible values are:
+
+      - `authorization`
+      - `payment`
+      - `refund`
+      - `payment_reversal`
+
+  - name: "validated_at"
+    type: "date-time"
+    description: ""
+---

--- a/_integration-schemas/chargebee/20-05-2019/virtual_bank_accounts.md
+++ b/_integration-schemas/chargebee/20-05-2019/virtual_bank_accounts.md
@@ -1,0 +1,84 @@
+---
+tap: "chargebee"
+version: "20-05-2019"
+key: "virtual-bank-account"
+
+name: "virtual_bank_accounts"
+doc-link: "https://apidocs.chargebee.com/docs/api/virtual_bank_accounts"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/virtual_bank_accounts.json"
+description: |
+  The `{{ table.name }}` table contains info about the virtual bank accounts in your {{ integration.display_name }} account. A virtual bank account is a unique account number that can be shared with your users while still protecting your sensitive bank account details.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List virtual bank accounts"
+    doc-link: "https://apidocs.chargebee.com/docs/api/virtual_bank_accounts#list_virtual_bank_accounts"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The virtual bank account number."
+    #foreign-key-id: "virtual-bank-account-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: "The time the virtual bank account was last updated."
+
+  - name: "account_number"
+    type: "string"
+    description: "The account number to which funds will be transferred."
+
+  - name: "bank_name"
+    type: "string"
+    description: "The name of the bank."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The time the virtual bank account was created."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer associated with the virtual bank account."
+    foreign-key-id: "customer-id"
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indicates if the virtual bank account has been deleted or not."
+
+  - name: "email"
+    type: "string"
+    description: "The email address associated with the virtual bank account."
+
+  - name: "gateway"
+    type: "string"
+    description: |
+      The name of the gateway the virtual bank account is stored in. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/virtual_bank_accounts#virtual_bank_account_gateway){:target="new"} for a full list of possible values.
+    doc-link: "https://apidocs.chargebee.com/docs/api/virtual_bank_accounts#virtual_bank_account_gateway"
+
+  - name: "gateway_account_id"
+    type: "string"
+    description: "The ID of the gateway account the virtual bank account is stored in."
+
+  - name: "object"
+    type: "string"
+    description: ""
+
+  - name: "reference_id"
+    type: "string"
+    description: "The ID provided by the gateway for the virtual bank account source."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the virtual bank account. Each update of the virtual bank account results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
+
+  - name: "routing_number"
+    type: "string"
+    description: "The routing number of the bank."
+
+  - name: "swift_code"
+    type: "string"
+    description: "The swift code of the bank in which the account exists."
+---

--- a/_integration-schemas/chargebee/addons.md
+++ b/_integration-schemas/chargebee/addons.md
@@ -45,6 +45,24 @@ attributes:
     type: "date-time"
     description: "The time at which the plan was moved to archived status."
 
+  - name: "avalara_sale_type"
+    type: "string"
+    description: |
+      **Applicable only if you use {{ integration.display_name }}'s AvaTax for Communications integration**. The type of sale carried out. Possible values are:
+
+      - `wholesale`
+      - `retail`
+      - `consumed`
+      - `vendor_use`
+
+  - name: "avalara_service_type"
+    type: "integer"
+    description: "**Applicable only if you use {{ integration.display_name }}'s AvaTax for Communications integration**. The type of service for the product to be taxed."
+
+  - name: "avalara_transaction_type"
+    type: "integer"
+    description: "**Applicable only if you use {{ integration.display_name }}'s AvaTax for Communications integration**. The type of product to be taxed."
+
   - name: "charge_type"
     type: "string"
     description: |
@@ -56,6 +74,10 @@ attributes:
   - name: "currency_code"
     type: "string"
     description: "The currency code (ISO 4217 format) of the addon."
+
+  - name: "custom_fields"
+    type: "string"
+    description: "" 
 
   - name: "description"
     type: "string"
@@ -183,9 +205,5 @@ attributes:
   - name: "unit"
     type: "string"
     description: |
-      Applicable only for quantity type addons. This specifies the type of quantity. For example: If the addon price is `$10` and `agent` is the unit, it will be displayed as `$10/agent`.
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
+      Applicable only for quantity type addons. This specifies the type of quantity. For example: If the addon price is `$10` and `agent` is the unit, it will be displayed as `$10/agent`.   
 ---

--- a/_integration-schemas/chargebee/coupons.md
+++ b/_integration-schemas/chargebee/coupons.md
@@ -37,6 +37,15 @@ attributes:
       - `specific`
       - `not_applicable`
 
+  - name: "addon_ids"
+    type: "array"
+    description: "IDs of the addons associated with the coupon."
+    subattributes:
+      - name: "value"
+        type: "string"
+        description: "The ID of the addon."
+        foreign-key-id: "addon-id"
+
   - name: "apply_discount_on"
     type: "string"
     description: ""
@@ -56,6 +65,10 @@ attributes:
   - name: "created_at"
     type: "date-time"
     description: "The time when the coupon was created."
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code (ISO 4217 format) of the coupon. Applicable for `fixed_amount` coupons."
 
   - name: "discount_amount"
     type: "number"
@@ -87,9 +100,21 @@ attributes:
       - `forever`
       - `limited_period`
 
+  - name: "invoice_name"
+    type: "string"
+    description: "The name of the invoice associated with the coupon."
+
+  - name: "invoice_notes"
+    type: "string"
+    description: "Invoice notes for the coupon."
+
   - name: "max_redemptions"
     type: "integer"
     description: "The maximum number of times the coupon can be redeemed."
+
+  - name: "meta_data"
+    type: "string"
+    description: "Additional info about the coupon."
 
   - name: "name"
     type: "string"
@@ -108,6 +133,15 @@ attributes:
       - `all`
       - `specific`
       - `not_applicable`
+
+  - name: "plan_ids"
+    type: "array"
+    description: "IDs of the plans associated with the coupon."
+    subattributes:
+      - name: "value"
+        type: "string"
+        description: "The ID of the plan."
+        foreign-key-id: "plan-id"
 
   - name: "redemptions"
     type: "integer"

--- a/_integration-schemas/chargebee/customers.md
+++ b/_integration-schemas/chargebee/customers.md
@@ -432,7 +432,7 @@ attributes:
     type: "string"
     description: ""  
 
-   - name: "created_from_ip"
+  - name: "created_from_ip"
     type: "string"
     description: ""  
 

--- a/_integration-schemas/chargebee/customers.md
+++ b/_integration-schemas/chargebee/customers.md
@@ -236,6 +236,24 @@ attributes:
     type: "date-time"
     description: "The time the customer was created."
 
+  - name: "created_from_ip"
+    type: "string"
+    description: "The IP address of the customer." 
+
+  - name: "custom_fields"
+    type: "string"
+    description: ""
+
+  - name: "customer_type"
+    type: "string"
+    description: |
+      **Applicable if you use {{ integration.display_name }}'s AvaTax for Sales integration.**. The type of the customer. Possible values are:
+
+      - `residential`
+      - `business`
+      - `senior_citizen`
+      - `industrial`
+
   - name: "deleted"
     type: "boolean"
     description: "Indicates whether the customer has been deleted or not."
@@ -244,17 +262,42 @@ attributes:
     type: "string"
     description: "The customer's email address."
 
+  - name: "entity_code"
+    type: "string"
+    description: |
+      **Applicable if you use {{ integration.display_name }}'s AvaTax for Sales integration.**. The exemption category of the customer, for USA and Canada.
+
   - name: "excess_payments"
     type: "integer"
     description: "The total unused payments associated with the customer."
+
+  - name: "exemption_details"
+    type: "string"
+    description: "**Applicable if you use {{ integration.display_name }}'s AvaTax for Sales integration.**. Exemption information for the customer."
+
+  - name: "exempt_number"
+    type: "string"
+    description: "**Applicable if you use {{ integration.display_name }}'s AvaTax for Sales integration.**. Indicates if sales should be exempted for the customer." 
 
   - name: "first_name"
     type: "string"
     description: "The first name of the customer."
 
+  - name: "fraud_flag"
+    type: "string"
+    description: |
+      Indicates if the customer has been identified as fraudulent. Possible values are:
+
+      - `safe`
+      - `fraudulent`
+
   - name: "invoice_notes"
     type: "string"
     description: "Invoice notes associated with the customer."
+
+  - name: "is_location_valid"
+    type: "boolean"
+    description: "Indicates if the customer's location is valid, based on their IP address and the card issuing country. Applicable only for EU, New Zealand, and Australia." 
 
   - name: "last_name"
     type: "string"
@@ -263,6 +306,10 @@ attributes:
   - name: "locale"
     type: "string"
     description: "Determines which region-specific language {{ integration.display_name }} uses to communicate with the customer."
+
+  - name: "meta_data"
+    type: "string"
+    description: "Additional info about the customer."
 
   - name: "net_term_days"
     type: "integer"
@@ -396,6 +443,10 @@ attributes:
     type: "integer"
     description: "The refundable credits balance of the customer."
 
+  - name: "registered_for_gst"
+    type: "boolean"
+    description: "Indicates if the customer is registered under GST. Available for Australia only."
+
   - name: "resource_version"
     type: "integer"
     description: "The version number of the customer. Each update of the customer results in an incremental change of this value. **Note**: This attribute will be present only if the customer has been updated after 2016-09-28."
@@ -418,49 +469,15 @@ attributes:
 
   - name: "vat_number_status"
     type: "string"
-    description: ""
+    description: |
+      **Applicable only if EU and Australian taxes are configured and the VAT number validation is enabled**. Possible values are:
+
+      - `valid`
+      - `invalid`
+      - `not_validated`
+      - `undetermined`
     
   - name: "vat_number_validated_time"
     type: "date-time"
     description: ""  
-
-  - name: "entity_code"
-    type: "string"
-    description: ""
-    
-  - name: "exempt_number"
-    type: "string"
-    description: ""  
-
-  - name: "created_from_ip"
-    type: "string"
-    description: ""  
-
-  - name: "is_location_valid"
-    type: "boolean"
-    description: ""  
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""
-    
-  - name: "customer_type"
-    type: "string"
-    description: ""
-
-  - name: "exemption_details"
-    type: "string"
-    description: ""
-
-  - name: "fraud_flag"
-    type: "string"
-    description: ""
-
-  - name: "meta_data"
-    type: "string"
-    description: ""
-    
-  - name: "registered_for_gst"
-    type: "boolean"
-    description: ""    
 ---

--- a/_integration-schemas/chargebee/events.md
+++ b/_integration-schemas/chargebee/events.md
@@ -29,11 +29,11 @@ attributes:
 
   - name: "api_version"
     type: "string"
-    description: ""
+    description: "The {{ integration.display_name }} API version used for rendering the event content."
     
   - name: "content"
     type: "object"
-    description: ""
+    description: "The data associated with the event."
     subattributes:
       - name: "addon"
         type: "object"
@@ -3032,9 +3032,11 @@ attributes:
           - name: "updated_at"
             type: "date-time"
             description: ""
+  
   - name: "event_type"
     type: "string"
-    description: ""
+    description: |
+      The event type. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_types){:target="new"} for a list of possible values.
   
   - name: "object"
     type: "string"
@@ -3042,11 +3044,18 @@ attributes:
   
   - name: "source"
     type: "string"
-    description: ""
-  
+    description: |
+      The source of the event. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_source){:target="new"} for a list of possible values.
+
   - name: "user"
     type: "string"
-    description: ""
+    description: |
+      The "user" that triggered the event. The value depends on the `source` value:
+
+      - When `source` is `admin_console`: The email address of the user that triggered the event.
+      - When `source` is `api`, `js_api`, or `bulk_operation`: The name of the API key that was used to trigger the event.
+      - When `source` is `external_service`: The name of the service that called the webhook. For example: `ADYEN`, `STRIPE`, `AMAZON_PAYMENTS` etc.
+      - When `source` is `hosted_page` or `portal`: The user attribute is not passed.
   
   - name: "webhook_status"
     type: "string"

--- a/_integration-schemas/chargebee/events.md
+++ b/_integration-schemas/chargebee/events.md
@@ -2563,7 +2563,7 @@ attributes:
           - name: "meta_data"
             type: "string"
             description: ""
-            - name: "custom_fields"
+          - name: "custom_fields"
             type: "string"
             description: ""
           - name: "mrr"

--- a/_integration-schemas/chargebee/events.md
+++ b/_integration-schemas/chargebee/events.md
@@ -4,7 +4,7 @@ version: "1"
 key: "event"
 
 name: "events"
-doc-link: "https://apidocs.chargebee.com/docs/api/events"
+doc-link: ""
 singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/events.json"
 description: |
   The `{{ table.name }}` table contains info about the events that have occurred on your {{ integration.display_name }} site. Event records contain data about affected resources and additional details, such as when the change occurred. This can be used to create a log of events for a record and analyze how it has changed over time.
@@ -29,2188 +29,3026 @@ attributes:
 
   - name: "api_version"
     type: "string"
-    description: "The Chargebee API Version used for rendering this event content. Possible values are `v1` or `v2`."
-
+    description: ""
+    
   - name: "content"
     type: "object"
-    description: |
-      The data associated with the event. The attributes in this object will vary depending on the event type. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_types){:target="new"} for a list of possible event types.
+    description: ""
     subattributes:
-      - name: "coupon"
+      - name: "addon"
         type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `coupon_created`
-          - `coupon_updated`
-          - `coupon_deleted`
-          - `coupon_set_created`
-          - `coupon_set_updated`
-          - `coupon_set_deleted`
-          - `coupon_codes_added`
-          - `coupon_codes_deleted`
-          - `coupon_codes_updated`
+        description: ""
         subattributes:
+          - name: "accounting_code"
+            type: "string"
+            description: ""
+          - name: "accouting_category1"
+            type: "string"
+            description: ""
+          - name: "accouting_category2"
+            type: "string"
+            description: ""
+          - name: "archived_at"
+            type: "date-time"
+            description: ""
+          - name: "avalara_sale_type"
+            type: "string"
+            description: ""
+          - name: "avalara_service_type"
+            type: "integer"
+            description: ""
+          - name: "avalara_transaction_type"
+            type: "integer"
+            description: ""
+          - name: "charge_type"
+            type: "string"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""
+          - name: "description"
+            type: "string"
+            description: ""
+          - name: "enabled_in_portal"
+            type: "boolean"
+            description: ""
           - name: "id"
             type: "string"
-            description: "The coupon ID."
-            foreign-key-id: "coupon-id"
-
+            description: ""
+          - name: "invoice_name"
+            type: "string"
+            description: ""
+          - name: "invoice_notes"
+            type: "string"
+            description: ""
+          - name: "is_shippable"
+            type: "boolean"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""  
+          - name: "name"
+            type: "string"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "period"
+            type: "integer"
+            description: ""
+          - name: "period_unit"
+            type: "string"
+            description: ""
+          - name: "price"
+            type: "integer"
+            description: ""
+          - name: "pricing_model"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "shipping_frequency_period"
+            type: "integer"
+            description: ""
+          - name: "shipping_frequency_period_unit"
+            type: "string"
+            description: ""
+          - name: "sku"
+            type: "string"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "tax_code"
+            type: "string"
+            description: ""
+          - name: "tax_profile_id"
+            type: "string"
+            description: ""
+          - name: "taxable"
+            type: "boolean"
+            description: ""
+          - name: "tiers"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "ending_unit"
+                type: "integer"
+                description: ""
+              - name: "price "
+                type: "integer"
+                description: ""
+              - name: "starting_unit"
+                type: "integer"
+                description: ""
+          - name: "type"
+            type: "string"
+            description: ""
+          - name: "unit"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "coupon"
+        type: "object"
+        description: ""
+        subattributes:
           - name: "addon_constraint"
             type: "string"
-            description: |
-              The addons the coupon can be applied to. Possible values are:
-
-              - `none`
-              - `all`
-              - `specific`
-              - `not_applicable`
-
+            description: ""
+          - name: "addon_ids"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "value"
+                type: "string"
+                description: ""
           - name: "apply_discount_on"
             type: "string"
             description: ""
-
           - name: "apply_on"
             type: "string"
-            description: |
-              The invoice items for which this coupon needs to be applied. Possible values are:
-
-              - `invoice_amount`: The coupon will be applied to the total invoice amount.
-              - `each_specified_item`: the discount will be applied to each specified plan and addon item.
-
+            description: ""
           - name: "archived_at"
             type: "date-time"
-            description: "The time when the coupon was archived."
-
+            description: ""
           - name: "created_at"
             type: "date-time"
-            description: "The time when the coupon was created."
-
-          - name: "discount_amount"
-            type: "number"
-            description: "When `discount_type: fixed_amount`, this value will be the discount value in cents."
-
-          - name: "discount_percentage"
-            type: "number"
-            description: "When `discount_type: percentage`, this value will be the discount value percentage."
-
-          - name: "discount_type"
-            type: "string"
-            description: |
-              The type of discount. Possible values are:
-
-              - `fixed_amount`
-              - `percentage`
-
-          - name: "duration_month"
-            type: "integer"
-            description: |
-              When `duration_type: limited_period`, this value will be the duration in months the coupon can be applied.
-
-          - name: "duration_type"
-            type: "string"
-            description: |
-              The duration the coupon is applicable. Possible values are:
-
-              - `one_time`
-              - `forever`
-              - `limited_period`
-
-          - name: "max_redemptions"
-            type: "integer"
-            description: "The maximum number of times the coupon can be redeemed."
-
-          - name: "name"
-            type: "string"
-            description: "The display name used in web interface for identifying the coupon."
-
-          - name: "object"
-            type: "string"
             description: ""
-
-          - name: "plan_constraint"
-            type: "string"
-            description: |
-              The plans the coupon can be applied to. Possible values are:
-
-              - `none`
-              - `all`
-              - `specific`
-              - `not_applicable`
-
-          - name: "redemptions"
-            type: "integer"
-            description: "The number of times the coupon has been redeemed."
-
-          - name: "resource_version"
-            type: "integer"
-            description: "The version number of the coupon. Each update of the coupon results in an incremental change of this value. **Note**: This attribute will be present only if the coupon has been updated after 2016-09-28."
-
-          - name: "status"
-            type: "string"
-            description: |
-              The status of the coupon. Possible values are:
-
-              - `active`
-              - `expired`
-              - `archived`
-              - `deleted`
-
-          - name: "updated_at"
-            type: "date-time"
-            description: "The time the coupon was last updated."
-
-      - name: "customer"
-        type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `card_added`
-          - `card_updated`
-          - `card_expiry_reminder`
-          - `card_expired`
-          - `card_deleted`
-          - `customer_created`
-          - `customer_changed`
-          - `customer_deleted`
-          - `customer_moved_out`
-          - `customer_moved_in`
-          - `hierarchy_created`
-          - `hierarchy_deleted`
-          - `promotional_credits_added`
-          - `promotional_credits_deducted`
-          - `subscription_created`
-          - `subscription_started`
-          - `subscription_trial_end_reminder`
-          - `subscription_activated`
-          - `subscription_changed`
-          - `subscription_cancellation_scheduled`
-          - `subscription_cancellation_reminder`
-          - `subscription_cancelled`
-          - `subscription_reactivated`
-          - `subscription_renewed`
-          - `subscription_scheduled_cancellation_removed`
-          - `subscription_changes_scheduled`
-          - `subscription_scheduled_changes_removed`
-          - `subscription_shipping_address_updated`
-          - `subscription_deleted`
-          - `subscription_paused`
-          - `subscription_pause_scheduled`
-          - `subscription_scheduled_pause_removed`
-          - `subscription_resumed`
-          - `subscription_resumption_scheduled`
-          - `subscription_scheduled_resumption_removed`
-          - `subscription_renewal_reminder`
-          - `payment_source_added`
-          - `payment_source_updated`
-          - `payment_source_deleted`
-          - `payment_succeeded`
-          - `payment_failed`
-          - `payment_refunded`
-          - `payment_initiated`
-          - `refund_initiated`
-          - `virtual_bank_account_added`
-          - `virtual_bank_account_updated`
-          - `virtual_bank_account_deleted`
-        subattributes:
-          - name: "id"
-            type: "string"
-            description: "The customer ID."
-            foreign-key-id: "customer-id"
-
-          - name: "allow_direct_debit"
-            type: "boolean"
-            description: "Indicates whether the customer can pay via direct debit or not."
-
-          - name: "auto_collection"
-            type: "string"
-            description: |
-              Indicates whether payments need to be automatically collected for the customer. Possible values are:
-
-              - `on`: When an invoice is created, an automatic attempt to charge the customer's payment method is made.
-              - `off`: Automatic collection of charges will not be made.
-
-          - name: "balances"
-            type: "array"
-            description: "The list of balances for the customer."
-            subattributes:
-              - name: "currency_code"
-                type: "string"
-                description: "The currency code in ISO 4217 for the balance."
-
-              - name: "excess_payments"
-                type: "integer"
-                description: "The total unused payments associated with the customer."
-
-              - name: "promotional_credits"
-                type: "integer"
-                description: "The promotional credits balance for the customer."
-
-              - name: "refundable_credits "
-                type: "integer"
-                description: "The refundable credits balance for the customer."
-
-              - name: "unbilled_charges"
-                type: "integer"
-                description: "The total unbilled charges for the customer."
-
-          - name: "billing_address"
-            type: "object"
-            description: "The billing address for the customer."
-            subattributes:
-              - name: "city"
-                type: "string"
-                description: "The city."
-
-              - name: "company"
-                type: "string"
-                description: "The company."
-
-              - name: "country"
-                type: "string"
-                description: "The country."
-
-              - name: "email"
-                type: "string"
-                description: "The email."
-
-              - name: "first_name"
-                type: "string"
-                description: "The first name."
-
-              - name: "last_name"
-                type: "string"
-                description: "The last name."
-
-              - name: "line1"
-                type: "string"
-                description: "The first line of the address."
-
-              - name: "line2"
-                type: "string"
-                description: "The second line of the address."
-
-              - name: "line3"
-                type: "string"
-                description: "The third line of the address."
-
-              - name: "phone"
-                type: "string"
-                description: "The phone number."
-
-              - name: "state"
-                type: "string"
-                description: "The state or province."
-
-              - name: "state_code"
-                type: "string"
-                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
-
-              - name: "validation_status"
-                type: "string"
-                description: |
-                  The address verification status. Possible values are:
-
-                  - `not_validated`
-                  - `valid`
-                  - `partially_valid`
-                  - `invalid`
-
-              - name: "zip"
-                type: "string"
-                description: "The zip or postal code."
-
-          - name: "billing_date"
-            type: "boolean"
-            description: "**Applicable when calendar billing (with customer specific billing date support) is enabled**. When set, renewals of all the monthly and yearly subscriptions of this customer will be aligned to this date."
-
-          - name: "billing_date_mode"
-            type: "string"
-            description: |
-              Indicates whether this customer's `billing_date` value is derived as per configurations or its specifically set (overriden). When specifically set, the `billing_date` will not be reset even when all of the monthly/yearly subscriptions are cancelled.
-
-              Possible values are:
-
-              - `using_defaults`: The `billing_date` value is set based on configured defaults.
-              - `manually_set`: The `billing_date` is specifically set.
-
-          - name: "billing_day_of_week"
-            type: "boolean"
-            description: |
-              **Applicable when calendar billing (with customer specific billing date support) is enabled**. When set, renewals of all the weekly subscriptions of this customer will be aligned to this week day.
-
-              Possible values are:
-
-              - `monday`
-              - `tuesday`
-              - `wednesday`
-              - `thursday`
-              - `friday`
-              - `saturday`
-              - `sunday`
-
-          - name: "billing_day_of_week_mode"
-            type: "string"
-            description: |
-              Indicates whether this customer's `billing_day_of_week` value is derived as per configurations or its specifically set (overriden). When specifically set, the `billing_day_of_week` will not be reset even when all of the weekly subscriptions are cancelled.
-
-              Possible values are:
-
-              - `using_defaults`: The `billing_day_of_week` value is set based on configured defaults.
-              - `manually_set`: The `billing_day_of_week` is specifically set.
-
-          - name: "card_status"
-            type: "string"
-            description: ""
-
-          - name: "cf_company_id"
-            type: "integer"
-            description: ""
-
-          - name: "company"
-            type: "string"
-            description: "The name of the company associated with the customer."
-
-          - name: "consolidated_invoicing"
-            type: "boolean"
-            description: "**Applicable when consolidated invoicing is enabled**. Indicates whether invoice consolidation should happen during subscription renewals. Needs to be set only if this value is different from the defaults configured."
-
-          - name: "contacts"
-            type: "array"
-            description: "A list of contacts associated with the customer."
-            subattributes:
-              - name: "email"
-                type: "string"
-                description: "The contact's email."
-
-              - name: "enabled"
-                type: "boolean"
-                description: "Indicates whether the contacted is enabled (`true`) or disabled (`false`)."
-
-              - name: "first_name"
-                type: "string"
-                description: "The first name of the contact."
-
-              - name: "id"
-                type: "string"
-                description: "The contact ID."
-
-              - name: "label"
-                type: "string"
-                description: "The label/tag provided for the contact."
-
-              - name: "last_name"
-                type: "string"
-                description: "The last name of the contact."
-
-              - name: "object"
-                type: "string"
-                description: ""
-
-              - name: "phone"
-                type: "string"
-                description: "The phone number of the contact."
-
-              - name: "send_account_email"
-                type: "string"
-                description: "Indicates whether account emails are enabled for the contact."
-
-              - name: "send_billing_email"
-                type: "string"
-                description: "Indicates whether billing emails are enabled for the contact."
-
-          - name: "created_at"
-            type: "date-time"
-            description: "The time the customer was created."
-
-          - name: "deleted"
-            type: "boolean"
-            description: "Indicates whether the customer has been deleted or not."
-
-          - name: "email"
-            type: "string"
-            description: "The customer's email address."
-
-          - name: "excess_payments"
-            type: "integer"
-            description: "The total unused payments associated with the customer."
-
-          - name: "first_name"
-            type: "string"
-            description: "The first name of the customer."
-
-          - name: "invoice_notes"
-            type: "string"
-            description: "Invoice notes associated with the customer."
-
-          - name: "last_name"
-            type: "string"
-            description: "The last name of the customer."
-
-          - name: "locale"
-            type: "string"
-            description: "Determines which region-specific language {{ integration.display_name }} uses to communicate with the customer."
-
-          - name: "net_term_days"
-            type: "integer"
-            description: "The number of days within which the customer has to make payment for invoices."
-
-          - name: "object"
-            type: "string"
-            description: ""
-
-          - name: "payment_method"
-            type: "object"
-            description: "The primary payment source for the customer."
-            subattributes:
-              - name: "gateway"
-                type: "string"
-                description: |
-                  The name of the gateway the payment is associated with. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/customers#customer_payment_method_gateway){:target="new"} for a full list of possible values.
-                doc-link: "https://apidocs.chargebee.com/docs/api/customers#customer_payment_method_gateway"
-
-              - name: "gateway_account_id"
-                type: "string"
-                description: "The gateway account the payment method is stored with."
-
-              - name: "object"
-                type: "string"
-                description: ""
-
-              - name: "reference_id"
-                type: "string"
-                description: |
-                  The reference ID.
-
-                  - For **Amazon** and **PayPal**, this will be the billing agreement ID.
-                  - For **GoCardless direct debit**, this will be the mandate ID.
-                  - For **card payments**, this will be the ID provided by the gateway/card vault for the specific payment method.
-
-              - name: "status"
-                type: "string"
-                description: |
-                  The current status of the payment method. Possible values include:
-
-                  - `valid`
-                  - `expiring`
-                  - `expired`
-                  - `invalid`
-                  - `pending_verification`
-
-              - name: "type"
-                type: "string"
-                description: |
-                  The type of the payment source. Possible values include:
-
-                  - `card` (Includes credit and debit cards)
-                  - `paypal_express_checkout`
-                  - `amazon_payments`
-                  - `direct_debit`
-                  - `generic`
-                  - `alipay`
-                  - `unionpay`
-                  - `apple_pay`
-                  - `wechat_pay`
-
-          - name: "phone"
-            type: "string"
-            description: "The customer's phone number."
-
-          - name: "pii_cleared"
-            type: "string"
-            description: |
-              Indicates whether the customer's personal info has been cleared. Possible values are:
-
-              - `active`
-              - `scheduled_for_clear`
-              - `cleared`
-
-          - name: "preferred_currency_code"
-            type: "string"
-            description: "**Applicable if the {{ integration.display_name }} Multicurrency feature is enabled.** The currency code of the customer's preferred currency (ISO 4217 format)."
-
-          - name: "primary_payment_source_id"
-            type: "string"
-            description: "The ID of the primary payment source for the customer."
-
-          - name: "promotional_credits"
-            type: "integer"
-            description: "The promotional credits balance of the customer."
-
-          - name: "referral_urls"
-            type: "array"
-            description: "A list of referral URLs for the customer."
-            subattributes:
-              - name: "created_at"
-                type: "date-time"
-                description: "The time the referral URL was created."
-
-              - name: "external_customer_id"
-                type: "string"
-                description: "The ID of the external customer in the referral system."
-
-              - name: "referral_account_id"
-                type: "string"
-                description: "The ID of the referral account."
-
-              - name: "referral_campaign_id"
-                type: "string"
-                description: "The ID of the referral campaign."
-
-              - name: "referral_external_account_id"
-                type: "string"
-                description: "The ID of the external referral account."
-
-              - name: "referral_sharing_url"
-                type: "string"
-                description: "The referral sharing URL for the customer."
-
-              - name: "referral_system"
-                type: "string"
-                description: |
-                  The URL for the referral system account. Possible values are:
-
-                  - `referral_candy`
-                  - `referral_saasquatch`
-                  - `friendbuy`
-
-              - name: "updated_at"
-                type: "date-time"
-                description: "The time the referral URL was last updated."
-
-          - name: "refundable_credits"
-            type: "integer"
-            description: "The refundable credits balance of the customer."
-
-          - name: "resource_version"
-            type: "integer"
-            description: "The version number of the customer. Each update of the customer results in an incremental change of this value. **Note**: This attribute will be present only if the customer has been updated after 2016-09-28."
-
-          - name: "taxability"
-            type: "string"
-            description: |
-              Indicates if the customer is liable for tax. Possible values are:
-
-              - `taxable`
-              - `exempt`
-
-          - name: "unbilled_charges"
-            type: "integer"
-            description: "The total unbilled charges for the customer."
-
-          - name: "updated_at"
-            type: "date-time"
-            description: "The time the customer was last updated."
-
-          - name: "vat_number"
-            type: "string"
-            description: "The VAT number for the customer."
-
-      - name: "invoice"
-        type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `invoice_generated`
-          - `invoice_updated`
-          - `invoice_deleted`
-          - `pending_invoice_created`
-          - `pending_invoice_updated`
-          - `payment_failed`
-          - `payment_initiated`
-          - `payment_refunded`
-          - `refund_initiated`
-          - `subscription_created`
-          - `subscription_started`
-          - `subscription_activated`
-          - `subscription_changed`
-          - `subscription_cancelled`
-          - `subscription_reactivated`
-          - `subscription_renewed`
-          - `subscription_paused`
-          - `subscription_resumed`
-        subattributes:
-          - name: "id"
-            type: "string"
-            description: "The invoice ID."
-            foreign-key-id: "invoice-id"
-
-          - name: "updated_at"
-            type: "date-time"
-            description: "The time the invoice was last updated."
-
-          - name: "adjustment_credit_notes"
-            type: "array"
-            description: "Details about the adjustments created for the invoice."
-            subattributes: &credit-note
-              - name: "cn_date"
-                type: "date-time"
-                description: "The date at which the credit note was created."
-
-              - name: "cn_id"
-                type: "string"
-                description: "The credit note ID."
-                foreign-key-id: "credit-note-id"
-
-              - name: "cn_reason_code"
-                type: "string"
-                description: &cn-reason-code |
-                  The reason for the credit note. Possible values are:
-
-                  - `write_off`
-                  - `subscription_change`
-                  - `subscription_cancellation`
-                  - `subscription_pause`
-                  - `chargeback`
-                  - `product_unsatisfactory`
-                  - `service_unsatisfactory`
-                  - `order_change`
-                  - `order_cancellation`
-                  - `waiver`
-                  - `other`
-                  - `fraudulent`
-
-              - name: "cn_status"
-                type: "string"
-                description: &cn-status |
-                  The status of the credit note. Possible values are:
-
-                  - `adjusted`
-                  - `refunded`
-                  - `refund_due`
-                  - `voided`
-
-              - name: "cn_total"
-                type: "integer"
-                description: "The total amount of the credit note."
-
-          - name: "amount_adjusted"
-            type: "integer"
-            description: "The total adjusted amount made against the invoice."
-
-          - name: "amount_due"
-            type: "integer"
-            description: "The total amount to be collected, include the invoice's payments in progress."
-
-          - name: "amount_paid"
-            type: "integer"
-            description: "The total payments received for the invoice."
-
-          - name: "amount_to_collect"
-            type: "integer"
-            description: "The total amount to be collected."
-
-          - name: "applied_credits"
-            type: "array"
-            description: "The refundable credits applied on the invoice."
-            subattributes:
-              - name: "applied_amount"
-                type: "integer"
-                description: "The applied amount, in cents."
-
-              - name: "applied_at"
-                type: "date-time"
-                description: "The time the credit was applied."
-
-              - name: "cn_date"
-                type: "date-time"
-                description: "The date the credit was created."
-
-              - name: "cn_id"
-                type: "string"
-                description: "The credit ID."
-                foreign-key-id: "credit-note-id"
-
-              - name: "cn_reason_code"
-                type: "string"
-                description: *cn-reason-code
-
-              - name: "cn_status"
-                type: "string"
-                description: *cn-status
-
-          - name: "base_currency_code"
-            type: "string"
-            description: ""
-
-          - name: "billing_address"
-            type: "object"
-            description: "The billing address for the invoice."
-            subattributes: &address
-              - name: "city"
-                type: "string"
-                description: "The city."
-
-              - name: "company"
-                type: "string"
-                description: "The company."
-
-              - name: "country"
-                type: "string"
-                description: "The country."
-
-              - name: "email"
-                type: "string"
-                description: "The email."
-
-              - name: "first_name"
-                type: "string"
-                description: "The first name."
-
-              - name: "last_name"
-                type: "string"
-                description: "The last name."
-
-              - name: "line1"
-                type: "string"
-                description: "The first line of the address."
-
-              - name: "line2"
-                type: "string"
-                description: "The second line of the address."
-
-              - name: "line3"
-                type: "string"
-                description: "The third line of the address."
-
-              - name: "phone"
-                type: "string"
-                description: "The phone number."
-
-              - name: "state"
-                type: "string"
-                description: "The state or province."
-
-              - name: "state_code"
-                type: "string"
-                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
-
-              - name: "validation_status"
-                type: "string"
-                description: |
-                  The address verification status. Possible values are:
-
-                  - `not_validated`
-                  - `valid`
-                  - `partially_valid`
-                  - `invalid`
-
-              - name: "zip"
-                type: "string"
-                description: "The zip or postal code."
-
-          - name: "credits_applied"
-            type: "integer"
-            description: "The total credits applied against the invoice."
-
           - name: "currency_code"
             type: "string"
-            description: "The currency code (ISO 4217 format) for the invoice."
-
+            description: ""
+          - name: "discount_amount"
+            type: "number"
+            description: ""
+          - name: "discount_percentage"
+            type: "number"
+            description: ""
+          - name: "discount_type"
+            type: "string"
+            description: ""
+          - name: "duration_month"
+            type: "integer"
+            description: ""
+          - name: "duration_type"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "invoice_name"
+            type: "string"
+            description: ""
+          - name: "invoice_notes"
+            type: "string"
+            description: ""
+          - name: "max_redemptions"
+            type: "integer"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+          - name: "name"
+            type: "string"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "plan_constraint"
+            type: "string"
+            description: ""
+          - name: "plan_ids"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "value"
+                type: "string"
+                description: ""
+          - name: "redemptions"
+            type: "integer"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "coupon_code"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "code"
+            type: "string"
+            description: ""
+          - name: "coupon_id"
+            type: "string"
+            description: ""
+          - name: "coupon_set_name"
+            type: "string"
+            description: ""
+          - name: "coupon_site_id"
+            type: "string"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+      - name: "coupon_set"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "archived_count"
+            type: "integer"
+            description: ""
+          - name: "coupon_id"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+          - name: "name"
+            type: "string"
+            description: ""
+          - name: "redeemed_count"
+            type: "integer"
+            description: ""
+          - name: "total_count"
+            type: "integer"
+            description: ""
+      - name: "credit_note"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "allocations"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "allocated_amount"
+                type: "integer"
+                description: ""
+              - name: "allocated_at"
+                type: "date-time"
+                description: ""
+              - name: "invoice_date"
+                type: "date-time"
+                description: ""
+              - name: "invoice_id"
+                type: "string"
+                description: ""
+              - name: "invoice_status"
+                type: "string"
+                description: ""
+          - name: "amount_allocated"
+            type: "integer"
+            description: ""
+          - name: "amount_available"
+            type: "integer"
+            description: ""
+          - name: "amount_refunded"
+            type: "integer"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
           - name: "customer_id"
             type: "string"
-            description: "The ID of the customer the invoice is for."
-            foreign-key-id: "customer-id"
-
+            description: ""
           - name: "date"
             type: "date-time"
-            description: |
-              Closing date of the invoice. Typically this is the date on which invoice is generated. If "wait & notify to send invoices enabled for usage based billing" is enabled in {{ integration.display_name }}, this will not be the same as date on which invoice was actually sent to customer.
-
+            description: ""
           - name: "deleted"
             type: "boolean"
-            description: "Indicates if the invoice has been deleted or not."
-
+            description: ""
           - name: "discounts"
             type: "array"
-            description: "Details about the discounts applied to the invoice."
+            description: ""
             subattributes:
               - name: "amount"
                 type: "integer"
-                description: "The discount amount, in cents."
-
+                description: ""
               - name: "description"
                 type: "string"
-                description: "The description of the discount line item."
-
+                description: ""
               - name: "entity_id"
                 type: "string"
-                description: "The ID of the entity the discount amount is based on. This value will only be present if `entity_type` is `item_level_coupon` or `document_level_coupon`."
-                foreign-key-id: "coupon-id"
-
+                description: ""
               - name: "entity_type"
                 type: "string"
-                description: &discount-line-item |
-                  The type of the discount line item. Possible values are:
-
-                  - `item_level_coupon`: Represents item-level coupons applied to the invoice.
-                  - `document_level_coupon`: Represents document-level coupons applied to the document.
-                  - `promotional_credits`: Represents promotional credits in the invoice.
-                  - `prorated_credits`: Represents credit adjustments in the invoice.
-
-          - name: "due_date"
-            type: "date-time"
-            description: "The due date of the invoice."
-
-          - name: "dunning_status"
+                description: ""
+          - name: "id"
             type: "string"
-            description: |
-              The current dunning status of the invoice. Possible values are:
-
-              - `in_progress`
-              - `exhausted`
-              - `stopped`
-              - `success`
-
-          - name: "exchange_rate"
-            type: "number"
             description: ""
-
-          - name: "expected_payment_date"
-            type: "date-time"
-            description: "The expected payment date recorded for the invoice."
-
-          - name: "first_invoice"
-            type: "boolean"
-            description: "Indicates if this is the first invoice raised for the subscription. If this is a non-recurring invoice, it indicates if this is the first invoice for the customer."
-
-          - name: "has_advance_charges"
-            type: "boolean"
-            description: "Indicates if there are any advanced charges present in the invoice."
-
-          - name: "is_gifted"
-            type: "boolean"
-            description: "Indicates if the invoice is gifted or not."
-
-          - name: "issued_credit_notes"
-            type: "array"
-            description: "A list of credit notes issued for the invoice."
-            subattributes: *credit-note
-
           - name: "line_item_discounts"
             type: "array"
-            description: "The list of discounts applied for each line item in the invoice."
+            description: ""
             subattributes:
               - name: "coupon_id"
                 type: "string"
-                description: "The coupon ID."
-                foreign-key-id: "coupon-id"
-
+                description: ""
               - name: "discount_amount"
                 type: "integer"
-                description: "The amount of the discount."
-
+                description: ""
               - name: "discount_type"
                 type: "string"
-                description: |
-                  The type of discount. Possible values are:
-
-                  - `fixed_amount`
-                  - `percentage`
-
+                description: ""
               - name: "line_item_id"
                 type: "string"
-                description: "The ID of the line item the discount was applied to."
-                foreign-key-id: "line-item-id"
-
+                description: ""
           - name: "line_item_taxes"
             type: "array"
-            description: "The list of taxes applied on line items."
+            description: ""
             subattributes:
+              - name: "is_non_compliance_tax"
+                type: "boolean"
+                description: ""
+              - name: "is_partial_tax_applied"
+                type: "boolean"
+                description: ""
               - name: "line_item_id"
                 type: "string"
-                description: "The ID of the line item for which the tax is applicable."
-                foreign-key-id: "line-item-id"
-
+                description: ""
               - name: "tax_amount"
                 type: "integer"
-                description: "The tax amount, in cents."
-
+                description: ""
               - name: "tax_juris_code"
                 type: "string"
-                description: "The tax jurisdiction code."
-
+                description: ""
               - name: "tax_juris_name"
                 type: "string"
-                description: "The name of the tax jurisdiction."
-
+                description: ""
               - name: "tax_juris_type"
                 type: "string"
-                description: |
-                  The type of tax jurisdiction. Possible values are:
-
-                  - `country`
-                  - `federal`
-                  - `state`
-                  - `county`
-                  - `city`
-                  - `special`
-                  - `unincorporated` (Combined tax of state and country)
-                  - `other`
-
+                description: ""
               - name: "tax_name"
                 type: "string"
-                description: "The name of the tax applied."
-
+                description: ""
               - name: "tax_rate"
                 type: "number"
-                description: "The rate of tax used to calculate the tax amount."
-
+                description: ""
+              - name: "taxable_amount"
+                type: "integer"
+                description: ""
+          - name: "line_item_tiers"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "ending_unit"
+                type: "integer"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+              - name: "quantity_used"
+                type: "integer"
+                description: ""
+              - name: "starting_unit"
+                type: "integer"
+                description: ""
+              - name: "unit_amount"
+                type: "integer"
+                description: ""
           - name: "line_items"
             type: "array"
-            description: "The line items in the invoice."
+            description: ""
             subattributes:
               - name: "amount"
                 type: "integer"
-                description: "The total amount of the line item, calculated as `unit_amount x quantity`."
-
+                description: ""
               - name: "date_from"
                 type: "date-time"
-                description: "The start date of the line item."
-
+                description: ""
               - name: "date_to"
                 type: "date-time"
-                description: "The end date of the line item."
-
+                description: ""
               - name: "description"
                 type: "string"
-                description: "The description of the line item."
-
+                description: ""
               - name: "discount_amount"
                 type: "integer"
-                description: "The discount amount applied to the line item, in cents."
-
+                description: ""
               - name: "entity_id"
                 type: "string"
-                description: |
-                  The ID of the entity the line item is based on.
-
+                description: ""
               - name: "entity_type"
                 type: "string"
-                description: |
-                  The modelled entity (plan, addon, etc.) this line item is based on. Possible values are:
-
-                  - `plan_setup`: The line item is based on a plan setup charge. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
-                  - `plan`: The line item is based on a plan entity. The `entity_id` will specify the plan ID ([`plans: id`](#plans)).
-                  - `addon`: The line item is based on an addon entity. The `entity_id` will specify the addon ID ([`addons: id`](#addons)).
-                  - `adhoc`: The line item is not modelled. The `entity_id` attribute will be `null`.
-
+                description: ""
               - name: "id"
                 type: "string"
-                description: "The line item ID."
-                foreign-key-id: "line-item-id"
-
+                description: ""
               - name: "is_taxed"
                 type: "boolean"
-                description: "Indicates whether the line item is taxed or not."
-
+                description: ""
               - name: "item_level_discount_amount"
                 type: "integer"
-                description: "The item level discount amount for the line item, in cents."
-
+                description: ""
               - name: "pricing_model"
                 type: "string"
-                description: |
-                  Indicates how the charges for the line item are calculated. Possible values are:
-
-                  - `flat_fee`: Charges single price on a recurring basis.
-                  - `per_unit`: Charges the price for each unit of the plan for the subscription on a recurring basis.
-                  - `tiered`: Charges different per unit price for the quantity purchased from every tier.
-                  - `volume`: Charges the per unit price for the total quantity purchased based on the tier under which it falls.
-                  - `stairstep`: Charges a price for a range.
-
+                description: ""
               - name: "quantity"
                 type: "integer"
-                description: "The quantity of the recurring item, represented by the line item."
-
+                description: ""
               - name: "subscription_id"
                 type: "string"
-                description: "The ID of the subscription associated with the line item."
-                foreign-key-id: "subscription-id"
-
+                description: ""
               - name: "tax_amount"
                 type: "integer"
-                description: "The tax amount of the line item, in cents."
-
+                description: ""
               - name: "tax_exempt_reason"
                 type: "string"
-                description: |
-                  The reason or category for why the line item is excluded from the taxable amount. Possible values are:
-
-                  - `tax_not_configured`
-                  - `region_non_taxable`
-                  - `export`
-                  - `customer_exempt`
-                  - `zero_rated`
-                  - `reverse_charge`
-                  - `high_value_physical_good`
-
+                description: ""
               - name: "tax_rate"
                 type: "number"
-                description: "The rate of tax used to calculate tax for the line item."
-
+                description: ""
               - name: "unit_amount"
                 type: "integer"
-                description: "The unit amount of the line item, in cents."
-
-          - name: "linked_orders"
+                description: ""
+          - name: "linked_refunds"
             type: "array"
-            description: "A list of orders associated with the invoice."
-            subattributes:
-              - name: "batch_id"
-                type: "string"
-                description: "The batch ID."
-
-              - name: "created_at"
-                type: "date-time"
-                description: "the time the order was created."
-
-              - name: "fulfillment_status"
-                type: "string"
-                description: "The fulfillment status of an order as reflected in the shipping/order management application. Typical statuses include `Shipped`, `Awaiting Shipment`, `Not fulfilled`, etc."
-
-              - name: "id"
-                type: "string"
-                description: "The order ID."
-
-              - name: "reference_id"
-                type: "string"
-                description: "This attribute can be used to map the orders in the shipping/order management application to the orders in {{ integration.display_name }}. The `reference_id` generally is same as the order id in the third party application."
-
-              - name: "status"
-                type: "string"
-                description: |
-                  The status of the order. Possible values include:
-
-                  - `new`
-                  - `processing`
-                  - `complete`
-                  - `cancelled`
-                  - `voided`
-                  - `queued`
-                  - `awaiting_shipment`
-                  - `on_hold`
-                  - `delivered`
-                  - `shipped`
-                  - `partially_delivered`
-                  - `returned`
-
-          - name: "linked_payments"
-            type: "array"
-            description: "The list of payment transactions for the invoice."
+            description: ""
             subattributes:
               - name: "applied_amount"
                 type: "integer"
-                description: "The transaction amount applied to the invoice."
-
+                description: ""
               - name: "applied_at"
                 type: "date-time"
-                description: "The time the amount was applied."
-
+                description: ""
               - name: "txn_amount"
                 type: "integer"
-                description: "The total amount of the transaction."
-
+                description: ""
               - name: "txn_date"
                 type: "date-time"
-                description: "The date the transaction occured."
-
+                description: ""
               - name: "txn_id"
                 type: "string"
-                description: "the transaction ID."
-                foreign-key-id: "transaction-id"
-
+                description: ""
               - name: "txn_status"
                 type: "string"
-                description: |
-                  The status of the transaction. Possible values are:
-
-                  - `in_progress`
-                  - `success`
-                  - `voided`
-                  - `failure`
-                  - `timeout`
-                  - `needs_attention`
-
-          - name: "net_term_days"
-            type: "integer"
-            description: "The number of days within which the invoice has to be paid."
-
-          - name: "new_sales_amount"
-            type: "integer"
-            description: ""
-
-          - name: "next_retry_at"
-            type: "date-time"
-            description: "A timestamp indicating when the next attempt to collect payment for this invoice will occur."
-
-          - name: "notes"
-            type: "array"
-            description: |
-              The list of notes associated with the invoice. If entity_type & entity_id are not present, then it is general notes (i.e Notes input provided under **Customize Invoice** action in {{ integration.display_name }} web interface).
-            subattributes:
-              - name: "entity_id"
-                type: "string"
-                description: "The entity ID."
-
-              - name: "entity_type"
-                type: "string"
-                description: |
-                  The type of entity the note belongs to. Possible values are:
-
-                  - [`plan`](#plans)
-                  - [`addon`](#addons)
-                  - [`coupon`](#coupons)
-                  - [`subscription`](#subscriptions)
-                  - [`customer`](#customers)
-
-              - name: "note"
-                type: "string"
-                description: "The content of the note."
-
-          - name: "object"
-            type: "string"
-            description: ""
-
-          - name: "paid_at"
-            type: "date-time"
-            description: "The time the invoice was paid."
-
-          - name: "po_number"
-            type: "string"
-            description: "The number of the purchase order associated with the invoice."
-
+                description: ""
           - name: "price_type"
             type: "string"
-            description: |
-              The price type of the invoice. Possible values are:
-
-                - `tax_exclusive`
-                - `tax_inclusive`
-
-          - name: "recurring"
-            type: "boolean"
-            description: "Indicates if the invoice belongs to a subscription or not."
-
+            description: ""
+          - name: "reason_code"
+            type: "string"
+            description: ""
+          - name: "reference_invoice_id"
+            type: "string"
+            description: ""
+          - name: "refunded_at"
+            type: "date-time"
+            description: ""
           - name: "resource_version"
             type: "integer"
-            description: "The version number of the invoice. Each update of the invoice results in an incremental change of this value. **Note**: This attribute will be present only if the invoice has been updated after 2016-09-28."
-
+            description: ""
           - name: "round_off_amount"
             type: "integer"
-            description: "The invoice rounded-off amount, in cents."
-
-          - name: "shipping_address"
-            type: "object"
-            description: "The shipping address for the invoice."
-            subattributes: *address
-
+            description: ""
           - name: "status"
             type: "string"
-            description: |
-              The status of the invoice. Possible values are:
-
-              - `paid`
-              - `posted`
-              - `payment_due`
-              - `not_paid`
-              - `voided`
-              - `pending`
-
+            description: ""
           - name: "sub_total"
             type: "integer"
-            description: "The subtotal of the invoice, in cents."
-
+            description: ""
           - name: "subscription_id"
             type: "string"
-            description: "The ID of the subscription associated with the invoice."
-            foreign-key-id: "subscription-id"
-
-          - name: "tax"
-            type: "integer"
-            description: "The total tax amount for the invoice, in cents."
-
+            description: ""
           - name: "taxes"
             type: "array"
             description: ""
             subattributes:
               - name: "amount"
                 type: "integer"
-                description: "The tax amount, in cents."
-
+                description: ""
               - name: "description"
                 type: "string"
-                description: "The description of the tax item."
-
+                description: ""
               - name: "name"
                 type: "string"
-                description: "The name of the tax applied. For example: `GST`"
-
-          - name: "term_finalized"
-            type: "boolean"
-            description: "Indicates if the invoice line item terms are finalized or not."
-
+                description: ""
           - name: "total"
             type: "integer"
-            description: "The total invoiced amount, in cents."
-
-          - name: "vat_number"
+            description: ""
+          - name: "type"
             type: "string"
-            description: "The VAT number."
-
-          - name: "voided_at"
-            type: "date-time"
-            description: "The time the invoice was voided."
-
-          - name: "write_off_amount"
-            type: "integer"
-            description: "The amount written off against the invoice, in cents."
-
-      - name: "plan"
-        type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `plan_created`
-          - `plan_updated`
-          - `plan_deleted`
-
-        subattributes:
-          - name: "billing_cycles"
-            type: "integer"
-            description: "The number of billing cycles the subscription is active."
-
-          - name: "charge_model"
-            type: "string"
-            description: |
-              Defines how the recurring charges for the subscription are calculated. Possible values are:
-
-              - `flat_fee`
-              - `per_unit`
-              - `tiered`
-              - `volume`
-              - `stairstep`
-
-          - name: "description"
-            type: "string"
-            description: "The description of the plan to show in hosted pages and the customer portal."
-
-          - name: "free_quantity"
-            type: "integer"
-            description: "The free quantity the subscriptions of the plan will have. Only quantities more than this value will be charged for the subscription."
-
-          - name: "id"
-            type: "string"
-            description: "The plan ID."
-            foreign-key-id: "plan-id"
-
-          - name: "invoice_notes"
-            type: "string"
-            description: "Invoice notes associated with the subscription."
-
-          - name: "name"
-            type: "string"
-            description: "The display name of the plan."
-
-          - name: "period"
-            type: "integer"
-            description: |
-              Defines the billing frequency for the plan. Used with `period_unit` to create a billing schedule for the plan.
-
-              For example: If `period_unit: week` and `period: 3`, billing would occur every `3 weeks`.
-
-          - name: "period_unit"
-            type: "string"
-            description: |
-              The time unit for the billing period. Used with `period` to create a billing schedule for the plan.
-
-              For example: If `period_unit: week` and `period: 3`, billing would occur every `3 weeks`.
-
-              Possible values are:
-
-              - `day`
-              - `week`
-              - `month`
-              - `year`
-
-          - name: "price"
-            type: "integer"
-            description: "The price of the plan."
-
-          - name: "redirect_url"
-            type: "string"
-            description: "The URL to redirect on successful checkout."
-
-          - name: "setup_cost"
-            type: "integer"
-            description: "The one-time setup fee charged as part of the first invoice for the plan."
-
-          - name: "sku"
-            type: "string"
-            description: "Ssed as Product name/code in your third party accounting application. {{ integration.display_name }} will use it as an alternate name in your accounting application."
-
-          - name: "status"
-            type: "string"
-            description: |
-              The plan state. Possible values are:
-
-              - `active`
-              - `archived`
-
-          - name: "tax_profile_id"
-            type: "string"
-            description: "The ID of the tax profile for the plan."
-
-          - name: "taxable"
-            type: "boolean"
-            description: "Indicates if the plan is taxable or not."
-
-          - name: "trial_period"
-            type: "integer"
-            description: |
-              The free time window for the customer to try the product. Used with `trial_period_unit` to create the free trial period.
-
-              For example: If `trial_period: day` and `trial_period_unit: 14`, the trial period would be `14 days`.
-
-          - name: "trial_period_unit"
-            type: "string"
-            description: |
-              The time unit for the trial period. Used with `trial_period` to create the free trial period.
-
-              For example: If `trial_period: day` and `trial_period_unit: 14`, the trial period would be `14 days`.
-
-              Possible values are:
-
-              - `day`
-              - `month`
-
+            description: ""
           - name: "updated_at"
             type: "date-time"
-            description: "The time the plan was last updated."
-
-      - name: "subscription"
-        type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `customer_deleted`
-          - `payment_succeeded`
-          - `payment_failed`
-          - `payment_refunded`
-          - `payment_initiated`
-          - `refund_initiated`
-          - `subscription_created`
-          - `subscription_started`
-          - `subscription_trial_end_reminder`
-          - `subscription_activated`
-          - `subscription_changed`
-          - `subscription_cancellation_scheduled`
-          - `subscription_cancellation_reminder`
-          - `subscription_cancelled`
-          - `subscription_reactivated`
-          - `subscription_renewed`
-          - `subscription_scheduled_cancellation_removed`
-          - `subscription_changes_scheduled`
-          - `subscription_scheduled_changes_removed`
-          - `subscription_shipping_address_updated`
-          - `subscription_deleted`
-          - `subscription_paused`
-          - `subscription_pause_scheduled`
-          - `subscription_scheduled_pause_removed`
-          - `subscription_resumed`
-          - `subscription_resumption_scheduled`
-          - `subscription_scheduled_resumption_removed`
-          - `subscription_renewal_reminder`
-        subattributes:
-          - name: "activated_at"
-            type: "date-time"
-            description: "The time at which the subscription moved from `in_trial` to `active`."
-
-          - name: "addons"
-            type: "array"
-            description: "Details about the addon(s) associated with the subscription."
-            subattributes:
-              - name: "id"
-                type: "string"
-                description: "The addon ID."
-                foreign-key-id: "addon-id"
-
-              - name: "object"
-                type: "string"
-                description: ""
-
-              - name: "quantity"
-                type: "integer"
-                description: "**Applicable only for the quantity based addons.** The quantity."
-
-              - name: "remaining_billing_cycles"
-                type: "integer"
-                description: "The number of billing cycles this addon will be attached to subscription."
-
-              - name: "trial_end"
-                type: "date-time"
-                description: "The time at which the trial ends for the addon."
-
-              - name: "unit_price"
-                type: "integer"
-                description: &addon-unit-price |
-                  The amount that will override the addon's default price. The plan's billing frequency will not be considered for overriding. E.g. If the plan's billing frequency is every 3 months, and if the price override amount is $10, $10 will be used, and not $30 (i.e $10*3).
-
-          - name: "affiliate_token"
+            description: ""
+          - name: "vat_number"
             type: "string"
-            description: "A unique tracking token for the subscription."
-
+            description: ""
+          - name: "voided_at"
+            type: "date-time"
+            description: ""
+      - name: "customer"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "allow_direct_debit"
+            type: "boolean"
+            description: ""
           - name: "auto_collection"
             type: "string"
-            description: |
-              Defines whether payments need to be collected automatically for this subscription. Possible values are:
-
-              - `on`
-              - `off`
-
-          - name: "base_currency_code"
-            type: "string"
-            description: "The base currency code for the subscription in ISO 4217 format."
-
-          - name: "billing_period"
-            type: "integer"
-            description: |
-              Defines the billing frequency for the subscription. Used with `billing_period_unit`, this determines how the customer is billed for the subscription.
-
-              For example: If `billing_period_unit: week` and `billing_period: 3`, the customer would be billed every `3 weeks`.
-
-          - name: "billing_period_unit"
-            type: "string"
-            description: |
-              Defines the billing period for the subscription. Used with `billing_period`, this determines how the customer is billed for the subscription.
-
-              For example: If `billing_period_unit: week` and `billing_period: 3`, the customer would be billed every `3 weeks`.
-
-              Possible values are:
-
-              - `day`
-              - `week`
-              - `month`
-              - `year`
-
-          - name: "cancel_reason"
-            type: "string"
-            description: |
-              The possible reason the subscription might be cancelled. Possible values are:
-
-              - `not_paid`
-              - `no_card`
-              - `fraud_review_failed`
-              - `non_compliant_eu_customer`
-              - `tax_calculation_failed`
-              - `currency_incompatible_with_gateway`
-              - `non_compliant_customer`
-
-          - name: "cancelled_at"
-            type: "date-time"
-            description: "The time at which subscription was cancelled or is set to be cancelled."
-
-          - name: "charged_event_based_addons"
-            type: "array"
-            description: "A list of event-based addons that have already been charged."
-            subattributes:
-              - name: "id"
-                type: "string"
-                description: "The addon ID."
-                foreign-key-id: "addon-id"
-
-              - name: "last_charged_at"
-                type: "date-time"
-                description: "The time when the addon was last charged for the subscription."
-
-              - name: "object"
-                type: "string"
-                description: ""
-
-          - name: "coupon"
+            description: ""
+          - name: "backup_payment_source_id"
             type: "string"
             description: ""
-
-          - name: "coupons"
+          - name: "balances"
             type: "array"
-            description: "Details about the coupon(s) associated with the subscription."
+            description: ""
             subattributes:
-              - name: "applied_count"
-                type: "integer"
-                description: "The number of times the coupon has been applied for the subscription."
-
-              - name: "apply_till"
-                type: "date-time"
-                description: "**Applicable for `limited month` coupons.** The date till the coupon is to be applied."
-
-              - name: "coupon_code"
-                type: "string"
-                description: "The coupon code used to redeem the coupon."
-
-              - name: "coupon_id"
-                type: "string"
-                description: "The coupon ID."
-                foreign-key-id: "coupon-id"
-
-              - name: "object"
+              - name: "currency_code"
                 type: "string"
                 description: ""
-
-          - name: "created_at"
-            type: "date-time"
-            description: "The time the subscription was created."
-
-          - name: "currency_code"
-            type: "string"
-            description: "The currency code for the subscription in ISO 4217 format."
-
-          - name: "current_term_end"
-            type: "date-time"
-            description: "The end of the current billing term for the subscription, after which the subscription will be immediately renewed."
-
-          - name: "current_term_start"
-            type: "date-time"
-            description: "The start of the current billing term for the subscription."
-
-          - name: "customer_id"
-            type: "string"
-            description: "The ID of the customer associated with the subscription."
-            foreign-key-id: "customer-id"
-
-          - name: "deleted"
-            type: "boolean"
-            description: "Indicates if the subscription has been deleted or not."
-
-          - name: "due_invoices_count"
-            type: "integer"
-            description: "The total number of invoices that are due for payment."
-
-          - name: "event_based_addons"
-            type: "array"
-            description: "A list of non-recurring addons associated with the subscription that will be charged on the occurrence of a specified event."
-            subattributes:
-              - name: "charge_once"
-                type: "boolean"
-                description: "If enabled, the addon will be charged only at the first occurrence of the event."
-
-              - name: "id"
-                type: "string"
-                description: "The addon ID."
-                foreign-key-id: "addon-id"
-
-              - name: "object"
-                type: "string"
+              - name: "excess_payments"
+                type: "integer"
                 description: ""
-
-              - name: "on_event"
-                type: "string"
-                description: "The event on which the addon will be charged."
-
-              - name: "quantity"
+              - name: "promotional_credits"
                 type: "integer"
-                description: "**Applicable only for the quantity based addons**. The addon quantity."
-
-              - name: "unit_price"
+                description: ""
+              - name: "refundable_credits "
                 type: "integer"
-                description: *addon-unit-price
-
-          - name: "exchange_rate"
-            type: "number"
-            description: "The exchange rate used for base currency conversion."
-
-          - name: "has_scheduled_changes"
-            type: "boolean"
-            description: "If true, there are subscription changes scheduled on next renewal."
-
-          - name: "id"
-            type: "string"
-            description: "The subscription ID."
-            foreign-key-id: "subscription-id"
-
-          - name: "invoice_notes"
-            type: "string"
-            description: "The invoice notes for the subscription."
-
-          - name: "mrr"
-            type: "integer"
-            description: "The monthly recurring revenue for the subscription, in cents."
-
-          - name: "next_billing_at"
-            type: "date-time"
-            description: "The date on which the next billing occurs."
-
-          - name: "object"
-            type: "string"
-            description: ""
-
-          - name: "payment_source_id"
-            type: "string"
-            description: "The ID of the payment source associated with the subscription."
-            foreign-key-id: "payment-source-id"
-
-          - name: "plan_amount"
-            type: "integer"
-            description: ""
-
-          - name: "plan_free_quantity"
-            type: "integer"
-            description: "The units of the item that will be free with the plan associated with the subscription."
-
-          - name: "plan_id"
-            type: "string"
-            description: "The ID of the plan associated with the subscription."
-            foreign-key-id: "plan-id"
-
-          - name: "plan_quantity"
-            type: "integer"
-            description: "The plan quantity for the subscription."
-
-          - name: "plan_unit_price"
-            type: "integer"
-            description: "The amount that will override the plan's default price."
-
-          - name: "po_number"
-            type: "string"
-            description: "The purchase order number associated with the subscription."
-
-          - name: "referral_info"
+                description: ""
+              - name: "unbilled_charges"
+                type: "integer"
+                description: ""
+          - name: "billing_address"
             type: "object"
-            description: "The referral details for the subscription, if applicable."
-            subattributes:
-              - name: "account_id"
-                type: "string"
-                description: "The referral account ID."
-
-              - name: "campaign_id"
-                type: "string"
-                description: "The referral campaign ID."
-
-              - name: "coupon_code"
-                type: "string"
-                description: "The referral coupon code."
-
-              - name: "destination_url"
-                type: "string"
-                description: "The destination URL for the campaign."
-
-              - name: "external_campaign_id"
-                type: "string"
-                description: "The campaign ID in an external reference system."
-
-              - name: "external_reference_id"
-                type: "string"
-                description: "The reference ID in an external reference system."
-
-              - name: "friend_offer_type"
-                type: "string"
-                description: |
-                  The friend offer type for the referral campaign. Possible values are:
-
-                  - `none`
-                  - `coupon`
-                  - `coupon_code`
-
-              - name: "notify_referral_system"
-                type: "string"
-                description: |
-                  Indicates whether referral purchases should be notified to the referral system. Possible values are:
-
-                  - `none`
-                  - `first_paid_conversion`
-                  - `all_invoices`
-
-              - name: "post_purchase_widget_enabled"
-                type: "boolean"
-                description: "Indicates if a post purchase widget is enabled for the campaign."
-
-              - name: "referral_code"
-                type: "string"
-                description: "The referral code."
-
-              - name: "referral_status"
-                type: "string"
-                description: ""
-
-              - name: "referrer_id"
-                type: "string"
-                description: "The referrer ID."
-
-              - name: "referrer_reward_type"
-                type: "string"
-                description: |
-                  The referrer reward type for the referral campaign. Possible values are:
-
-                  - `none`
-                  - `referral_direct_reward`
-                  - `custom_promotional_credit`
-                  - `custom_revenue_percent_based`
-
-              - name: "reward_status"
-                type: "string"
-                description: |
-                  The reward status for the referral subscription. Possible values are:
-
-                  - `pending`
-                  - `paid`
-                  - `invalid`
-
-          - name: "remaining_billing_cycles"
-            type: "integer"
-            description: "The number of billing cycles the subscription will run."
-
-          - name: "resource_version"
-            type: "integer"
-            description: "The version number of the subscription. Each update of the subscription results in an incremental change of this value. **Note**: This attribute will be present only if the resource has been updated after 2016-09-28."
-
-          - name: "shipping_address"
-            type: "object"
-            description: "The shipping address for the subscription."
+            description: ""
             subattributes:
               - name: "city"
                 type: "string"
-                description: "The city."
-
+                description: ""
               - name: "company"
                 type: "string"
-                description: "The company."
-
+                description: ""
               - name: "country"
                 type: "string"
-                description: "The country."
-
+                description: ""
               - name: "email"
                 type: "string"
-                description: "The email."
-
+                description: ""
               - name: "first_name"
                 type: "string"
-                description: "The first name."
-
+                description: ""
               - name: "last_name"
                 type: "string"
-                description: "The last name."
-
+                description: ""
               - name: "line1"
                 type: "string"
-                description: "The first line of the address."
-
+                description: ""
               - name: "line2"
                 type: "string"
-                description: "The second line of the address."
-
+                description: ""
               - name: "line3"
                 type: "string"
-                description: "The third line of the address."
-
+                description: ""
               - name: "phone"
                 type: "string"
-                description: "The phone number."
-
+                description: ""
               - name: "state"
                 type: "string"
-                description: "The state or province."
-
+                description: ""
               - name: "state_code"
                 type: "string"
-                description: "The ISO 3166-2 state/province code without the country prefix. Currently supported for USA, Canada and India."
-
-              - name: "validation_status"
+                description: ""
+              - name: "validation_status,"
                 type: "string"
-                description: |
-                  The address verification status. Possible values are:
-
-                  - `not_validated`
-                  - `valid`
-                  - `partially_valid`
-                  - `invalid`
-
+                description: ""
               - name: "zip"
                 type: "string"
-                description: "The zip or postal code."
-
-          - name: "start_date"
-            type: "date-time"
-            description: |
-              **Applicable only when `status: future`**. The scheduled start time of the future subscription.
-
-          - name: "started_at"
-            type: "date-time"
-            description: |
-              The time when the subscription started. This value will be `null` for future subscriptions.
-
-          - name: "status"
+                description: ""
+          - name: "billing_date"
+            type: "boolean"
+            description: ""
+          - name: "billing_date_mode"
             type: "string"
-            description: |
-              The current status of the subscription. Possible values are:
-
-              - `future`
-              - `in_trial`
-              - `active`
-              - `non_renewing`
-              - `paused`
-              - `cancelled`
-
-          - name: "trial_end"
+            description: ""
+          - name: "billing_day_of_week"
+            type: "boolean"
+            description: ""
+          - name: "billing_day_of_week_mode"
+            type: "string"
+            description: ""
+          - name: "card_status"
+            type: "string"
+            description: ""
+          - name: "cf_company_id"
+            type: "integer"
+            description: ""
+          - name: "company"
+            type: "string"
+            description: ""
+          - name: "consolidated_invoicing"
+            type: "boolean"
+            description: ""
+          - name: "contacts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "enabled"
+                type: "boolean"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "label"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "send_account_email"
+                type: "string"
+                description: ""
+              - name: "send_billing_email"
+                type: "string"
+                description: ""
+          - name: "created_at"
             type: "date-time"
-            description: |
-              The end of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
-
-          - name: "trial_start"
-            type: "date-time"
-            description: |
-              The start of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
-
+            description: ""
+          - name: "created_from_ip"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""
+          - name: "customer_type"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "email"
+            type: "string"
+            description: ""
+          - name: "entity_code"
+            type: "string"
+            description: ""
+          - name: "excess_payments"
+            type: "integer"
+            description: ""
+          - name: "exempt_number"
+            type: "string"
+            description: ""
+          - name: "exemption_details"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""  
+          - name: "first_name"
+            type: "string"
+            description: ""
+          - name: "fraud_flag"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "invoice_notes"
+            type: "string"
+            description: ""
+          - name: "is_location_valid"
+            type: "boolean"
+            description: ""
+          - name: "last_name"
+            type: "string"
+            description: ""
+          - name: "locale"
+            type: "string"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+          - name: "net_term_days"
+            type: "integer"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "payment_method"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "gateway"
+                type: "string"
+                description: ""
+              - name: "gateway_account_id "
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "reference_id"
+                type: "string"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+              - name: "type"
+                type: "string"
+                description: ""
+          - name: "phone"
+            type: "string"
+            description: ""
+          - name: "pii_cleared"
+            type: "string"
+            description: ""
+          - name: "preferred_currency_code"
+            type: "string"
+            description: ""
+          - name: "primary_payment_source_id"
+            type: "string"
+            description: ""
+          - name: "promotional_credits"
+            type: "integer"
+            description: ""
+          - name: "referral_urls"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "created_at"
+                type: "date-time"
+                description: ""
+              - name: "external_customer_id"
+                type: "string"
+                description: ""
+              - name: "referral_account_id"
+                type: "string"
+                description: ""
+              - name: "referral_campaign_id"
+                type: "string"
+                description: ""
+              - name: "referral_external_account_id"
+                type: "string"
+                description: ""
+              - name: "referral_sharing_url"
+                type: "string"
+                description: ""
+              - name: "referral_system"
+                type: "string"
+                description: ""
+              - name: "updated_at"
+                type: "date-time"
+                description: ""
+          - name: "refundable_credits"
+            type: "integer"
+            description: ""
+          - name: "registered_for_gst"
+            type: "boolean"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "taxability"
+            type: "string"
+            description: ""
+          - name: "unbilled_charges"
+            type: "integer"
+            description: ""
           - name: "updated_at"
             type: "date-time"
-            description: "The time the subscription was last updated."
-
+            description: ""
+          - name: "vat_number"
+            type: "string"
+            description: ""
+          - name: "vat_number_status"
+            type: "string"
+            description: ""
+          - name: "vat_number_validated_time"
+            type: "date-time"
+            description: ""
+      - name: "gift"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "auto_claim"
+            type: "boolean"
+            description: ""
+          - name: "claim_expiry_date"
+            type: "date-time"
+            description: ""
+          - name: "gift_receiver"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "customer_id"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "subscription_id"
+                type: "string"
+                description: ""
+          - name: "gift_timelines"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "occurred_at"
+                type: "date-time"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+          - name: "gifter"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "customer_id"
+                type: "string"
+                description: ""
+              - name: "invoice_id"
+                type: "string"
+                description: ""
+              - name: "note"
+                type: "string"
+                description: ""
+              - name: "signature"
+                type: "string"
+                description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "scheduled_at"
+            type: "date-time"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "invoice"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "adjustment_credit_notes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "cn_date"
+                type: "date-time"
+                description: ""
+              - name: "cn_id"
+                type: "string"
+                description: ""
+              - name: "cn_reason_code"
+                type: "string"
+                description: ""
+              - name: "cn_status"
+                type: "string"
+                description: ""
+              - name: "cn_total"
+                type: "integer"
+                description: ""
+          - name: "amount_adjusted"
+            type: "integer"
+            description: ""
+          - name: "amount_due"
+            type: "integer"
+            description: ""
+          - name: "amount_paid"
+            type: "integer"
+            description: ""
+          - name: "amount_to_collect"
+            type: "integer"
+            description: ""
+          - name: "applied_credits"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: ""
+              - name: "applied_at"
+                type: "date-time"
+                description: ""
+              - name: "cn_date"
+                type: "date-time"
+                description: ""
+              - name: "cn_id"
+                type: "string"
+                description: ""
+              - name: "cn_reason_code"
+                type: "string"
+                description: ""
+              - name: "cn_status"
+                type: "string"
+                description: ""
+          - name: "base_currency_code"
+            type: "string"
+            description: ""
+          - name: "billing_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "credits_applied"
+            type: "integer"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "date"
+            type: "date-time"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "discounts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+          - name: "due_date"
+            type: "date-time"
+            description: ""
+          - name: "dunning_status"
+            type: "string"
+            description: ""
+          - name: "exchange_rate"
+            type: "number"
+            description: ""
+          - name: "expected_payment_date"
+            type: "date-time"
+            description: ""
+          - name: "first_invoice"
+            type: "boolean"
+            description: ""
+          - name: "has_advance_charges"
+            type: "boolean"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "is_gifted"
+            type: "boolean"
+            description: ""
+          - name: "issued_credit_notes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "cn_date"
+                type: "date-time"
+                description: ""
+              - name: "cn_id"
+                type: "string"
+                description: ""
+              - name: "cn_reason_code"
+                type: "string"
+                description: ""
+              - name: "cn_status"
+                type: "string"
+                description: ""
+              - name: "cn_total"
+                type: "integer"
+                description: ""
+          - name: "line_item_discounts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "coupon_id"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "discount_type"
+                type: "string"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+          - name: "line_item_taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "is_non_compliance_tax"
+                type: "boolean"
+                description: ""
+              - name: "is_partial_tax_applied"
+                type: "boolean"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "tax_juris_code"
+                type: "string"
+                description: ""
+              - name: "tax_juris_name"
+                type: "string"
+                description: ""
+              - name: "tax_juris_type"
+                type: "string"
+                description: ""
+              - name: "tax_name"
+                type: "string"
+                description: ""
+              - name: "tax_rate"
+                type: "integer"
+                description: ""
+              - name: "taxable_amount"
+                type: "integer"
+                description: ""
+          - name: "line_item_tiers"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "ending_unit"
+                type: "integer"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+              - name: "quantity_used"
+                type: "integer"
+                description: ""
+              - name: "starting_unit"
+                type: "integer"
+                description: ""
+              - name: "unit_amount"
+                type: "integer"
+                description: ""
+          - name: "line_items"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "date_from"
+                type: "date-time"
+                description: ""
+              - name: "date_to"
+                type: "date-time"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "is_taxed"
+                type: "boolean"
+                description: ""
+              - name: "item_level_discount_amount"
+                type: "integer"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "pricing_model"
+                type: "string"
+                description: ""
+              - name: "quantity"
+                type: "integer"
+                description: ""
+              - name: "subscription_id"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "tax_exempt_reason"
+                type: "string"
+                description: ""
+              - name: "tax_rate"
+                type: "integer"
+                description: ""
+              - name: "unit_amount"
+                type: "integer"
+                description: ""
+          - name: "linked_orders"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "batch_id"
+                type: "string"
+                description: ""
+              - name: "created_at"
+                type: "date-time"
+                description: ""
+              - name: "document_number"
+                type: "string"
+                description: ""
+              - name: "fulfillment_status"
+                type: "string"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "order_type"
+                type: "string"
+                description: ""
+              - name: "reference_id"
+                type: "string"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+          - name: "linked_payments"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: ""
+              - name: "applied_at"
+                type: "date-time"
+                description: ""
+              - name: "txn_amount"
+                type: "integer"
+                description: ""
+              - name: "txn_date"
+                type: "date-time"
+                description: ""
+              - name: "txn_id"
+                type: "string"
+                description: ""
+              - name: "txn_status"
+                type: "string"
+                description: ""
+          - name: "net_term_days"
+            type: "integer"
+            description: ""
+          - name: "new_sales_amount"
+            type: "integer"
+            description: ""
+          - name: "next_retry_at"
+            type: "date-time"
+            description: ""
+          - name: "notes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+              - name: "note"
+                type: "string"
+                description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "paid_at"
+            type: "date-time"
+            description: ""
+          - name: "po_number"
+            type: "string"
+            description: ""
+          - name: "price_type"
+            type: "string"
+            description: ""
+          - name: "recurring"
+            type: "boolean"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "round_off_amount"
+            type: "integer"
+            description: ""
+          - name: "shipping_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status,"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "sub_total"
+            type: "integer"
+            description: ""
+          - name: "subscription_id"
+            type: "string"
+            description: ""
+          - name: "tax"
+            type: "integer"
+            description: ""
+          - name: "taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "name"
+                type: "string"
+                description: ""
+          - name: "term_finalized"
+            type: "boolean"
+            description: ""
+          - name: "total"
+            type: "integer"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+          - name: "vat_number"
+            type: "string"
+            description: ""
+          - name: "voided_at"
+            type: "date-time"
+            description: ""
+          - name: "write_off_amount"
+            type: "integer"
+            description: ""
+      - name: "order"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "amount_adjusted"
+            type: "integer"
+            description: ""
+          - name: "amount_paid"
+            type: "integer"
+            description: ""
+          - name: "batch_id"
+            type: "string"
+            description: ""
+          - name: "billing_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "cancellation_reason"
+            type: "string"
+            description: ""
+          - name: "cancelled_at"
+            type: "date-time"
+            description: ""
+          - name: "created_at"
+            type: "date-time"
+            description: ""
+          - name: "created_by"
+            type: "string"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "delivered_at"
+            type: "date-time"
+            description: ""
+          - name: "discount"
+            type: "integer"
+            description: ""
+          - name: "document_number"
+            type: "string"
+            description: ""
+          - name: "fulfillment_status"
+            type: "string"
+            description: ""
+          - name: "gift_id"
+            type: "string"
+            description: ""
+          - name: "gift_note"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "invoice_id"
+            type: "string"
+            description: ""
+          - name: "invoice_round_off_amount"
+            type: "integer"
+            description: ""
+          - name: "is_gifted"
+            type: "boolean"
+            description: ""
+          - name: "line_item_discounts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "coupon_id"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "discount_type"
+                type: "string"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+          - name: "line_item_taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "is_non_compliance_tax"
+                type: "boolean"
+                description: ""
+              - name: "is_partial_tax_applied"
+                type: "boolean"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "tax_juris_code"
+                type: "string"
+                description: ""
+              - name: "tax_juris_name"
+                type: "string"
+                description: ""
+              - name: "tax_juris_type"
+                type: "string"
+                description: ""
+              - name: "tax_name"
+                type: "string"
+                description: ""
+              - name: "tax_rate"
+                type: "integer"
+                description: ""
+              - name: "taxable_amount"
+                type: "integer"
+                description: ""
+          - name: "linked_credit_notes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "amount_adjusted"
+                type: "integer"
+                description: ""
+              - name: "amount_refunded"
+                type: "integer"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+              - name: "type"
+                type: "string"
+                description: ""
+          - name: "note"
+            type: "string"
+            description: ""
+          - name: "order_date"
+            type: "date-time"
+            description: ""
+          - name: "order_line_items"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "amount_adjusted"
+                type: "integer"
+                description: ""
+              - name: "amount_paid"
+                type: "integer"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+              - name: "fulfillment_amount"
+                type: "integer"
+                description: ""
+              - name: "fulfillment_quantity"
+                type: "integer"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "invoice_id"
+                type: "string"
+                description: ""
+              - name: "invoice_line_item_id"
+                type: "string"
+                description: ""
+              - name: "is_shippable"
+                type: "boolean"
+                description: ""
+              - name: "item_level_discount_amount"
+                type: "integer"
+                description: ""
+              - name: "refundable_credits"
+                type: "integer"
+                description: ""
+              - name: "refundable_credits_issued"
+                type: "integer"
+                description: ""
+              - name: "sku"
+                type: "string"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "unit_price"
+                type: "integer"
+                description: ""
+          - name: "order_type"
+            type: "string"
+            description: ""
+          - name: "paid_on"
+            type: "date-time"
+            description: ""
+          - name: "payment_status"
+            type: "string"
+            description: ""
+          - name: "price_type"
+            type: "string"
+            description: ""
+          - name: "reference_id"
+            type: "string"
+            description: ""
+          - name: "refundable_credits"
+            type: "integer"
+            description: ""
+          - name: "refundable_credits_issued"
+            type: "integer"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "rounding_adjustement"
+            type: "integer"
+            description: ""
+          - name: "shipment_carrier"
+            type: "string"
+            description: ""
+          - name: "shipped_at"
+            type: "date-time"
+            description: ""
+          - name: "shipping_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status,"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "shipping_cut_off_date"
+            type: "date-time"
+            description: ""
+          - name: "shipping_date"
+            type: "date-time"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "status_update_at"
+            type: "date-time"
+            description: ""
+          - name: "sub_total"
+            type: "integer"
+            description: ""
+          - name: "subscription_id"
+            type: "string"
+            description: ""
+          - name: "tax"
+            type: "integer"
+            description: ""
+          - name: "total"
+            type: "integer"
+            description: ""
+          - name: "tracking_id"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "payment_source"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "amazon_payment"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "agreement_id"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+          - name: "bank_account"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "account_holder_type"
+                type: "string"
+                description: ""
+              - name: "account_type"
+                type: "string"
+                description: ""
+              - name: "bank_name"
+                type: "string"
+                description: ""
+              - name: "echeck_type"
+                type: "string"
+                description: ""
+              - name: "last4"
+                type: "string"
+                description: ""
+              - name: "mandate_id"
+                type: "string"
+                description: ""
+              - name: "name_on_account"
+                type: "string"
+                description: ""
+          - name: "card"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "billing_addr1"
+                type: "string"
+                description: ""
+              - name: "billing_addr2"
+                type: "string"
+                description: ""
+              - name: "billing_city"
+                type: "string"
+                description: ""
+              - name: "billing_country"
+                type: "string"
+                description: ""
+              - name: "billing_state"
+                type: "string"
+                description: ""
+              - name: "billing_state_code"
+                type: "string"
+                description: ""
+              - name: "billing_zip"
+                type: "string"
+                description: ""
+              - name: "brand"
+                type: "string"
+                description: ""
+              - name: "expiry_month"
+                type: "integer"
+                description: ""
+              - name: "expiry_year"
+                type: "integer"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "funding_type"
+                type: "string"
+                description: ""
+              - name: "iin"
+                type: "string"
+                description: ""
+              - name: "last4"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "masked_number"
+                type: "string"
+                description: ""
+          - name: "created_at"
+            type: "date-time"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "gateway"
+            type: "string"
+            description: ""
+          - name: "gateway_account_id"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "ip_address"
+            type: "string"
+            description: ""
+          - name: "issuing_country"
+            type: "string"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "paypal"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "agremeent_id"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+          - name: "reference_id"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "type"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "plan"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "account_code"
+            type: "string"
+            description: ""
+          - name: "accounting_category1"
+            type: "string"
+            description: ""
+          - name: "accounting_category2"
+            type: "string"
+            description: ""
+          - name: "addon_applicability"
+            type: "string"
+            description: ""
+          - name: "applicable_addons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "id"
+                type: "string"
+                description: ""
+          - name: "archived_at"
+            type: "date-time"
+            description: ""
+          - name: "avalara_sale_type"
+            type: "string"
+            description: ""
+          - name: "avalara_service_type"
+            type: "integer"
+            description: ""
+          - name: "avalara_transaction_type"
+            type: "integer"
+            description: ""
+          - name: "billing_cycles"
+            type: "integer"
+            description: ""
+          - name: "charge_model"
+            type: "string"
+            description: ""
+          - name: "claim_url"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""
+          - name: "description"
+            type: "string"
+            description: ""
+          - name: "enabled_in_hosted_pages"
+            type: "boolean"
+            description: ""
+          - name: "enabled_in_portal"
+            type: "boolean"
+            description: ""
+          - name: "event_based_addons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "charge_once"
+                type: "boolean"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "on_event"
+                type: "string"
+                description: ""
+              - name: "quantity"
+                type: "integer"
+                description: ""
+          - name: "free_quantity"
+            type: "integer"
+            description: ""
+          - name: "giftable"
+            type: "boolean"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "invoice_name"
+            type: "string"
+            description: ""
+          - name: "invoice_notes"
+            type: "string"
+            description: ""
+          - name: "is_shippable"
+            type: "boolean"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""  
+          - name: "name"
+            type: "string"
+            description: ""
+          - name: "period"
+            type: "integer"
+            description: ""
+          - name: "period_unit"
+            type: "string"
+            description: ""
+          - name: "price"
+            type: "integer"
+            description: ""
+          - name: "redirect_url"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "setup_cost"
+            type: "integer"
+            description: ""
+          - name: "shipping_frequency_period"
+            type: "integer"
+            description: ""
+          - name: "shipping_frequency_period_unit"
+            type: "string"
+            description: ""
+          - name: "sku"
+            type: "string"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "tax_code"
+            type: "string"
+            description: ""
+          - name: "tax_profile_id"
+            type: "string"
+            description: ""
+          - name: "taxable"
+            type: "boolean"
+            description: ""
+          - name: "tiers"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "ending_unit"
+                type: "integer"
+                description: ""
+              - name: "price"
+                type: "integer"
+                description: ""
+              - name: "starting_unit"
+                type: "integer"
+                description: ""
+          - name: "trial_period"
+            type: "integer"
+            description: ""
+          - name: "trial_period_unit"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+      - name: "promotional_credit"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "amount"
+            type: "string"
+            description: ""
+          - name: "closing_balance"
+            type: "integer"
+            description: ""
+          - name: "created_at"
+            type: "date-time"
+            description: ""
+          - name: "credit_type"
+            type: "string"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "description"
+            type: "string"
+            description: ""
+          - name: "done_by"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "reference"
+            type: "string"
+            description: ""
+          - name: "type"
+            type: "string"
+            description: ""
+      - name: "quote"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "amount_due"
+            type: "integer"
+            description: ""
+          - name: "amount_paid"
+            type: "integer"
+            description: ""
+          - name: "billing_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "credits_applied"
+            type: "integer"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "date"
+            type: "date-time"
+            description: ""
+          - name: "discounts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "line_item_discounts"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "coupon_id"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "discount_type"
+                type: "string"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+          - name: "line_item_taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "is_non_compliance_tax"
+                type: "boolean"
+                description: ""
+              - name: "is_partial_tax_applied"
+                type: "boolean"
+                description: ""
+              - name: "line_item_id"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "tax_juris_code"
+                type: "string"
+                description: ""
+              - name: "tax_juris_name"
+                type: "string"
+                description: ""
+              - name: "tax_juris_type"
+                type: "string"
+                description: ""
+              - name: "tax_name"
+                type: "string"
+                description: ""
+              - name: "tax_rate"
+                type: "number"
+                description: ""
+              - name: "taxable_amount"
+                type: "integer"
+                description: ""
+          - name: "line_items"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "customer_id"
+                type: "string"
+                description: ""
+              - name: "date_from"
+                type: "date-time"
+                description: ""
+              - name: "date_to"
+                type: "date-time"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "discount_amount"
+                type: "integer"
+                description: ""
+              - name: "entity_id"
+                type: "string"
+                description: ""
+              - name: "entity_type"
+                type: "string"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "is_taxed"
+                type: "boolean"
+                description: ""
+              - name: "item_level_discount_amount"
+                type: "integer"
+                description: ""
+              - name: "pricing_model"
+                type: "string"
+                description: ""
+              - name: "quantity"
+                type: "integer"
+                description: ""
+              - name: "subscription_id"
+                type: "string"
+                description: ""
+              - name: "tax_amount"
+                type: "integer"
+                description: ""
+              - name: "tax_exempt_reason"
+                type: "string"
+                description: ""
+              - name: "tax_rate"
+                type: "number"
+                description: ""
+              - name: "unit_amount"
+                type: "integer"
+                description: ""
+          - name: "operation_type"
+            type: "string"
+            description: ""
+          - name: "po_number"
+            type: "string"
+            description: ""
+          - name: "price_type"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "shipping_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status,"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "sub_total"
+            type: "integer"
+            description: ""
+          - name: "subscription_id"
+            type: "string"
+            description: ""
+          - name: "taxes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "description"
+                type: "string"
+                description: ""
+              - name: "name"
+                type: "string"
+                description: ""
+          - name: "total"
+            type: "integer"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+          - name: "valid_till"
+            type: "date-time"
+            description: ""
+          - name: "vat_number"
+            type: "string"
+            description: ""
+      - name: "subscription"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "activated_at"
+            type: "date-time"
+            description: ""
+          - name: "addons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "quantity"
+                type: "integer"
+                description: ""
+              - name: "remaining_billing_cycles"
+                type: "integer"
+                description: ""
+              - name: "trial_end"
+                type: "date-time"
+                description: ""
+              - name: "unit_price"
+                type: "integer"
+                description: ""
+          - name: "affiliate_token"
+            type: "string"
+            description: ""
+          - name: "auto_collection"
+            type: "string"
+            description: ""
+          - name: "base_currency_code"
+            type: "string"
+            description: ""
+          - name: "billing_period"
+            type: "integer"
+            description: ""
+          - name: "billing_period_unit"
+            type: "string"
+            description: ""
+          - name: "cancel_reason"
+            type: "string"
+            description: ""
+          - name: "cancelled_at"
+            type: "date-time"
+            description: ""
+          - name: "charged_event_based_addons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "last_charged_at"
+                type: "date-time"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+          - name: "coupon"
+            type: "string"
+            description: ""
+          - name: "coupons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "applied_count"
+                type: "integer"
+                description: ""
+              - name: "apply_till"
+                type: "date-time"
+                description: ""
+              - name: "coupon_code"
+                type: "string"
+                description: ""
+              - name: "coupon_id"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+          - name: "created_at"
+            type: "date-time"
+            description: ""
+          - name: "created_from_ip"
+            type: "string"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "current_term_end"
+            type: "date-time"
+            description: ""
+          - name: "current_term_start"
+            type: "date-time"
+            description: ""
+          - name: "custom_fields"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "due_invoices_count"
+            type: "integer"
+            description: ""
+          - name: "due_since"
+            type: "date-time"
+            description: ""
+          - name: "event_based_addons"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "charge_once"
+                type: "boolean"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "object"
+                type: "string"
+                description: ""
+              - name: "on_event"
+                type: "string"
+                description: ""
+              - name: "quantity"
+                type: "integer"
+                description: ""
+              - name: "unit_price"
+                type: "integer"
+                description: ""
+          - name: "exchange_rate"
+            type: "number"
+            description: ""
+          - name: "gift_id"
+            type: "string"
+            description: ""
+          - name: "has_scheduled_changes"
+            type: "boolean"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "invoice_notes"
+            type: "string"
+            description: ""
+          - name: "meta_data"
+            type: "string"
+            description: ""
+            - name: "custom_fields"
+            type: "string"
+            description: ""
+          - name: "mrr"
+            type: "integer"
+            description: ""
+          - name: "next_billing_at"
+            type: "date-time"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "pause_date"
+            type: "date-time"
+            description: ""
+          - name: "payment_source_id"
+            type: "string"
+            description: ""
+          - name: "plan_amount"
+            type: "integer"
+            description: ""
+          - name: "plan_free_quantity"
+            type: "integer"
+            description: ""
+          - name: "plan_id"
+            type: "string"
+            description: ""
+          - name: "plan_quantity"
+            type: "integer"
+            description: ""
+          - name: "plan_unit_price"
+            type: "integer"
+            description: ""
+          - name: "po_number"
+            type: "string"
+            description: ""
+          - name: "referral_info"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "account_id"
+                type: "string"
+                description: ""
+              - name: "campaign_id"
+                type: "string"
+                description: ""
+              - name: "coupon_code"
+                type: "string"
+                description: ""
+              - name: "destination_url"
+                type: "string"
+                description: ""
+              - name: "external_campaign_id"
+                type: "string"
+                description: ""
+              - name: "external_reference_id"
+                type: "string"
+                description: ""
+              - name: "friend_offer_type"
+                type: "string"
+                description: ""
+              - name: "notify_referral_system"
+                type: "string"
+                description: ""
+              - name: "post_purchase_widget_enabled"
+                type: "boolean"
+                description: ""
+              - name: "referral_code"
+                type: "string"
+                description: ""
+              - name: "referral_system"
+                type: "string"
+                description: ""
+              - name: "referrer_id"
+                type: "string"
+                description: ""
+              - name: "referrer_reward_type"
+                type: "string"
+                description: ""
+              - name: "reward_status"
+                type: "string"
+                description: ""
+          - name: "remaining_billing_cycles"
+            type: "integer"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "resume_date"
+            type: "date-time"
+            description: ""
+          - name: "setup_fee"
+            type: "integer"
+            description: ""
+          - name: "shipping_address"
+            type: "object"
+            description: ""
+            subattributes:
+              - name: "city"
+                type: "string"
+                description: ""
+              - name: "company"
+                type: "string"
+                description: ""
+              - name: "country"
+                type: "string"
+                description: ""
+              - name: "email"
+                type: "string"
+                description: ""
+              - name: "first_name"
+                type: "string"
+                description: ""
+              - name: "last_name"
+                type: "string"
+                description: ""
+              - name: "line1"
+                type: "string"
+                description: ""
+              - name: "line2"
+                type: "string"
+                description: ""
+              - name: "line3"
+                type: "string"
+                description: ""
+              - name: "phone"
+                type: "string"
+                description: ""
+              - name: "state"
+                type: "string"
+                description: ""
+              - name: "state_code"
+                type: "string"
+                description: ""
+              - name: "validation_status,"
+                type: "string"
+                description: ""
+              - name: "zip"
+                type: "string"
+                description: ""
+          - name: "start_date"
+            type: "date-time"
+            description: ""
+          - name: "started_at"
+            type: "date-time"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "total_dues"
+            type: "integer"
+            description: ""
+          - name: "trial_end"
+            type: "date-time"
+            description: ""
+          - name: "trial_start"
+            type: "date-time"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
       - name: "transaction"
         type: "object"
-        description: |
-          Applicable when `events.event_type` is one of the following:
-
-          - `authorization_succeeded`
-          - `authorization_voided`
-          - `payment_succeeded`
-          - `payment_failed`
-          - `payment_refunded`
-          - `payment_initiated`
-          - `refund_initiated`
-          - `transaction_created`
-          - `transaction_updated`
-          - `transaction_deleted`
+        description: ""
         subattributes:
-            - name: "amount"
-              type: "integer"
-              description: "The amount for the transaction."
-
-            - name: "amount_unused"
-              type: "integer"
-              description: "**Applicable only for payments.** The unused amount present for the transaction."
-
-            - name: "base_currency_code"
-              type: "string"
-              description: ""
-
-            - name: "currency_code"
-              type: "string"
-              description: "The currency code for the transaction, in ISO 4217 format."
-
-            - name: "customer_id"
-              type: "string"
-              description: "The ID of the customer associated with the transaction."
-              foreign-key-id: "customer-id"
-
-            - name: "date"
-              type: "date-time"
-              description: "The date the transaction occurred."
-
-            - name: "deleted"
-              type: "boolean"
-              description: "Indicates if the transaction has been deleted."
-
-            - name: "error_code"
-              type: "string"
-              description: "The error code received from the payment gateway on failure."
-
-            - name: "error_text"
-              type: "string"
-              description: "The error message received from the payment gateway on failure."
-
-            - name: "exchange_rate"
-              type: "number"
-              description: ""
-
-            - name: "fraud_flag"
-              type: "string"
-              description: |
-                Indicates whether or not the transaction has been identified as fraudulent. Possible values are:
-
-                - `safe`
-                - `suspicious`
-                - `fraudulent`
-
-            - name: "fraud_reason"
-              type: "string"
-              description: "A short description why the transaction was marked as fraudulent or suspicious."
-
-            - name: "gateway"
-              type: "string"
-              description: "The name of the gateway used to process the transaction."
-
-            - name: "gateway_account_id"
-              type: "string"
-              description: "The account ID of the gateway used to process the transaction."
-
-            - name: "id"
-              type: "string"
-              description: "The transaction ID."
-              foreign-key-id: "transaction-id"
-
-            - name: "id_at_gateway"
-              type: "string"
-              description: "The ID with which the transaction is referred in the `gateway`."
-
-            - name: "linked_credit_notes"
-              type: "array"
-              description: "**Applicable only for refund transactions.** The list of credit notes the transaction is associated with."
-              subattributes:
-                - name: "applied_amount"
-                  type: "integer"
-                  description: "The transaction amount applied to the invoice."
-
-                - name: "applied_at"
-                  type: "date-time"
-                  description: "The time the credit note was applied."
-
-                - name: "cn_date"
-                  type: "date-time"
-                  description: "The date the credit note was created."
-
-                - name: "cn_id"
-                  type: "string"
-                  description: "The credit note ID."
-                  foreign-key-id: "credit-note-id"
-
-                - name: "cn_reason_code"
-                  type: "string"
-                  description: |
-                    The reason for the credit note. Possible values are:
-
-                    - `write_off`
-                    - `subscription_change`
-                    - `subscription_cancellation`
-                    - `subscription_pause`
-                    - `chargeback`
-                    - `product_unsatisfactory`
-                    - `service_unsatisfactory`
-                    - `order_change`
-                    - `order_cancellation`
-                    - `waiver`
-                    - `other`
-                    - `fraudulent`
-
-                - name: "cn_reference_invoice_id"
-                  type: "string"
-                  description: "The invoice ID."
-                  foreign-key-id: "invoice-id"
-
-                - name: "cn_status"
-                  type: "string"
-                  description: |
-                    The status of the credit note. Possible values are:
-
-                    - `adjusted`
-                    - `refunded`
-                    - `refund_due`
-                    - `voided`
-
-                - name: "cn_total"
-                  type: "integer"
-                  description: "The total amount of the credit note."
-
-            - name: "linked_invoices"
-              type: "array"
-              description: "**Applicable only for payment transactions.** The list of invoices the transaction has been applied to."
-              subattributes:
-                - name: "applied_amount"
-                  type: "integer"
-                  description: "The transaction amount applied to the invoice."
-
-                - name: "applied_at"
-                  type: "date-time"
-                  description: "The time at which the transaction was applied."
-
-                - name: "invoice_date"
-                  type: "date-times"
-                  description: "The date the invoice was issued."
-
-                - name: "invoice_id"
-                  type: "string"
-                  description: "The invoice ID."
-                  foreign-key-id: "invoice-id"
-
-                - name: "invoice_status"
-                  type: "string"
-                  description: |
-                    The current status of the invoice. Possible values are:
-
-                    - `paid`
-                    - `posted`
-                    - `payment_due`
-                    - `not_paid`
-                    - `voided`
-                    - `pending`
-
-                - name: "invoice_total"
-                  type: "integer"
-                  description: "The total amount of the invoice."
-
-            - name: "linked_refunds"
-              type: "array"
-              description: "**Applicable only for payment transactions.** The list of refunds issued for the payment transaction."
-              subattributes:
-                - name: "txn_amount"
-                  type: "integer"
-                  description: "The total amount of the transaction."
-
-                - name: "txn_date"
-                  type: "date-time"
-                  description: "The date the transaction occured."
-
-                - name: "txn_id"
-                  type: "string"
-                  description: "the transaction ID."
-                  foreign-key-id: "transaction-id"
-
-                - name: "txn_status"
-                  type: "string"
-                  description: |
-                    The status of the transaction. Possible values are:
-
-                    - `in_progress`
-                    - `success`
-                    - `voided`
-                    - `failure`
-                    - `timeout`
-                    - `needs_attention`
-
-            - name: "masked_card_number"
-              type: "string"
-              description: "**Applicable only when `payment_method: card`.** The masked card number used for the transaction."
-
-            - name: "object"
-              type: "string"
-              description: ""
-
-            - name: "payment_method"
-              type: "string"
-              description: |
-                The payment method for the transaction. Possible values are:
-
-                - `card`
-                - `cash`
-                - `check`
-                - `chargeback`
-                - `bank_transfer`
-                - `amazon_payments`
-                - `paypal_express_checkout`
-                - `direct_debit`
-                - `alipay`
-                - `unionpay`
-                - `apple_pay`
-                - `wechat_pay`
-                - `ach_credit`
-                - `other`
-
-            - name: "payment_source_id"
-              type: "string"
-              description: "The ID of the payment source used for the transaction."
-              foreign-key-id: "payment-source-id"
-
-            - name: "reference_number"
-              type: "string"
-              description: "The reference number for the transaction."
-
-            - name: "reference_transaction_id"
-              type: "string"
-              description: "**Applicable only when `type` is `refund` or `payment_reversal`.** The reference payment ID."
-              foreign-key-id: "transaction-id"
-
-            - name: "refunded_txn_id"
-              type: "string"
-              description: "**Applicable only when `type: refund`**. The ID of the original transaction that was refunded."
-              foreign-key-id: "transaction-id"
-
-            - name: "resource_version"
-              type: "integer"
-              description: "The version number of the transaction. Each update of the transaction results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
-
-            - name: "reversal_txn_id"
-              type: "string"
-              description: "**Applicable only when `type: payment_reversal`**. The ID of the original transaction that was reversed."
-
-            - name: "settled_at"
-              type: "date-time"
-              description: "The time at which the final status of the transaction has been marked."
-
-            - name: "status"
-              type: "string"
-              description: |
-                The status of the transaction. Possible values are:
-
-                - `in_progress`
-                - `success`
-                - `voided`
-                - `failure`
-                - `timeout`
-                - `needs_attention`
-
-            - name: "subscription_id"
-              type: "string"
-              description: "The ID of the subscription associated with the transaction."
-              foreign-key-id: "subscription-id"
-
-            - name: "type"
-              type: "string"
-              description: |
-                The type of the transaction. Possible values are:
-
-                - `authorization`
-                - `payment`
-                - `refund`
-                - `payment_reversal`
-
-            - name: "updated_at"
-              type: "date-time"
-              description: "The time the transaction was last updated."
-
-            - name: "validated_at"
-              type: "date-time"
-              description: ""
-
+          - name: "amount"
+            type: "integer"
+            description: ""
+          - name: "amount_capturable"
+            type: "string"
+            description: ""
+          - name: "amount_unused"
+            type: "integer"
+            description: ""
+          - name: "authorization_reason"
+            type: "string"
+            description: ""
+          - name: "base_currency_code"
+            type: "string"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "date"
+            type: "date-time"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "error_code"
+            type: "string"
+            description: ""
+          - name: "error_text"
+            type: "string"
+            description: ""
+          - name: "exchange_rate"
+            type: "number"
+            description: ""
+          - name: "fraud_flag"
+            type: "string"
+            description: ""
+          - name: "fraud_reason"
+            type: "string"
+            description: ""
+          - name: "gateway"
+            type: "string"
+            description: ""
+          - name: "gateway_account_id"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "id_at_gateway"
+            type: "string"
+            description: ""
+          - name: "linked_credit_notes"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: ""
+              - name: "applied_at"
+                type: "date-time"
+                description: ""
+              - name: "cn_date"
+                type: "date-time"
+                description: ""
+              - name: "cn_id"
+                type: "string"
+                description: ""
+              - name: "cn_reason_code"
+                type: "string"
+                description: ""
+              - name: "cn_reference_invoice_id"
+                type: "string"
+                description: ""
+              - name: "cn_status"
+                type: "string"
+                description: ""
+              - name: "cn_total"
+                type: "integer"
+                description: ""
+          - name: "linked_invoices"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "applied_amount"
+                type: "integer"
+                description: ""
+              - name: "applied_at"
+                type: "date-time"
+                description: ""
+              - name: "invoice_date"
+                type: "date-times"
+                description: ""
+              - name: "invoice_id"
+                type: "string"
+                description: ""
+              - name: "invoice_status"
+                type: "string"
+                description: ""
+              - name: "invoice_total"
+                type: "integer"
+                description: ""
+          - name: "linked_payments"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "amount"
+                type: "integer"
+                description: ""
+              - name: "date"
+                type: "date-time"
+                description: ""
+              - name: "id"
+                type: "string"
+                description: ""
+              - name: "status"
+                type: "string"
+                description: ""
+          - name: "linked_refunds"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "txn_amount"
+                type: "integer"
+                description: ""
+              - name: "txn_date"
+                type: "date-time"
+                description: ""
+              - name: "txn_id"
+                type: "string"
+                description: ""
+              - name: "txn_status"
+                type: "string"
+                description: ""
+          - name: "masked_card_number"
+            type: "string"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "payment_method"
+            type: "string"
+            description: ""
+          - name: "payment_source_id"
+            type: "string"
+            description: ""
+          - name: "reference_authorization_id"
+            type: "string"
+            description: ""
+          - name: "reference_number"
+            type: "string"
+            description: ""
+          - name: "reference_transaction_id"
+            type: "string"
+            description: ""
+          - name: "refunded_txn_id"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "reversal_transaction_id"
+            type: "string"
+            description: ""
+          - name: "reversal_txn_id"
+            type: "string"
+            description: ""
+          - name: "settled_at"
+            type: "date-time"
+            description: ""
+          - name: "status"
+            type: "string"
+            description: ""
+          - name: "subscription_id"
+            type: "string"
+            description: ""
+          - name: "type"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
+          - name: "validated_at"
+            type: "date-time"
+            description: ""
+          - name: "voided_at"
+            type: "date-time"
+            description: ""
+      - name: "unbilled_charges"
+        type: "array"
+        description: ""
+        subattributes:
+          - name: "amount"
+            type: "integer"
+            description: ""
+          - name: "currency_code"
+            type: "string"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "description"
+            type: "string"
+            description: ""
+          - name: "discount_amount"
+            type: "integer"
+            description: ""
+          - name: "entity_id"
+            type: "string"
+            description: ""
+          - name: "entity_type"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "is_voided"
+            type: "boolean"
+            description: ""
+          - name: "pricing_model"
+            type: "string"
+            description: ""
+          - name: "quantity"
+            type: "integer"
+            description: ""
+          - name: "subscription_id"
+            type: "string"
+            description: ""
+          - name: "tiers"
+            type: "array"
+            description: ""
+            subattributes:
+              - name: "ending_unit"
+                type: "integer"
+                description: ""
+              - name: "quantity_used "
+                type: "integer"
+                description: ""
+              - name: "starting_unit"
+                type: "integer"
+                description: ""
+              - name: "unit_amount "
+                type: "integer"
+                description: ""
+          - name: "unit_amount"
+            type: "integer"
+            description: ""
+          - name: "voided_at"
+            type: "date-time"
+            description: ""
+      - name: "virtual_bank_account"
+        type: "object"
+        description: ""
+        subattributes:
+          - name: "account_number"
+            type: "string"
+            description: ""
+          - name: "bank_name"
+            type: "string"
+            description: ""
+          - name: "created_at"
+            type: "date-time"
+            description: ""
+          - name: "customer_id"
+            type: "string"
+            description: ""
+          - name: "deleted"
+            type: "boolean"
+            description: ""
+          - name: "email"
+            type: "string"
+            description: ""
+          - name: "gateway"
+            type: "string"
+            description: ""
+          - name: "gateway_account_id"
+            type: "string"
+            description: ""
+          - name: "id"
+            type: "string"
+            description: ""
+          - name: "object"
+            type: "string"
+            description: ""
+          - name: "reference_id"
+            type: "string"
+            description: ""
+          - name: "resource_version"
+            type: "integer"
+            description: ""
+          - name: "routing_number"
+            type: "string"
+            description: ""
+          - name: "swift_code"
+            type: "string"
+            description: ""
+          - name: "updated_at"
+            type: "date-time"
+            description: ""
   - name: "event_type"
     type: "string"
-    description: |
-      The event type. Refer to [{{ integration.display_name }}'s documentation](https://apidocs.chargebee.com/docs/api/events#event_types){:target="new"} for a full list of possible event types.
-    doc-link: "https://apidocs.chargebee.com/docs/api/events#event_types"
-
+    description: ""
+  
   - name: "object"
     type: "string"
     description: ""
-
+  
   - name: "source"
     type: "string"
-    description: |
-      The source of the event. Possible values are:
-
-      - `admin_console`
-      - `api`
-      - `scheduled_job`
-      - `hosted_page`
-      - `portal`
-      - `system`
-      - `none`
-      - `js_api`
-      - `migration`
-      - `bulk_operation`
-      - `external_service`
-
+    description: ""
+  
   - name: "user"
     type: "string"
-    description: "The event created by the user."
-
+    description: ""
+  
   - name: "webhook_status"
     type: "string"
-    description: |
-      The current status of the webhook for this event. Possible values are:
-
-      - `not_configured`
-      - `scheduled`
-      - `succeeded`
-      - `re_scheduled`
-      - `failed`
-      - `skipped`
-      - `not_applicable`
-    doc-link: "https://apidocs.chargebee.com/docs/api/events#event_webhooks"
+    description: ""
 ---

--- a/_integration-schemas/chargebee/foreign-keys.md
+++ b/_integration-schemas/chargebee/foreign-keys.md
@@ -244,7 +244,7 @@ foreign-keys:
       - table: "transactions"
       - table: "gifts"
         subattribute: "gift_receiver"
-        join-on "subscription_id"
+        join-on: "subscription_id"
       - table: "orders"
         join-on: "subscription_id"  
 

--- a/_integration-schemas/chargebee/foreign-keys.md
+++ b/_integration-schemas/chargebee/foreign-keys.md
@@ -10,6 +10,9 @@ foreign-keys:
     all-foreign-keys:
       - table: "addon"
         join-on: "id"
+      - table: "coupons"
+        subattribute: "addon_ids"
+        join-on: "value"
       - table: "events"
         subattribute: "content.subscription.addons"
         join-on: "id"
@@ -22,6 +25,9 @@ foreign-keys:
       - table: "invoices"
         subattribute: "notes"
         join-on: "entity_id"
+      - table: "plans"
+        subattribute: "applicable_addons"
+        join-on: "id"
       - table: "subscriptions"
         subattribute: "addons"
         join-on: "id"
@@ -110,6 +116,7 @@ foreign-keys:
         subattribute: "notes"
         join-on: "entity_id"
       - table: "payment_sources"
+      - table: "promotional_credits"
       - table: "subscriptions"
       - table: "transactions"
       - table: "virtual_bank_accounts"
@@ -121,6 +128,17 @@ foreign-keys:
         join-on: "customer_id"
       - table: "orders"
         join-on: "customer_id"  
+
+  - id: "gift-id"
+    attribute: "id"
+    table: "gifts"
+    all-foreign-keys:
+      - table: "gifts"
+        join-on: "id"
+      - table: "orders"
+        join-on: "gift_id"
+      - table: "subscriptions"
+        join-on: "gift_id"
 
   - id: "line-item-id"
     attribute: "line_item_id"
@@ -190,9 +208,12 @@ foreign-keys:
     attribute: "plan_id"
     table: "plans"
     all-foreign-keys:
-      - table: "events"
+      - table: "coupons"
         subattribute: "content.plan"
         join-on: "id"
+      - table: "events"
+        subattribute: "plan_ids"
+        join-on: "value"
       - table: "events"
         subattribute: "content.subscription"
       - table: "plans"
@@ -286,14 +307,5 @@ foreign-keys:
     table: "orders"
     all-foreign-keys:
       - table: "orders"
-        join-on: "id"
-
-  - id: "gift-id"
-    attribute: "id"
-    table: "gifts"
-    all-foreign-keys:
-      - table: "gifts"
-        join-on: "id"
-      - table: "orders"
-        join-on: "gift_id"          
+        join-on: "id"         
 ---

--- a/_integration-schemas/chargebee/gifts.md
+++ b/_integration-schemas/chargebee/gifts.md
@@ -1,0 +1,111 @@
+---
+tap: "chargebee"
+version: "1"
+key: "gifts"
+
+name: "gifts"
+doc-link: "https://apidocs.chargebee.com/docs/api/gifts"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/gifts.json"
+description: "The `{{ table.name }}` table contains info about the gifts in your {{ integration.display_name }} account."
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List gifts"
+    doc-link: "https://apidocs.chargebee.com/docs/api/gifts#list_gifts"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The gift ID."
+    foreign-key-id: "gift-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    description: "The time the gift was last updated"
+    replication-key: true
+
+  - name: "auto_claim"
+    type: "boolean"
+    description: "Whether or not the gift is an auto-claim gift."
+
+  - name: "claim_expiry_date"
+    type: "date-time"
+    description: "The date until which the gift can be received."
+
+  - name: "gift_receiver"
+    type: "object"
+    description: "Details of the gift receiver."
+    subattributes:
+      - name: "customer_id"
+        type: "string"
+        foreign-key-id: "customer-id"
+        description: "The receiver's customer ID."
+      - name: "email"
+        type: "string"
+        description: "The receiver's email."
+      - name: "first_name"
+        type: "string"
+        description: "The first name of the receiver."
+      - name: "last_name"
+        type: "string"
+        description: "The last name of the receiver."
+      - name: "subscription_id"
+        type: "string"
+        description: "The subscription created for the gift."
+        foreign-key-id: "subscription-id"
+
+  - name: "gift_timelines"
+    type: "array"
+    description: "The gift timeline details."
+    subattributes:
+      - name: "occurred_at"
+        type: "date-time"
+        description: "The timestamp of when this event occured."
+      - name: "status"
+        type: "string"
+        description: |
+          The status of the gift. The possible values are:
+          - `scheduled`
+          - `unclaimed`
+          - `claimed`
+          - `cancelled`
+          - `expired`
+
+  - name: "gifter"
+    type: "object"
+    description: "The gifter's details."
+    subattributes:
+      - name: "customer_id"
+        type: "string"
+        description: "The gifter's customer ID."
+      - name: "invoice_id"
+        type: "string"
+        description: "The gifter's gift invoice ID."
+        foreign-key-id: "invoice_id"
+      - name: "note"
+        type: "string"
+        description: "The personalize message for the gift."
+      - name: "signature"
+        type: "string"
+        description: "The gifter's signature."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of this resource."
+
+  - name: "scheduled_at"
+    type: "date-time"
+    description: "The date in which the receiver will recieve the gift notification."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the gift. The possible values are:
+      - `scheduled`
+      - `unclaimed`
+      - `claimed`
+      - `cancelled`
+      - `expired`
+---

--- a/_integration-schemas/chargebee/invoices.md
+++ b/_integration-schemas/chargebee/invoices.md
@@ -270,6 +270,14 @@ attributes:
     type: "boolean"
     description: "Indicates if the invoice is gifted or not."
 
+  - name: "is_partial_tax_applied"
+    type: "boolean"
+    description: "Indicates if partial tax has been applied."
+
+  - name: "is_non_compliance_tax"
+    type: "boolean"
+    description: ""
+
   - name: "issued_credit_notes"
     type: "array"
     description: "A list of credit notes issued for the invoice."
@@ -441,6 +449,30 @@ attributes:
         type: "integer"
         description: "The unit amount of the line item, in cents."
 
+  - name: "line_item_tiers"
+    type: "array"
+    description: ""
+    subattributes:
+      - name: "line_item_id"
+        type: "string"
+        description: ""
+
+      - name: "starting_unit"
+        type: "integer"
+        description: ""
+
+      - name: "ending_unit"
+        type: "integer"
+        description: ""
+
+      - name: "quantity_used"
+        type: "integer"
+        description: ""
+
+      - name: "unit_amount"
+        type: "integer"
+        description: ""
+
   - name: "linked_orders"
     type: "array"
     description: "A list of orders associated with the invoice."
@@ -494,6 +526,14 @@ attributes:
       - name: "applied_at"
         type: "date-time"
         description: "The time the amount was applied."
+
+      - name: "document_number"
+        type: "integer"
+        description: ""
+
+      - name: "order_type"
+        type: "string"
+        description: ""
 
       - name: "txn_amount"
         type: "integer"
@@ -617,6 +657,10 @@ attributes:
   - name: "tax"
     type: "integer"
     description: "The total tax amount for the invoice, in cents."
+
+  - name: "taxable_amount"
+    type: "integer"
+    description: ""
 
   - name: "taxes"
     type: "array"

--- a/_integration-schemas/chargebee/orders.md
+++ b/_integration-schemas/chargebee/orders.md
@@ -1,0 +1,476 @@
+---
+tap: "chargebee"
+version: "1"
+key: "orders"
+
+name: "orders"
+doc-link: "https://apidocs.chargebee.com/docs/api/orders"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/orders.json"
+description: "The `{{ table.name }}` table contains info about the orders in your {{ integration.display_name }} account. The **Order Management** feature must be enabled to sync this table. For more information, refer to the [{{ integration.display_name }} docs](https://www.chargebee.com/docs/orders.html)."
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List orders"
+    doc-link: "https://apidocs.chargebee.com/docs/api/orders#list_orders"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The order ID."
+    foreign-key-id: "order-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    description: "The time the order was last updated."
+    replication-key: true
+
+  - name: "amount_adjusted"
+    type: "integer"
+    description: "The amount the order was adjusted."
+
+  - name: "amount_paid"
+    type: "integer"
+    description: "The total amount paid for the order."
+
+  - name: "batch_id"
+    type: "string"
+    description: "The unique ID to identify a group of orders."
+
+  - name: "billing_address"
+    type: "object"
+    description: "The billing address of the order."
+    subattributes:
+      - name: "city"
+        type: "string"
+        description: "The city."
+      - name: "company"
+        type: "string"
+        description: "The company name."
+      - name: "country"
+        type: "string"
+        description: "The country."
+      - name: "email"
+        type: "string"
+        description: "The email of the billed client."
+      - name: "first_name"
+        type: "string"
+        description: "The first name of the billed client."
+      - name: "last_name"
+        type: "string"
+        description: "The last name of the billed client."
+      - name: "line1"
+        type: "string"
+        description: "The first line of the address."
+      - name: "line2"
+        type: "string"
+        description: "The second line of the address"
+      - name: "line3"
+        type: "string"
+        description: "The third line of the address."
+      - name: "object"
+        type: "string"
+        description: ""
+      - name: "phone"
+        type: "string"
+        description: "The phone number of the billed client."
+      - name: "state"
+        type: "string"
+        description: "The state."
+      - name: "state_code"
+        type: "string"
+        description: "The state code."
+      - name: "validation_status"
+        type: "string"
+        description: "The address verification status."
+      - name: "zip"
+        type: "string"
+        description: "The zip code."
+
+  - name: "cancellation_reason"
+    type: "string"
+    description: "The reason for the order cancellation."
+
+  - name: "cancelled_at"
+    type: "date-time"
+    description: "The date the order was cancelled."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The date the order was created."
+
+  - name: "created_by"
+    type: "string"
+    description: "The source or user that created the order."
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code of the invoice."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The customer ID."
+    foreign-key-id: "customer-id"
+
+  - name: "deleted"
+    type: "boolean"
+    description: "Indication of wheteher or not the resource has been deleted."
+
+  - name: "delivered_at"
+    type: "date-time"
+    description: "The date the order was delivered."
+
+  - name: "discount"
+    type: "integer"
+    description: "The total discount on the order."
+
+  - name: "document_number"
+    type: "string"
+    description: "The serial number of the order."
+
+  - name: "fulfillment_status"
+    type: "string"
+    description: |
+      The fulfillment status of the order. Typical values are:
+      - `Shipped`
+      - `Awaiting Shipment`
+      - `Not fulfilled`
+
+  - name: "gift_id"
+    type: "string"
+    description: "The gift ID if the order is a gift."
+    foreign-key-id: "gift-id"
+
+  - name: "gift_note"
+    type: "string"
+    description: "The gift message added during the purchase."
+
+  - name: "invoice_id"
+    type: "string"
+    description: "The invoice number."
+    foreign-key-id: "invoice-id"
+
+  - name: "invoice_round_off_amount"
+    type: "integer"
+    description: "The total round off taken from the invoice level."
+
+  - name: "is_gifted"
+    type: "boolean"
+    description: "Indication of whether this order is a gift or not."
+
+  - name: "line_item_discounts"
+    type: "array"
+    description: "The list of discounts applied to the order."
+    subattributes:
+      - name: "coupon_id"
+        type: "string"
+        description: "The coupon ID."
+        foreign-key-id: "coupon-id"
+      - name: "discount_amount"
+        type: "integer"
+        description: "The discount amount."
+      - name: "discount_type"
+        type: "string"
+        description: "The type of discount."
+      - name: "line_item_id"
+        type: "string"
+        description: "The reference ID of the item that the discount is applied to."
+        foreign-key-id: "line-item-id"
+
+  - name: "line_item_taxes"
+    type: "array"
+    description: "The list of taxes applied on the order's line items."
+    subattributes:
+      - name: "is_non_compliance_tax"
+        type: "boolean"
+        description: "Indicates the non-compliance tax that should not be reported to the jurisdiction."
+      - name: "is_partial_tax_applied"
+        type: "boolean"
+        description: "Indicates whether or not tax is applied on a portion of the line item amount."
+      - name: "line_item_id"
+        type: "string"
+        description: "The reference ID of the item where tax is applicable."
+      - name: "tax_amount"
+        type: "integer"
+        description: "The tax amount."
+      - name: "tax_juris_code"
+        type: "string"
+        description: "The tax jurisdiction code."
+      - name: "tax_juris_name"
+        type: "string"
+        description: "The tax jurisdiction name."
+      - name: "tax_juris_type"
+        type: "string"
+        description: "The type of tax jurisdiction."
+      - name: "tax_name"
+        type: "string"
+        description: "The name of the tax applied."
+      - name: "tax_rate"
+        type: "integer"
+        description: "The tax rate."
+      - name: "taxable_amount"
+        type: "integer"
+        description: "The actual portion of the line item amount that is taxable."
+
+  - name: "linked_credit_notes"
+    type: "array"
+    description: "The credit notes linked to the order."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The order amount."
+      - name: "amount_adjusted"
+        type: "integer"
+        description: "The total amount adjusted on the order."
+      - name: "amount_refunded"
+        type: "integer"
+        description: "The total refundable credits issued on the order."
+      - name: "id"
+        type: "string"
+        description: "The credit note ID."
+        foreign-key-id: "credit-note-id"
+      - name: "status"
+        type: "string"
+        description: "The credit note status."
+      - name: "type"
+        type: "string"
+        description: |
+          The credit note type. Possible values are:
+          - `adjustment`
+          - `refundable`
+
+  - name: "note"
+    type: "string"
+    description: "The custom note for the order."
+
+  - name: "order_date"
+    type: "date-time"
+    description: "The date that the order will be processed."
+
+  - name: "order_line_items"
+    type: "array"
+    description: "The list of line items in the order."
+    subattributes:
+      - name: "amount"
+        type: "integer"
+        description: "The subtotal of the order line item."
+      - name: "amount_adjusted"
+        type: "integer"
+        description: "The total amount adjusted on the invoice."
+      - name: "amount_paid"
+        type: "integer"
+        description: "The total amount paid on the invoice."
+      - name: "description"
+        type: "string"
+        description: "The line item description."
+      - name: "discount_amount"
+        type: "integer"
+        description: "The discount given on the order line item."
+      - name: "entity_id"
+        type: "string"
+        description: "The identifier of the modelled entity this line item is based on."
+      - name: "entity_type"
+        type: "string"
+        description: |
+          The specified modelled entity this line item is based on. Possible values are:
+          - `plan_setup`
+          - `plan`
+          - `addon`
+          - `adhoc`
+      - name: "fulfillment_amount"
+        type: "integer"
+        description: "The amount that is going to get fulfilled for this order."
+      - name: "fulfillment_quantity"
+        type: "integer"
+        description: "The quantity that is going to get fulfilled for this order."
+      - name: "id"
+        type: "string"
+        description: "The order line item ID."
+      - name: "invoice_id"
+        type: "string"
+        description: "The invoice of the line item."
+      - name: "invoice_line_item_id"
+        type: "string"
+        description: "The invoice line item ID associated with this order line item."
+      - name: "is_shippable"
+        type: "boolean"
+        description: "Specifies whether or not the charge is applicable for shipping."
+      - name: "item_level_discount_amount"
+        type: "integer"
+        description: "The item level discount amount."
+      - name: "refundable_credits"
+        type: "integer"
+        description: "The total amount of refundable credits."
+      - name: "refundable_credits_issued"
+        type: "integer"
+        description: "The total refundable credits issued on the invoice."
+      - name: "sku"
+        type: "string"
+        description: "The SKU for the delivery."
+      - name: "status"
+        type: "string"
+        description: |
+          The status of the order. Possible values are
+            - `queued`
+            - `awaiting_shipment`
+            - `on_hold`
+            - `delivered`
+            - `shipped`
+            - `partially_delivered`
+            - `returned`
+            - `cancelled`
+      - name: "tax_amount"
+        type: "integer"
+        description: "The total amount of tax applied on the line item."
+      - name: "unit_price"
+        type: "integer"
+        description: "The unit price."
+
+  - name: "order_type"
+    type: "string"
+    description: |
+      The order type. Possible values are:
+      - `manual`
+      - `system_generated`
+
+  - name: "paid_on"
+    type: "date-time"
+    description: "The date the invoice was paid."
+
+  - name: "payment_status"
+    type: "string"
+    description: |
+      The payment status of the order. Possible values are:
+      - `not_paid`
+      - `paid`
+
+  - name: "price_type"
+    type: "string"
+    description: |
+      The price type of the order. Possible values are:
+      - `tax_exclusive`
+      - `tax_inclusive`
+
+  - name: "reference_id"
+    type: "string"
+    description: "The reference ID."
+
+  - name: "refundable_credits"
+    type: "integer"
+    description: "The total amount that can be issued as credits for the order."
+
+  - name: "refundable_credits_issued"
+    type: "integer"
+    description: "The total amount issued as credits on behalf of the order."
+
+  - name: "resource_version"
+    type: "integer"
+    description: "The version number of the resource."
+
+  - name: "rounding_adjustement"
+    type: "integer"
+    description: "Rounding adjustment."
+
+  - name: "shipment_carrier"
+    type: "string"
+    description: "The shipment carrier."
+
+  - name: "shipped_at"
+    type: "date-time"
+    description: "The date the order was shipped."
+
+  - name: "shipping_address"
+    type: "object"
+    description: "The shipping address for the order."
+    subattributes:
+      - name: "city"
+        type: "string"
+        description: "The city."
+      - name: "company"
+        type: "string"
+        description: "The name of the company."
+      - name: "country"
+        type: "string"
+        description: "The country."
+      - name: "email"
+        type: "string"
+        description: "The email of the shipment recipient."
+      - name: "first_name"
+        type: "string"
+        description: "The first name of the recipient."
+      - name: "last_name"
+        type: "string"
+        description: "The last name of the recipient."
+      - name: "line1"
+        type: "string"
+        description: "Line 1 of the address."
+      - name: "line2"
+        type: "string"
+        description: "Line 2 of the address."
+      - name: "line3"
+        type: "string"
+        description: "Line 3 of the address."
+      - name: "phone"
+        type: "string"
+        description: "The phone numger of the recipient."
+      - name: "state"
+        type: "string"
+        description: "The state."
+      - name: "state_code"
+        type: "string"
+        description: "The state code."
+      - name: "validation_status,"
+        type: "string"
+        description: |
+          The address verification status. Possible values are:
+          - `not_validated`
+          - `valid`
+          - `partially_valid`
+          - `invalid`
+      - name: "zip"
+        type: "string"
+        description: "The zip code."
+
+  - name: "shipping_cut_off_date"
+    type: "date-time"
+    description: "The time after an order becomes unservicable."
+
+  - name: "shipping_date"
+    type: "date-time"
+    description: "The date the order will be delivered."
+
+  - name: "status"
+    type: "string"
+    description: |
+      The status of the order. Possible values are:
+      - `new`
+      - `processing`
+      - `complete`
+      - `cancelled`
+
+  - name: "status_update_at"
+    type: "date-time"
+    description: "The time the order was last updated."
+
+  - name: "sub_total"
+    type: "integer"
+    description: "The order's subtotal."
+
+  - name: "subscription_id"
+    type: "string"
+    description: "The subscription ID linked to the order."
+    foreign-key-id: "subscription-id"
+
+  - name: "tax"
+    type: "integer"
+    description: "The total tax for the order."
+
+  - name: "total"
+    type: "integer"
+    description: "The amount charged for the order."
+
+  - name: "tracking_id"
+    type: "string"
+    description: "The tracking ID of the order."
+---

--- a/_integration-schemas/chargebee/plans.md
+++ b/_integration-schemas/chargebee/plans.md
@@ -27,6 +27,43 @@ attributes:
     replication-key: true
     description: "The time the plan was last updated."
 
+  - name: "account_code"
+    type: "string"
+    description: ""
+
+  - name: "accounting_category1"
+    type: "string"
+    description: ""
+
+  - name: "accounting_category2"
+    type: "string"
+    description: ""
+
+  - name: "addon_applicability"
+    type: "string"
+    description: ""
+
+  - name: "applicable_addons"
+    type: "array"
+    description: "IDs of the addons associated with the plan."
+    subattributes:
+      - name: "id"
+        type: "string"
+        description: "The ID of the addon."
+        foreign-key-id: "addon-id"
+
+  - name: "archived_at"
+    type: "date-time"
+    description: "The time the plan was archived."
+
+  - name: "avalara_service_type"
+    type: "integer"
+    description: ""
+
+  - name: "avalara_transaction_type"
+    type: "integer"
+    description: ""
+
   - name: "billing_cycles"
     type: "integer"
     description: "The number of billing cycles the subscription is active."
@@ -42,17 +79,62 @@ attributes:
       - `volume`
       - `stairstep`
 
+  - name: "claim_url"
+    type: "string"
+    description: ""
+
+  - name: "custom_fields"
+    type: "string"
+    description: "" 
+
   - name: "description"
     type: "string"
     description: "The description of the plan to show in hosted pages and the customer portal."
+
+  - name: "event_based_addons"
+    type: "array"
+    description: "IDs of the event-based addons associated with the plan."
+    subattributes:
+      - name: "id"
+        type: "string"
+        description: "The ID of the addon."
+        foreign-key-id: "addon-id"
+
+      - name: "quantity"
+        type: "integer"
+        description: "The addon quantity."
+
+      - name: "on_event"
+        type: string"
+        description: ""
+
+      - name: "charge_once"
+        type: "boolean"
+        description: ""
 
   - name: "free_quantity"
     type: "integer"
     description: "The free quantity the subscriptions of the plan will have. Only quantities more than this value will be charged for the subscription."
 
+  - name: "giftable"
+    type: "boolean"
+    description: ""
+
+  - name: "invoice_name"
+    type: "string"
+    description: ""
+
   - name: "invoice_notes"
     type: "string"
     description: "Invoice notes associated with the subscription."
+
+  - name: "is_shippable"
+    type: "boolean"
+    description: ""
+
+  - name: "meta_data"
+    type: "string"
+    description: ""
 
   - name: "name"
     type: "string"
@@ -87,13 +169,25 @@ attributes:
     type: "string"
     description: "The URL to redirect on successful checkout."
 
+  - name: "resource_version"
+    type: "integer"
+    description: ""
+
   - name: "setup_cost"
     type: "integer"
     description: "The one-time setup fee charged as part of the first invoice for the plan."
 
+  - name: "shipping_frequency_period"
+    type: "integer"
+    description: ""
+
+  - name: "shipping_frequency_period_unit"
+    type: "string"
+    description: ""
+
   - name: "sku"
     type: "string"
-    description: "Ssed as Product name/code in your third party accounting application. {{ integration.display_name }} will use it as an alternate name in your accounting application."
+    description: "Used as Product name/code in your third party accounting application. {{ integration.display_name }} will use it as an alternate name in your accounting application."
 
   - name: "status"
     type: "string"
@@ -110,6 +204,26 @@ attributes:
   - name: "taxable"
     type: "boolean"
     description: "Indicates if the plan is taxable or not."
+
+  - name: "tiers"
+    type: "array"
+    description: ""
+    subattributes:
+      - name: "starting_unit"
+        type: "integer"
+        description: ""
+
+      - name: "ending_unit"
+        type: "integer"
+        description: ""
+
+      - name: "price"
+        type: "integer"
+        description: ""
+
+  - name: ""
+    type: 
+    description: ""
 
   - name: "trial_period"
     type: "integer"
@@ -128,9 +242,5 @@ attributes:
       Possible values are:
 
       - `day`
-      - `month`
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
+      - `month`   
 ---

--- a/_integration-schemas/chargebee/promotional_credits.md
+++ b/_integration-schemas/chargebee/promotional_credits.md
@@ -1,0 +1,71 @@
+---
+tap: "chargebee"
+version: "1"
+key: "promotional-credit"
+
+name: "promotional_credits"
+doc-link: "https://apidocs.chargebee.com/docs/api/promotional_credits"
+singer-schema: "https://github.com/singer-io/tap-chargebee/blob/master/tap_chargebee/schemas/promotional_credits.json"
+description: |
+  The `{{ table.name }}` table contains info about the promotional_credits in your {{ integration.display_name }} account.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+    name: "List promotional credits"
+    doc-link: "https://apidocs.chargebee.com/docs/api/promotional_credits#list_promotional_credits"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The promotional credit ID."
+    # foreign-key-id: "promotional-credit-id"
+
+  - name: "created_at"
+    type: "date-time"
+    replication-key: true
+    description: "The date and time the promotional credit was created."
+
+  - name: "amount"
+    type: "string"
+    description: "The amount of the promotional credit."
+
+  - name: "closing_balance"
+    type: "integer"
+    description: "The closing balance on the end date."
+
+  - name: "credit_type"
+    type: "string"
+    description: |
+      The type of promotional credit provided to the customer. Possible values are:
+
+      - `loyalty_credits`
+      - `referral_rewards`
+      - `general`
+
+  - name: "currency_code"
+    type: "string"
+    description: "The currency code (ISO 4217 format) for promotional credit."
+
+  - name: "customer_id"
+    type: "string"
+    description: "The ID of the customer associated with the promotional credit."
+    foreign-key-id: "customer-id"
+
+  - name: "description"
+    type: "string"
+    description: "Description of the promotional credit."
+
+  - name: "done_by"
+    type: "string"
+    description: "The user who added/deducted the credit."
+
+  - name: "type"
+    type: "string"
+    description: |
+      The type of promotional credit. Possible values are:
+
+      - `increment`
+      - `decrement`
+---

--- a/_integration-schemas/chargebee/subscriptions.md
+++ b/_integration-schemas/chargebee/subscriptions.md
@@ -57,6 +57,10 @@ attributes:
         description: "The addon ID."
         foreign-key-id: "addon-id"
 
+      - name: "amount"
+        type: "integer"
+        description: ""
+
       - name: "object"
         type: "string"
         description: ""
@@ -182,6 +186,10 @@ attributes:
     type: "date-time"
     description: "The time the subscription was created."
 
+  - name: "created_from_ip"
+    type: "string"
+    description: ""
+
   - name: "currency_code"
     type: "string"
     description: "The currency code for the subscription in ISO 4217 format."
@@ -193,6 +201,10 @@ attributes:
   - name: "current_term_start"
     type: "date-time"
     description: "The start of the current billing term for the subscription."
+
+  - name: "custom_fields"
+    type: "string"
+    description: ""  
 
   - name: "customer_id"
     type: "string"
@@ -206,6 +218,10 @@ attributes:
   - name: "due_invoices_count"
     type: "integer"
     description: "The total number of invoices that are due for payment."
+
+  - name: "due_since"
+    type: "date-time"
+    description: ""
 
   - name: "event_based_addons"
     type: "array"
@@ -240,6 +256,11 @@ attributes:
     type: "number"
     description: "The exchange rate used for base currency conversion."
 
+  - name: "gift_id"
+    type: "string"
+    description: "The ID of the gift associated with the subscription."
+    foreign-key-id: "gift-id"
+
   - name: "has_scheduled_changes"
     type: "boolean"
     description: "If true, there are subscription changes scheduled on next renewal."
@@ -247,6 +268,10 @@ attributes:
   - name: "invoice_notes"
     type: "string"
     description: "The invoice notes for the subscription."
+
+  - name: "meta_data"
+    type: "string"
+    description: ""
 
   - name: "mrr"
     type: "integer"
@@ -258,6 +283,10 @@ attributes:
 
   - name: "object"
     type: "string"
+    description: ""
+
+  - name: "pause_date"
+    type: "date-time"
     description: ""
 
   - name: "payment_source_id"
@@ -362,6 +391,10 @@ attributes:
           - `custom_promotional_credit`
           - `custom_revenue_percent_based`
 
+      - name: "referral_system"
+        type: "string"
+        description: ""
+
       - name: "reward_status"
         type: "string"
         description: |
@@ -378,6 +411,14 @@ attributes:
   - name: "resource_version"
     type: "integer"
     description: "The version number of the subscription. Each update of the subscription results in an incremental change of this value. **Note**: This attribute will be present only if the resource has been updated after 2016-09-28."
+
+  - name: "resume_date"
+    type: "date-time"
+    description: ""
+
+  - name: "setup_fee"
+    type: "integer"
+    description: ""
 
   - name: "shipping_address"
     type: "object"
@@ -467,6 +508,10 @@ attributes:
       - `paused`
       - `cancelled`
 
+  - name: "total_dues"
+    type: "integer"
+    description: ""
+
   - name: "trial_end"
     type: "date-time"
     description: |
@@ -475,9 +520,5 @@ attributes:
   - name: "trial_start"
     type: "date-time"
     description: |
-      The start of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.
-
-  - name: "custom_fields"
-    type: "string"
-    description: ""    
+      The start of the trial period for the subscription. The presence of this value for future subscriptions (`status: future`) implies the subscription will move to `in_trial` when the subscription starts.  
 ---

--- a/_integration-schemas/chargebee/transactions.md
+++ b/_integration-schemas/chargebee/transactions.md
@@ -35,6 +35,14 @@ attributes:
     type: "integer"
     description: "**Applicable only for payments.** The unused amount present for the transaction."
 
+  - name: "amount_capturable"
+    type: "string"
+    description: ""
+
+  - name: "authorization_reason"
+    type: "string"
+    description: ""
+
   - name: "base_currency_code"
     type: "string"
     description: ""
@@ -217,6 +225,26 @@ attributes:
           - `timeout`
           - `needs_attention`
 
+  - name: "linked_payments"
+    type: "array"
+    description: "The list of payments the transaction has been applied to."
+    subattributes:
+      - name: "id"
+        type: "string"
+        description: ""
+
+      - name: "status"
+        type: "string"
+        description: ""
+
+      - name: "amount"
+        type: "integer"
+        description: ""
+
+      - name: "date"
+        type: "date-time"
+        description: ""
+
   - name: "masked_card_number"
     type: "string"
     description: "**Applicable only when `payment_method: card`.** The masked card number used for the transaction."
@@ -250,6 +278,10 @@ attributes:
     description: "The ID of the payment source used for the transaction."
     foreign-key-id: "payment-source-id"
 
+  - name: "reference_authorization_id"
+    type: "string"
+    description: ""
+
   - name: "reference_number"
     type: "string"
     description: "The reference number for the transaction."
@@ -267,6 +299,10 @@ attributes:
   - name: "resource_version"
     type: "integer"
     description: "The version number of the transaction. Each update of the transaction results in an incremental change of this value. **Note**: This attribute will be present only if the credit note has been updated after 2016-09-28."
+
+  - name: "reversal_transaction_id"
+    type: "integer"
+    description: ""
 
   - name: "reversal_txn_id"
     type: "string"
@@ -304,6 +340,10 @@ attributes:
       - `payment_reversal`
 
   - name: "validated_at"
+    type: "date-time"
+    description: ""
+
+  - name: "voided_at"
     type: "date-time"
     description: ""
 ---

--- a/_saas-integrations/chargebee/v1/chargebee-v1.md
+++ b/_saas-integrations/chargebee/v1/chargebee-v1.md
@@ -59,6 +59,7 @@ table-selection: true
 column-selection: true
 
 
+
 # -------------------------- #
 #      Feature Summary       #
 # -------------------------- #
@@ -70,6 +71,10 @@ feature-summary: |
 # -------------------------- #
 #      Setup Instructions    #
 # -------------------------- #
+
+requirement-items:
+- item: |
+    Your **Order Management** feature must be enabled before you can sync your `orders` table. Refer to the [{{ integration.display_name }} docs](https://www.chargebee.com/docs/orders.html) for more information.
 
 setup-steps:
   - title: "Generate an API Key"


### PR DESCRIPTION
This pull request updates the following:
-  added the `gifts` and `orders` tables
- updated the `subscriptions`, `addons`, `events`, `customers` and `plans` tables
- mentions in the `orders` table and setup instructions about the order management feature enablement