### PR TITLE
MongoDB - replica set names

### DIFF
--- a/_data/ui/database-integration-settings/mongo.yml
+++ b/_data/ui/database-integration-settings/mongo.yml
@@ -73,11 +73,11 @@ mongodb:
     name: "Replica Set"
     version: "1, 2"
     copy: |
-      **Optional.** The name of the replica set to be used for Log-based Incremental Replication. To return the replica set name in {{ integration.display_name }}, use the command `rs.status()`. It will return your replica set name under the key "set":
+      **Optional.** The name of the replica set you created in [Step 3.1](##create-replica-set) to be used for Log-based Incremental Replication. If needed, you can return the replica set name using the `rs.status()` command. The replica set name will be returned under key `set`:
    
-           ```shell
-           "set" : "Name of your replica set",
-           ...
+            ```shell
+            "set" : "Name of your replica set",
+            ...
             ```
 
   - &schema-name
@@ -104,11 +104,11 @@ mongodb-atlas:
   - *password
   - *database
   - name: "Authentication Database"
-    version: "1"
+    version: "1,2"
     copy: |
       This must be `admin`. This is the name of the Stitch user's [authentication database](https://docs.mongodb.com/v3.4/core/security-users/#user-authentication-database){:target="new"}. This is the name of the database where the [Stitch database user was initially created](#create-database-user).
   - name: "Replica Set"
-    version: "2"
+    version: "1,2"
     copy: |
       **Optional.** The name of the replica set you retrieved in the previous step ([3.1](#locate-database-connection-details)) to be used for Log-based Incremental Replication.
   - *schema-name

--- a/_data/ui/database-integration-settings/mongo.yml
+++ b/_data/ui/database-integration-settings/mongo.yml
@@ -73,7 +73,12 @@ mongodb:
     name: "Replica Set"
     version: "1, 2"
     copy: |
-      **Optional.** The name of the replica set to be used for Log-based Incremental Replication.
+      **Optional.** The name of the replica set to be used for Log-based Incremental Replication. To return the replica set name in {{ integration.display_name }}, use the command `rs.status()`. It will return your replica set name under the key "set":
+   
+           ```shell
+           "set" : "Name of your replica set",
+           ...
+            ```
 
   - &schema-name
     name: *schema-names-tables-name
@@ -103,7 +108,7 @@ mongodb-atlas:
     copy: |
       This must be `admin`. This is the name of the Stitch user's [authentication database](https://docs.mongodb.com/v3.4/core/security-users/#user-authentication-database){:target="new"}. This is the name of the database where the [Stitch database user was initially created](#create-database-user).
   - name: "Replica Set"
-    version: "1"
+    version: "2"
     copy: |
       **Optional.** The name of the replica set you retrieved in the previous step ([3.1](#locate-database-connection-details)) to be used for Log-based Incremental Replication.
   - *schema-name

--- a/_includes/integrations/databases/setup/binlog/mongodb-oplog.html
+++ b/_includes/integrations/databases/setup/binlog/mongodb-oplog.html
@@ -24,12 +24,16 @@ In this step, you'll edit the `/etc/mongod.conf` file to add a [replica set]({{ 
 
 3. Navigate to the `/etc/mongod.conf` file.
 
-4. In `/etc/mongod.conf`, uncomment `replication` and specify a name for the replica set (`replSetName`). In this example, we're using `rs0` as the replica set name:
+4. In `/etc/mongod.conf`, uncomment `replication` and specify a name for the replica set (`replSetName`). 
+
+   In this example, we're using `rs0` as the replica set name:
 
    ```shell
    replication:
       replSetName: "rs0"
 	 ```
+
+    Use the `rs.status()` command to return this replica set's name going forward.
 
 	 **Note**: As `/etc/mongod.conf` is a protected file, you may need to assume `sudo` to edit it.
 


### PR DESCRIPTION
This PR adds info about using `rs.status()` to return replica set names for MongoDB integrations.