### PR TITLE
Google Sheets - Empty worksheets and header row

### DIFF
--- a/_data/errors/extraction/databases/mssql.yml
+++ b/_data/errors/extraction/databases/mssql.yml
@@ -23,7 +23,7 @@ all:
     cause: |
       Change Tracking is not enabled for the named database, which contains tables that are set to replicate and use Log-based Incremental Replication in Stitch.
     fix-it: |
-      Enabled Change Tracking for the database referenced in the error message. To use Change Tracking, you must enabled it both at the database and table level.
+      Enable Change Tracking for the database referenced in the error message. To use Change Tracking, you must enabled it both at the database and table level.
 
       To enable Change Tracking for the database, log into your database and run the following statement, replacing `<database_name>` with the name of the database:
 

--- a/_data/errors/extraction/saas/google-sheets.yml
+++ b/_data/errors/extraction/saas/google-sheets.yml
@@ -1,0 +1,39 @@
+# -------------------------- #
+#    Google Sheets Errors    #
+# -------------------------- #
+
+## This file contains extraction errors and how to (potentially)
+## fix them for the Google Sheets integration.
+
+## An object containing raw error messages
+raw-error:
+  malformed-sheet: &malformed-sheet "SKIPPING Malformed sheet: [sheet_name]"
+  empty-sheet: &empty-sheet "SKIPPING Empty sheet: [sheet_name]"
+  
+
+all:
+  - message: *malformed-sheet
+    id: "malformed-sheet"
+    applicable-to: &google-sheets-v1 "Google Sheets v1 integrations"
+    level: "info"
+    category: "Sheet setup"
+    version: "1" 
+    summary: "Malformed sheet"
+    cause: |
+      The sheet isn't formatted according to [Stitch's requirements]({{ site.baseurl }}/integrations/saas/google-sheets#setup-requirements).
+    fix-it: |
+      Verify that the sheet meet's Stitch's requirements and modify if necessary.
+
+  - message: *empty-sheet
+    id: "empty-sheet"
+    applicable-to: &google-sheets-v1 "Google Sheets v1 integrations"
+    level: "info"
+    category: "Sheet setup"
+    version: "1" 
+    summary: "Empty sheet"
+    cause: |
+      The sheet doesn't have a header row and a data row, as per [Stitch's requirements]({{ site.baseurl }}/integrations/saas/google-sheets#setup-requirements).
+    fix-it: |
+      Modify the sheet so that it contains a header row in the first row and a full row of data in the second row.
+
+      **Note**: Columns in the data row (second row) must all have non-`NULL` values. If a column in this row has a `NULL` value, a [malformed sheet error](#malformed-sheet) will surface during Extraction.

--- a/_data/taps/extraction/replication-methods/key-based-incremental.yml
+++ b/_data/taps/extraction/replication-methods/key-based-incremental.yml
@@ -107,15 +107,18 @@ hard-deletes:
 database-file-integrations:
   - item: "What's replicated during a replication job?"
     other-integrations: "Only new or updated rows in a table."
-    this-integration: "The entire contents of a modified file."
+    this-integration: |
+      The entire contents of a modified {{ file-name | default: "file" }}. {{ file-note | flatify }}
 
   - item: "What's used as a Replication Key?"
     other-integrations: "A column or columns in a table."
-    this-integration: "The time a file is modified."
+    this-integration: |
+      The time a {{ file-name | default: "file" }} is modified.
 
   - item: "Are Replication Keys inclusive?"
     other-integrations: "**Yes**. Rows with a Replication Key value **greater than or equal to** the last saved bookmark are replicated."
-    this-integration: "**No**. Only files with a modification timestamp value greater than the last saved bookmark are replicated."
+    this-integration: |
+      **No**. Only {{ file-name | default: "file" | append: "s" }} with a modification timestamp value greater than the last saved bookmark are replicated.
 
 
 

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -331,10 +331,15 @@ troubleshooting:
   dw-loading-errors: /troubleshooting/destinations/destination-loading-error-reference
   view-dependency-errors: /troubleshooting/destinations/redshift-dependent-view-errors
   aws-io-errors: /troubleshooting/destinations/aws-io-errors
+  
+## Database extraction Errors
   mysql-extraction-errors: "{{ link.troubleshooting.database-extraction-errors }}#mysql-error-reference"
   mongodb-extraction-errors: "{{ link.troubleshooting.database-extraction-errors }}#mongodb-error-reference"
   oracle-extraction-errors: "{{ link.troubleshooting.database-extraction-errors }}#oracle-error-reference"
   mssql-extraction-errors: "{{ link.troubleshooting.database-extraction-errors }}#microsoft-sql-server-error-reference-error-reference"
+
+## SaaS extraction errors
+  google-sheets-extraction-errors: /troubleshooting/integrations/google-sheets-extraction-error-reference
 
 ## Connection Errors
   saas-connection-errors: /troubleshooting/integrations/saas-integration-connection-errors

--- a/_includes/replication/extraction/file-modification-replication-keys.html
+++ b/_includes/replication/extraction/file-modification-replication-keys.html
@@ -1,6 +1,6 @@
 <!-- This file includes content that describes how key-based incremental
     replication works for integrations that are file system-based.
-    An example is Amazon S3 CSV, or Heap (which is based on S3). -->
+    An example is Amazon S3 CSV, Google Sheets, or Heap (which is based on S3). -->
 
 While data from {{ integration.display_name }} integrations is replicated using [Key-based Incremental Replication]({{ link.replication.key-based-incremental | prepend: site.baseurl }}), the behavior for this integration differs subtly from other integrations.
 
@@ -24,11 +24,11 @@ The table below compares Key-based Incremental Replication and [Replication Key]
 			<td align="right" width="30%; fixed">
 				<strong>{{ comparison.item | flatify }}</strong>
 			</td>
-			<td>
-				{{ comparison.this-integration | markdownify }}
+			<td width="35%; fixed">
+				{{ comparison.this-integration | flatify | markdownify }}
 			</td>
 			<td>
-				{{ comparison.other-integrations | markdownify }}
+				{{ comparison.other-integrations | flatify | markdownify }}
 			</td>
 		</tr>
 	{% endfor %}

--- a/_integration-schemas/google-sheets/file_metadata.md
+++ b/_integration-schemas/google-sheets/file_metadata.md
@@ -1,18 +1,19 @@
 ---
 tap: "google-sheets"
 version: "1"
-key: "file_metadata"
+key: "file-metadata"
 
 name: "file_metadata"
 doc-link: "https://developers.google.com/sheets/api/reference/rest"
 singer-schema: "https://github.com/singer-io/tap-google-sheets/blob/master/tap_google_sheets/schemas/file_metadata.json"
-description: "This table contains metadata about the spreadsheet file."
+description: |
+  The `{{ table.name }}` table contains metadata about the spreadsheet defined in the integration's settings.
 
 replication-method: "Key-based Incremental"
 
 api-method:
-    name: "getSheets"
-    doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
+  name: "getSheets"
+  doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
 
 attributes:
   - name: "id"
@@ -23,16 +24,16 @@ attributes:
 
   - name: "modifiedTime"
     type: "date-time"
+    replication-key: true
     description: "The date and time the file was last modified."
-    replication-key: true  
 
   - name: "createdTime"
     type: "date-time"
-    description: "The date the spreadsheet was created."
+    description: "The date the file was created."
 
   - name: "driveId"
     type: "string"
-    description: "The drive ID."
+    description: "The ID of the drive containing the file."
 
   - name: "lastModifyingUser"
     type: "object"
@@ -41,9 +42,11 @@ attributes:
       - name: "displayName"
         type: "string"
         description: "The user's display name."
+
       - name: "emailAdress"
         type: "string"
         description: "The user's email address."
+
       - name: "kind"
         type: "string"
         description: "The type of user."

--- a/_integration-schemas/google-sheets/foreign-keys.md
+++ b/_integration-schemas/google-sheets/foreign-keys.md
@@ -28,8 +28,9 @@ foreign-keys:
       - table: "sheet_metadata"
         join-on: "spreadsheetId"
       - table: "sheets_loaded"
-        join-on: "spreadsheetId"  
-
+        join-on: "spreadsheetId"
+      - table: "sample_table"
+        join-on: "__sdc_spreadsheet_id"
 
   - id: "sheet-id"
     table: "sheet_metadata"
@@ -39,13 +40,6 @@ foreign-keys:
         join-on: "sheetId"
       - table: "sheets_loaded"
         join-on: "sheetId"
-
-
-  - id: "column-index"
-    table: "sheet_metadata"
-    attribute: "columns.column-index"
-    all-foreign-keys:
-      - table: "sheet_metadata"
-        join-on: "columns.column-index"
-
+      - table: "sample_table"
+        join-on: "__sdc_sheet_id"
 ---

--- a/_integration-schemas/google-sheets/sample-table.md
+++ b/_integration-schemas/google-sheets/sample-table.md
@@ -1,0 +1,44 @@
+---
+tap: "google-sheets"
+version: "1"
+key: "sample-table"
+
+name: "sample_table"
+doc-link: "https://developers.google.com/sheets/api/reference/rest"
+singer-schema: ""
+description: |
+  This is an example of a table created from a sheet you set to replicate.
+
+  For every sheet you set to replicate, Stitch will create a corresponding table in your destination. The table will contain the columns you select in Stitch, along with a few columns Stitch requires for replication.
+  
+  Refer to the [Data replication](#extraction--data-replication) section for more info about how this table replicates.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: "getSheets"
+  doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
+
+attributes:
+  - name: "__sdc_row"
+    type: "integer"
+    primary-key: true
+    description: |
+      The number of the row in the spreadsheet.
+#   foreign-key-id: "file-id"
+
+  - name: "__sdc_sheet_id"
+    type: "integer"
+    description: "The ID of the sheet containing the record."
+    foreign-key-id: "sheet-id"
+
+  - name: "__sdc_spreadsheet_id"
+    type: "string"
+    description: "The ID of the spreadsheet containing the record."
+    foreign-key-id: "spreadsheet-id"
+
+  - name: "[COLUMNS_YOU_SELECT]"
+    type: "varies"
+    description: |
+      A column will be created for every column set to replicate in Stitch.
+---

--- a/_integration-schemas/google-sheets/sample-table.md
+++ b/_integration-schemas/google-sheets/sample-table.md
@@ -15,6 +15,9 @@ description: |
 
 replication-method: "Key-based Incremental"
 
+replication-key:
+  name: "Spreadsheet's modified_at"
+
 api-method:
   name: "getSheets"
   doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"

--- a/_integration-schemas/google-sheets/sheet_metadata.md
+++ b/_integration-schemas/google-sheets/sheet_metadata.md
@@ -1,12 +1,13 @@
 ---
 tap: "google-sheets"
 version: "1"
-key: "sheet_metadata"
+key: "sheet-metadata"
 
 name: "sheet_metadata"
 doc-link: "https://developers.google.com/sheets/api/reference/rest"
 singer-schema: "https://github.com/singer-io/tap-google-sheets/blob/master/tap_google_sheets/schemas/sheet_metadata.json"
-description: "This table contains metadata about the sheets within a spreadsheet."
+description: |
+  The `{{ table.name }}` table contains metadata about the sheets within the spreadsheet defined in the integration's settings.
 
 replication-method: "Full Table"
 
@@ -15,34 +16,6 @@ api-method:
     doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
 
 attributes:
-  - name: "columns"
-    type: "object"
-    description: ""
-    subattributes:
-      - name: "columnIndex"
-        type: "integer"
-        primary-key: true
-        description: "The column index in the data table on which the filter is applied to."
-        foreign-key-id: "column-index"
-      - name: "columnLetter"
-        type: "string"
-        description: "The letter of the column."
-      - name: "columnName"
-        type: "string"
-        description: "The header name in the column."
-      - name: "columnType"
-        type: "string"
-        description: "The type of column"
-      - name: "columnSkipped"
-        type: "boolean"
-        description: "Field that identifies if the column has been skipped."
-      - name: "type"
-        type: "string"
-        description: ""
-      - name: "format"
-        type: "string"
-        description: ""  
-
   - name: "sheetId"
     type: "integer"
     primary-key: true
@@ -52,8 +25,40 @@ attributes:
   - name: "spreadsheetId"
     type: "string"
     primary-key: true
-    description: "The ID of the spreadsheet." 
-    foreign-key-id: "spreadsheet-id" 
+    description: "The ID of the spreadsheet containing the sheet." 
+    foreign-key-id: "spreadsheet-id"
+
+  - name: "columns"
+    type: "object"
+    description: "Details about the columns in the sheet."
+    subattributes:
+      - name: "columnIndex"
+        type: "integer"
+        description: "The column index in the data table on which the filter is applied to."
+
+      - name: "columnLetter"
+        type: "string"
+        description: "The letter of the column."
+
+      - name: "columnName"
+        type: "string"
+        description: "The header name in the column."
+
+      - name: "columnType"
+        type: "string"
+        description: "The type of column."
+
+      - name: "columnSkipped"
+        type: "boolean"
+        description: "Field that identifies if the column has been skipped."
+
+      - name: "type"
+        type: "string"
+        description: ""
+
+      - name: "format"
+        type: "string"
+        description: ""   
 
   - name: "gridProperties"
     type: "object"
@@ -62,12 +67,15 @@ attributes:
       - name: "columnCount"
         type: "integer"
         description: "The number of columns in the grid."
+
       - name: "frozenColumnCount"
         type: "integer"
         description: "The number of columns that are frozen in the grid."
+
       - name: "frozenRowCount"
         type: "integer"
         description: "The number of rows that are frozen in the grid."
+
       - name: "rowCount"
         type: "integer"
         description: "The number of rows in the grid."
@@ -78,11 +86,16 @@ attributes:
 
   - name: "sheetType"
     type: "string"
-    description: "The type of sheet. It can be be following values: `sheet_type_unspecified`, `object`, `grid`."
+    description: |
+      The type of the sheet. Possible values are:
+
+      - `sheet_type_unspecified`
+      - `object`
+      - `grid`
 
   - name: "sheetUrl"
     type: "string"
-    description: "The url of the sheet."
+    description: "The URL of the sheet."
 
   - name: "title"
     type: "string"

--- a/_integration-schemas/google-sheets/sheets_loaded.md
+++ b/_integration-schemas/google-sheets/sheets_loaded.md
@@ -1,12 +1,13 @@
 ---
 tap: "google-sheets"
 version: "1"
-key: "sheets_loaded"
+key: "sheets-loaded"
 
 name: "sheets_loaded"
 doc-link: "https://developers.google.com/sheets/api/reference/rest"
 singer-schema: "https://github.com/singer-io/tap-google-sheets/blob/master/tap_google_sheets/schemas/sheets_loaded.json"
-description: "This table contains table contains information about the individual sheets loaded."
+description: |
+  The `{{ table.name }}` table contains metadata about individual sheets loaded to your destination.
 
 replication-method: "Full Table"
 

--- a/_integration-schemas/google-sheets/spreadsheet_metadata.md
+++ b/_integration-schemas/google-sheets/spreadsheet_metadata.md
@@ -6,13 +6,14 @@ key: "spreadsheet_metadata"
 name: "spreadsheet_metadata"
 doc-link: "https://developers.google.com/sheets/api/reference/rest"
 singer-schema: "https://github.com/singer-io/tap-google-sheets/blob/master/tap_google_sheets/schemas/spreadsheet_metadata.json"
-description: "This table contains metadata about the spreadsheet."
+description: |
+  The `{{ table.name }}` table contains metadata about the spreadsheet defined in the integration's settings.
 
 replication-method: "Full Table"
 
 api-method:
-    name: "getSheets"
-    doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
+  name: "getSheets"
+  doc-link: "https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/sheets#top_of_page"
 
 attributes:
   - name: "spreadsheetId"
@@ -28,6 +29,7 @@ attributes:
       - name: "autoRecalc"
         type: "string"
         description: "The amount of time to wait before volatile functions are recalculated."
+        
       - name: "locale"
         type: "string"
         description: |
@@ -35,9 +37,11 @@ attributes:
             - an ISO 639-1 language code such as `en`
             - an ISO 639-2 language code such as `fil`, if no 639-1 code exists
             - a combination of the ISO language code and country code, such as `en_US`
+
       - name: "timeZone"
         type: "string"
         description: "The time zone of the spreadsheet, in CLDR format such as `America/New_York`. If the time zone isn't recognized, this may be a custom time zone such as `GMT-07:00`."
+
       - name: "title"
         type: "string"
         description: "The title of the spreadsheet."

--- a/_saas-integrations/google-sheets/v1/google-sheets-v1.md
+++ b/_saas-integrations/google-sheets/v1/google-sheets-v1.md
@@ -98,6 +98,10 @@ feature-summary: |
 #      Setup Instructions    #
 # -------------------------- #
 
+requirements-list:
+  - item: |
+      **One header row** in your worksheets. If there are multiple headers, that are not in the first row, you run the risk of your worksheet data not being replicated correctly. Headers that are not in the first row may be counted as column data.
+      
 setup-steps:
   - title: "Obtain your Spreadsheet ID"
     anchor: "obtain-spreadsheet-id"
@@ -130,6 +134,11 @@ replication sections:
       Stitch's {{ integration.display_name }} integration will output tables containing metadata about your spreadsheet, as well as replications of your individual sheets. For each sheet, the integration will output the schema of its resources, based on the column headers and datatypes in row two. It will also output a record for all columns that have columns headers and for each row of data.
 
       The primary key in each row of a sheet is the row number. The field for the primary key is `__sdc_row`. The foreign keys included in the sheet are connected to the **Spreadsheet Metadata**, `__sdc_spreadsheet_id`, and the **Sheet Metadata**, `__sdc_sheet_id`.
+
+  - title: "Empty Worksheets"
+    anchor: "empty-worksheets"
+    content: |
+      In discovery and sync mode of your Stitch {{ integration.display_name }} integration, Stitch will check the worksheets' header and first data row (the second row) for data. If there is no data in either of those rows, Stitch will skip that worksheet for replication.
 
 
 

--- a/_saas-integrations/google-sheets/v1/google-sheets-v1.md
+++ b/_saas-integrations/google-sheets/v1/google-sheets-v1.md
@@ -100,10 +100,10 @@ feature-summary: |
 
 requirements-list:
   - item: |
-      **One header row** in your worksheets. If there are multiple headers, that are not in the first row, you run the risk of your worksheet data not being replicated correctly. Headers that are not in the first row may be counted as column data.
+      **One header row** in your worksheets. If there are multiple headers that are not in the first row, your worksheet data may not be replicated correctly. Headers that aren't in the first row may be extracted as column data.
       
 setup-steps:
-  - title: "Obtain your Spreadsheet ID"
+  - title: "Obtain your spreadsheet ID"
     anchor: "obtain-spreadsheet-id"
     content: |
       1. Go to [{{ integration.display_name }}](http://sheets.google.com){:target="new"} and log into the Google account associated with the spreadsheet you are looking to integrate.
@@ -122,7 +122,7 @@ setup-steps:
 #     Replication Details    #
 # -------------------------- #
 
-replication sections:  
+replication-sections:  
   - title: "Spreadsheet Setup"
     anchor: "spreadsheet-setup"
     content: |

--- a/_troubleshooting/errors/extraction-errors/saas/google-sheets-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/saas/google-sheets-extraction-errors.md
@@ -1,0 +1,23 @@
+---
+title: Google Sheets Extraction Error Reference
+keywords: troubleshooting, integration, extraction error
+layout: general
+
+permalink: /troubleshooting/integrations/google-sheets-extraction-error-reference
+
+summary: "Extraction errors for Google Sheets integrations and how to resolve them."
+
+level: "guide"
+top-level: "replication"
+# category: "extraction-errors"
+type: "saas-integration, error, replication"
+
+sections:
+  - content: |
+      These errors will surface in the Google Sheets integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
+
+      {% assign errors = site.data.errors.extraction.saas.google-sheets.all | sort_natural:"message" %}
+
+      {% include troubleshooting/error-messages.html display-name="Google Sheets" %}
+---
+{% include misc/data-files.html %}


### PR DESCRIPTION
This update includes:
- adding a section to the the replication notes mentioning the "skip worksheet" logic
- adds having a header row as a requirement