### PR TITLE
DynamoDB/v1 - Remove quotes from projection expressions

### DIFF
--- a/_data/errors/extraction/databases/dynamodb.yml
+++ b/_data/errors/extraction/databases/dynamodb.yml
@@ -1,0 +1,26 @@
+# ----------------------------- #
+#   DynamoDB Extraction Errors  #
+# ----------------------------- #
+
+## This file contains the extraction errors that can arise 
+## while replicating data from a DynamoDB-backed database.
+
+raw-error:
+  quote-projection-expression-error: &quote-projection-expression-error |
+    An error occurred (ValidationException) when calling the Scan operation: Invalid ProjectionExpression: Syntax error; token: """, near: ""[FIELD_NAME]" 
+
+all:
+# Change tracking not enabled for database
+  - message: *quote-projection-expression-error
+    id: "quote-projection-expression-error"
+    applicable-to: &all-dynamodb "Amazon DynamoDB v1 database integrations"
+    level: "critical"
+    category: "Projection expressions"
+    category-doc: |
+      {{ link.integrations.dynamodb-projection-expressions | prepend: site.baseurl }}
+    version: "1"
+    summary: "Projection expression contains double quotes"
+    cause: |
+      A projection expression entered in Stitch contains double quotes.
+    fix-it: |
+      Remove double quotes from any projection expression and ensure they adhere to [Stitch's other requirements for projection expressions]({{ link.integrations.dynamodb-projection-expressions | prepend: site.baseurl | append: "#projection-query-stitch-requirements" }}).

--- a/_data/taps/links/dynamodb.yml
+++ b/_data/taps/links/dynamodb.yml
@@ -8,4 +8,4 @@ accessing-elements: "https://docs.aws.amazon.com/amazondynamodb/latest/developer
 
 expressions-attributes: "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Attributes.html"
 
-projection-expressions: "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ProjectionExpressions.html"
+projection-queries: "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ProjectionExpressions.html"

--- a/_database-integrations/dynamodb/dynamodb-projection-expressions.md
+++ b/_database-integrations/dynamodb/dynamodb-projection-expressions.md
@@ -128,7 +128,7 @@ sections:
           Return only the specified fields (`name`, `is_active`) in the `customers` table. If including multiple fields, separate them with a comma.
         projection-query: |
           ```json
-          "name, is_active"
+          name, is_active
           ```
         sql: |
           ```sql
@@ -149,7 +149,7 @@ sections:
           Refer to [{{ page.display_name }}'s documentation]({{ site.data.taps.links.dynamodb.expressions-attributes }}){:target="new"} for more examples of dot notation for map elements.
         projection-query: |
           ```json
-          "name, details.age, details.type"
+          name, details.age, details.type
           ```
         sql: |
           In destinations - like Snowflake - that also use dot notation to query nested data, the query might look like this:
@@ -173,7 +173,7 @@ sections:
           Refer to [{{ page.display_name }}'s documentation]({{ site.data.taps.links.dynamodb.expressions-attributes }}){:target="new"} for more examples of accessing fields in lists.
         projection-query: |
           ```json
-          "name, acquaintances[1]"
+          name, acquaintances[1]
           ```
         results: |
           {% assign results = section.data %}

--- a/_database-integrations/dynamodb/dynamodb-projection-expressions.md
+++ b/_database-integrations/dynamodb/dynamodb-projection-expressions.md
@@ -266,6 +266,8 @@ sections:
     content: |
       If a table's projection expression doesn't meet [Stitch's requirements](#projection-query-stitch-requirements), a critical error will arise during Extraction. Extractions will not be successful until the issue is resolved.
 
+      Refer to the [Database integration extraction error reference]({{ link.troubleshooting.database-extraction-errors | prepend: site.baseurl | append: "#amazon-dynamodb-server-error-reference" }}) for {{ page.display_name }} extraction errors and help resolving them.
+
   - title: "Resources"
     anchor: "projection-query-resources"
     summary: "Additional resources for projection expressions"

--- a/_includes/shared/integrations/projection-column-selection.html
+++ b/_includes/shared/integrations/projection-column-selection.html
@@ -56,7 +56,7 @@ The following table indicates the availability of Stitch's {{ page.display_name 
 
 {% when "what-are-projection-queries" %}
 
-In {{ page.display_name }}, the default for queries is to return all fields in matching {{ table-name }}.  A [projection {{ projection-type }}]({{ site.data.taps.links[page.name].projection-queries }}){:target="new"} is used to specify or restrict the data returned in query results. By specifying a projection {{ projection-type }}, you can specify the fields you want to return or exclude.
+In {{ page.display_name }}, the default for queries is to return all fields in matching {{ table-name }}.  A [projection {{ projection-type }}]({{ site.data.taps.links[page.name]projection-queries }}){:target="new"} is used to specify or restrict the data returned in query results. By specifying a projection {{ projection-type }}, you can specify the fields you want to return or exclude.
 
 For example: Not specifying a {{ projection-type }} in Stitch is similar to `SELECT *` in SQL. If you wanted to only return a subset of fields, you'd specify them in the `SELECT` clause:
 

--- a/_troubleshooting/errors/extraction-errors/database-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/database-extraction-errors.md
@@ -54,6 +54,17 @@ sections:
 
       {% include troubleshooting/error-messages.html display-name="Common" %}
 
+
+  - title: "Amazon DynamoDB extraction errors"
+    anchor: "amazon-dynamodb-server-error-reference"
+    db-type: "dynamodb"
+    content: |
+      {{ page.applicable-integrations-note | flatify }}
+
+      {% assign errors = site.data.errors.extraction.databases.dynamodb.all | sort_natural:"message" %}
+
+      {% include troubleshooting/error-messages.html top-anchor="amazon-dynamodb-server-error-reference" display-name="Amazon DynamoDB" %}
+
   - title: "Microsoft SQL Server extraction errors"
     anchor: "microsoft-sql-server-error-reference"
     db-type: "mssql"


### PR DESCRIPTION
This PR updates the DynamoDB projection expression guide to reflect a recent discovery by support. Encasing double quotes were causing syntax errors, resulting in issues during extraction. The tap seems to encase queries in quotes on its own, so the user entering quotes in Stitch will cause errors.