### PR TITLE
Move multiple integrations to GA

### DIFF
--- a/_data/taps/versions/3plcentral.yml
+++ b/_data/taps/versions/3plcentral.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "December 20, 2019"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/darksky.yml
+++ b/_data/taps/versions/darksky.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "January 3, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/dynamodb.yml
+++ b/_data/taps/versions/dynamodb.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "January 6, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/linkedin-ads.yml
+++ b/_data/taps/versions/linkedin-ads.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
+    status: "released"
+    #full-release: "April 2, 2020"
     date-released: "February 19, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/recharge.yml
+++ b/_data/taps/versions/recharge.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "January 27, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/saasoptics.yml
+++ b/_data/taps/versions/saasoptics.yml
@@ -15,7 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "March 4, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/shiphero.yml
+++ b/_data/taps/versions/shiphero.yml
@@ -6,7 +6,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
+    status: "released"
+    # full-release: "April 2, 2020"
     date-released: "March 8, 2019"
     # date-last-connection:
     deprecation-date: ""


### PR DESCRIPTION
This PR moves the following integrations from `beta` to `released`:

- 3PL Central
- Darksky
- Amazon DynamoDB
- ReCharge
- SaaSOptics
- Shiphero
