### PR TITLE
Zendesk/v1 - Add users_fields to users table

### DIFF
--- a/_integration-schemas/zendesk/users.md
+++ b/_integration-schemas/zendesk/users.md
@@ -279,11 +279,11 @@ attributes:
 
   - name: "user_fields"
     type: "object"
-    description: "The values of custom fields in the user's record. These custom fields originate from the `user_fields` table in {{ integration.display_name }}."
+    description: "The values of custom fields in the user's record. A column will be created for every custom field with at least one non-null value."
     subattributes:
       - name: "CUSTOM_FIELD_NAME"
-        type: "varied"
-        description: "The custom field description."
+        type: "varies"
+        description: "The custom field. The name and data type of the custom field depend on the name and data type of the field in {{ integration.display_name }}."
 
   - name: "verified"
     type: "boolean"

--- a/_integration-schemas/zendesk/users.md
+++ b/_integration-schemas/zendesk/users.md
@@ -277,13 +277,13 @@ attributes:
     type: "string"
     description: "The API URL associated with the user."
 
-  # - name: "user_fields"
-  #   type: "object"
-  #   description: "The values of custom fields in the user's record."
-  #   subattributes:
-  #     - name: "[TODO]"
-  #       type: 
-  #       description: 
+  - name: "user_fields"
+    type: "object"
+    description: "The values of custom fields in the user's record. These custom fields originate from the `user_fields` table in {{ integration.display_name }}."
+    subattributes:
+      - name: "CUSTOM_FIELD_NAME"
+        type: "varied"
+        description: "The custom field description."
 
   - name: "verified"
     type: "boolean"


### PR DESCRIPTION
This PR adds the `user_fields` attribute to the `users` table.