### PR TITLE
Github/v1 - Add releases table

### DIFF
--- a/_integration-schemas/github/foreign-keys.md
+++ b/_integration-schemas/github/foreign-keys.md
@@ -82,4 +82,11 @@ foreign-keys:
     all-foreign-keys:
       - table: "commits"
         join-on: "sha"
+
+  - id: "release-id"
+    attribute: "id"
+    table: "releases"
+    all-foreign-keys:
+      - table: "releases"
+        join-on: "id"   
 ---

--- a/_integration-schemas/github/releases.md
+++ b/_integration-schemas/github/releases.md
@@ -1,0 +1,77 @@
+---
+tap: "github"
+version: "1"
+
+name: "releases"
+doc-link: "https://developer.github.com/v3/repos/releases/"
+singer-schema: "https://github.com/singer-io/tap-github/blob/master/tap_github/schemas/releases.json"
+description: "The releases table returns a list of releases. This does not include regular Git release tag data. This enpoint will only return actual releases."
+
+replication-method: "Full Table"
+
+api-method:
+    name: "listReleases"
+    doc-link: "https://developer.github.com/v3/repos/releases/#list-releases"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The release ID."
+    foreign-key-id: "release-id"
+
+  - name: "_sdc_repository"
+    type: "string"
+    description: ""
+
+  - name: "author"
+    type: "object"
+    description: "Details about the author of the release."
+    subattributes:
+      - name: "id"
+        type: "integer"
+        description: "The user ID of the author."
+      - name: "login"
+        type: "string"
+        description: "The username of the author."
+
+  - name: "body"
+    type: "string"
+    description: "The text describing the tag."
+
+  - name: "created_at"
+    type: "date-time"
+    description: "The date the release was created."
+
+  - name: "draft"
+    type: "boolean"
+    description: "`TRUE` if the release is a draft release."
+
+  - name: "html_url"
+    type: "string"
+    description: "The HTML URL to the release." 
+
+  - name: "name"
+    type: "string"
+    description: "The name of the release."
+
+  - name: "prerelease"
+    type: "boolean"
+    description: "`TRUE` the release is a prerelease."
+
+  - name: "published_at"
+    type: "date-time"
+    description: "The date the release was published."
+
+  - name: "tag_name"
+    type: "string"
+    description: "The name of the tag."
+
+  - name: "target_commitish"
+    type: "string"
+    description: "The commitish value that determines where the Git tag was created."
+
+  - name: "url"
+    type: "string"
+    description: "The URL to the release."
+---

--- a/_integration-schemas/github/releases.md
+++ b/_integration-schemas/github/releases.md
@@ -5,7 +5,8 @@ version: "1"
 name: "releases"
 doc-link: "https://developer.github.com/v3/repos/releases/"
 singer-schema: "https://github.com/singer-io/tap-github/blob/master/tap_github/schemas/releases.json"
-description: "The releases table returns a list of releases. This does not include regular Git release tag data. This enpoint will only return actual releases."
+description: |
+  The `{{ table.name }}` table contains a list of releases. **Note**: {{ integration.display_name }} doesn't include regular Git tags that haven't been associated with a release.
 
 replication-method: "Full Table"
 
@@ -18,7 +19,7 @@ attributes:
     type: "string"
     primary-key: true
     description: "The release ID."
-    foreign-key-id: "release-id"
+    # foreign-key-id: "release-id"
 
   - name: "_sdc_repository"
     type: "string"
@@ -31,6 +32,7 @@ attributes:
       - name: "id"
         type: "integer"
         description: "The user ID of the author."
+
       - name: "login"
         type: "string"
         description: "The username of the author."
@@ -45,7 +47,7 @@ attributes:
 
   - name: "draft"
     type: "boolean"
-    description: "`TRUE` if the release is a draft release."
+    description: "If `TRUE`, the release is a draft release."
 
   - name: "html_url"
     type: "string"
@@ -57,7 +59,7 @@ attributes:
 
   - name: "prerelease"
     type: "boolean"
-    description: "`TRUE` the release is a prerelease."
+    description: "If `TRUE`, the release is a pre-release."
 
   - name: "published_at"
     type: "date-time"


### PR DESCRIPTION
This PR adds the `releases` table and updates the foreign keys.