### PR TITLE
Update pardot version for ga

### DIFF
--- a/_data/taps/versions/pardot.yml
+++ b/_data/taps/versions/pardot.yml
@@ -6,7 +6,7 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
+    status: "released" ## beta, released, deprecated
     date-released: "February 12, 2020"
     # date-last-connection:
     deprecation-date: ""

--- a/_data/taps/versions/pardot.yml
+++ b/_data/taps/versions/pardot.yml
@@ -13,8 +13,8 @@ released-versions:
     sunset-date: ""
   
   - number: "15-10-2015"
-    status: "released" ## beta, released, deprecated
+    status: "deprecated" ## beta, released, deprecated
     date-released: "October 15, 2015"
     # date-last-connection:
-    deprecation-date: ""
-    sunset-date: ""
+    deprecation-date: "05/01/2020"
+    sunset-date: "07/30/2020"

--- a/_data/taps/versions/pardot.yml
+++ b/_data/taps/versions/pardot.yml
@@ -16,5 +16,5 @@ released-versions:
     status: "deprecated" ## beta, released, deprecated
     date-released: "October 15, 2015"
     # date-last-connection:
-    deprecation-date: "05/01/2020"
-    sunset-date: "07/30/2020"
+    deprecation-date: "May 1, 2020"
+    sunset-date: "July 30, 2020"


### PR DESCRIPTION
Updates the release status of platform.pardot and adds deprecation / sunset dates to v 15-10-2015