### PR TITLE
Mixpanel start date limitations

### DIFF
--- a/_integration-schemas/shopify/collects.md
+++ b/_integration-schemas/shopify/collects.md
@@ -2,8 +2,8 @@
 tap: "shopify"
 version: "1"
 
-name: "collects"https://shopify.dev/docs/admin-api/rest/reference/products/collect?api[version]=2019-07"
-singer-schema: "https://github.com/singer-io/tap-shopify/blob/master/tap_shopify/schemas/collects.json
+name: "collects"
+singer-schema: "https://github.com/singer-io/tap-shopify/blob/master/tap_shopify/schemas/collects.json"
 doc-link: ""
 description: |
   The `{{ table.name }}` table contains info about collects, which are used to manage relationships between products and custom collections. For every product in a custom collection, there's a collect that tracks the ID of both the product and the custom collection.

--- a/_saas-integrations/mixpanel/mixpanel-latest.md
+++ b/_saas-integrations/mixpanel/mixpanel-latest.md
@@ -156,7 +156,7 @@ setup-steps:
   - title: "Define the historical sync"
     content: |
       {% include integrations/saas/setup/historical-sync.html %}
-      When selecting a start date, do not exceed 365 days prior to today's date. If the start date exceeds 365 days the {{ integration.display_name }} API will return errors and block extraction.
+      When selecting a start date earlier than the default number of days in the integration, refer to your {{ integration.display_name }} account's pricing plan to determine how many days of historical data is allocated. If you enter a number of days greater that what your account has, the {{ integration.display_name }} API will return errors and block extraction.
   - title: "replication frequency"
   - title: "track data"
 

--- a/_saas-integrations/mixpanel/mixpanel-latest.md
+++ b/_saas-integrations/mixpanel/mixpanel-latest.md
@@ -153,7 +153,10 @@ setup-steps:
   - title: "add integration"
     content: |
       4. Paste your API credentials in the the **API Key** and **Secret** fields, respectively.
-  - title: "historical sync"
+  - title: "Define the historical sync"
+    content: |
+      {% include integrations/saas/setup/historical-sync.html %}
+      When selecting a start date, do not exceed 365 days prior to today's date. If the start date exceeds 365 days the {{ integration.display_name }} API will return errors and block extraction.
   - title: "replication frequency"
   - title: "track data"
 

--- a/_saas-integrations/mixpanel/mixpanel-latest.md
+++ b/_saas-integrations/mixpanel/mixpanel-latest.md
@@ -156,7 +156,12 @@ setup-steps:
   - title: "Define the historical sync"
     content: |
       {% include integrations/saas/setup/historical-sync.html %}
-      When selecting a start date earlier than the default number of days in the integration, refer to your {{ integration.display_name }} account's pricing plan to determine how many days of historical data is allocated. If you enter a number of days greater that what your account has, the {{ integration.display_name }} API will return errors and block extraction.
+      
+      **Note**: {{ integration.display_name }} limits the number of days historical data may be accessed, depending on your {{ integration.display_name }} plan. If you select a Start Date greater than what your {{ integration.display_name }} account has access to, the {{ integration.display_name }} API will return an error and prevent Stitch from extracting data.
+      
+      For example: If you have a Starter Free {{ integration.display_name }} plan, you have access to 90 days of historical data (as of 04/28/2020). If you select a Start Date greater than 90 days, {{ integration.display_name }}'s API will prevent Stitch from extracting your data.
+      
+      Refer to [{{ integration.display_name }}'s documentation](https://help.mixpanel.com/hc/en-us/articles/115004511246){:target="new"} for more info and to check your {{ integration.display_name }} account's historical data access limit.
   - title: "replication frequency"
   - title: "track data"
 


### PR DESCRIPTION
This update notes not to exceed 365 days for a start date selection.