### PR TITLE
Update max record size limit

### DIFF
--- a/_data/destinations/common/reference-data.yml
+++ b/_data/destinations/common/reference-data.yml
@@ -184,7 +184,7 @@ destination-details-description: |
 max-record-size:
   title: "Maximum record size"
   tooltip: "The maximum size a single record can be to be loaded successfully into the destination."
-  default: "4MB"
+  default: "{{ site.data.import-api.general.max-record-size }}"
   additional-info: "{{ destination-data.max-record-size-additional-info | flatify }}"
 
 table-name-length:

--- a/_data/errors/extraction/common.yml
+++ b/_data/errors/extraction/common.yml
@@ -11,7 +11,8 @@ raw-error:
 
   time-limit: &time-limit-error "The process was terminated. Most often this occurs because the job has exceeded its allotted runtime. The next job will run based on the integration's schedule."
 
-  record-size-limit: &record-size-limit-error "A single record is larger than the Stitch API limit of 20 Mb"
+## The max record size value is kept in the Import API data files: _/data/import-api/general.yml
+  record-size-limit: &record-size-limit-error "A single record is larger than the Stitch API limit of {{ site.data.import-api.general.max-record-size }}"
 
 time-limit: &time-limit
   message: *time-limit-error
@@ -30,14 +31,14 @@ time-limit: &time-limit
     Stitch will automatically retry extraction based on the integration's schedule.
 
 record-size-limit: &record-size-limit
-  message: *record-size-limit-error
+  message: "{{ site.data.errors.extraction.common.raw-error.record-size-limit | flatify }}"
   id: "record-size-limit"
   applicable-to: "All integrations"
   level: "critical"
   category: "Extraction job limits"
   summary: "Maximum record size exceeded"
   cause: |
-    A single record exceeded the maximum size limit of 20MB. This limit is imposed by the [Import API]({{ link.getting-started.basic-concepts | prepend: site.baseurl | append: "#system-architecture" }}), which Stitch uses as part of the replication process. 
+    A single record exceeded the maximum size limit of {{ site.data.import-api.general.max-record-size }}. This limit is imposed by the [Import API]({{ link.getting-started.basic-concepts | prepend: site.baseurl | append: "#system-architecture" }}), which Stitch uses as part of the replication process. 
   fix-it: |
     Locate the record in the source and, if possible, modify it to be less than Stitch's limit. You can also try de-selecting columns in the table containing the record.
 

--- a/_data/errors/extraction/common.yml
+++ b/_data/errors/extraction/common.yml
@@ -9,8 +9,9 @@ raw-error:
   10k-table-limit: &10k-table-limit |
     Stitch has discovered more than the maximum supported limit of 10,000 tables in your integration.
 
-  time-limit: &time-limit-error "The process was terminated.  Most often this occurs because the job has exceeded its allotted runtime. The next job will run based on the integration's schedule."
+  time-limit: &time-limit-error "The process was terminated. Most often this occurs because the job has exceeded its allotted runtime. The next job will run based on the integration's schedule."
 
+  record-size-limit: &record-size-limit-error "A single record is larger than the Stitch API limit of 20 Mb"
 
 time-limit: &time-limit
   message: *time-limit-error
@@ -28,15 +29,29 @@ time-limit: &time-limit
 
     Stitch will automatically retry extraction based on the integration's schedule.
 
+record-size-limit: &record-size-limit
+  message: *record-size-limit-error
+  id: "record-size-limit"
+  applicable-to: "All integrations"
+  level: "critical"
+  category: "Extraction job limits"
+  summary: "Maximum record size exceeded"
+  cause: |
+    A single record exceeded the maximum size limit of 20MB. This limit is imposed by the [Import API]({{ link.getting-started.basic-concepts | prepend: site.baseurl | append: "#system-architecture" }}), which Stitch uses as part of the replication process. 
+  fix-it: |
+    Locate the record in the source and, if possible, modify it to be less than Stitch's limit. You can also try de-selecting columns in the table containing the record.
+
+
 # ---------------------------- #
 #  Database Extraction Errors  #
 # ---------------------------- #
 
 databases:
   - <<: *time-limit
+  - <<: *record-size-limit
   - message: *10k-table-limit
     id: "10k-table-limit"
-    applicable-to: "All integrations"
+    applicable-to: "All database integrations"
     level: "critical"
     category: "Discovery job limits"
     summary: "Maximum discoverable table limit exceeded"
@@ -54,3 +69,4 @@ databases:
 
 saas:
   - <<: *time-limit
+  - <<: *record-size-limit

--- a/_data/import-api/general.yml
+++ b/_data/import-api/general.yml
@@ -1,3 +1,5 @@
+max-record-size: "20MB"
+
 attributes:
   client-id: |
     The Stitch client ID associated with your Stitch account.
@@ -46,7 +48,7 @@ attributes:
 request-body-requirements:
   common:
     - "Must contain all [required arguments](#[NAME]-data--arguments)."
-    - "Cannot exceed 4MB in size."
+    - "Cannot exceed {{ site.data.import-api.general.max-record-size }} in size."
     - "Each `data` object in the request body must contain between 1 and 20,000 records."
     - "Each `data` object in the request body cannot exceed 10,000 individual data points."
 

--- a/_data/import-api/response-codes/batch.yml
+++ b/_data/import-api/response-codes/batch.yml
@@ -124,7 +124,7 @@ all:
   - code: "413"
     responses:
       - method: "post"
-        condition: "Request body exceeds 4MB"
+        condition: "Request body exceeds {{ site.data.import-api.general.max-record-size }}"
         version: "all"
         response-body: |
           ```json

--- a/_data/import-api/response-codes/general-codes.yml
+++ b/_data/import-api/response-codes/general-codes.yml
@@ -60,7 +60,7 @@ all-codes:
     text: "Request Entity Too Large"
     error: true
     description: |
-      The size of the request body exceeded 4MB.
+      The size of the request body exceeded {{ site.data.import-api.general.max-record-size }}.
 
   - code: "415"
     text: "Unsupported Media Type"

--- a/_data/import-api/response-codes/push.yaml
+++ b/_data/import-api/response-codes/push.yaml
@@ -83,7 +83,7 @@ all:
   - code: "413"
     responses:
       - method: "post"
-        condition: "Request body exceeds 4MB"
+        condition: "Request body exceeds {{ site.data.import-api.general.max-record-size }}"
         version: "all"
         response-body: |
           ```json

--- a/_data/stitch/notifications/replication.yml
+++ b/_data/stitch/notifications/replication.yml
@@ -80,7 +80,7 @@ critical:
     content:
       - "The name of the affected table"
     potential-causes:
-      - "A record in the table exceeds Stitch's 4MB limit"
+      - "A record in the table exceeds Stitch's {{ site.data.import-api.general.max-record-size }} limit"
     app-category: "persistence"
     singer: false
 

--- a/_data/taps/import-api/return-codes.yml
+++ b/_data/taps/import-api/return-codes.yml
@@ -25,7 +25,7 @@ codes:
     description: "The request has an HTTP method that is not supported by the endpoint. `POST` and `GET` are supported by the Import API. Check that you’re using the correct HTTP method."
 
   - name: "413 Request Entity Too Large"
-    description: "The size of the request body was over 4MB."
+    description: "The size of the request body was over {{ site.data.import-api.general.max-record-size }}."
 
   - name: "415 Unsupported Media Type"
     description: "The content header of the request did not specify JSON or Transit."

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -326,6 +326,7 @@ troubleshooting:
   errors: /troubleshooting/error-notifications
 
   database-extraction-errors: /troubleshooting/integrations/database-extraction-error-reference
+  saas-extraction-errors: /troubleshooting/integrations/common-saas-extraction-error-reference
 
   reauth-integrations: /troubleshooting/integrations/reauthorizing-integrations
   dw-loading-errors: /troubleshooting/destinations/destination-loading-error-reference

--- a/_getting-started/connecting-other-data-sources-guide.md
+++ b/_getting-started/connecting-other-data-sources-guide.md
@@ -106,7 +106,7 @@ sections:
 
       1. The webhook's payload (delivery) must come via a `POST` request.
       2. The request body (data) must be valid JSON.
-      3. The request body must be less than 4MB in size.
+      3. The request body must be less than {{ site.data.import-api.general.max-record-size }} in size.
 
       Refer to the [Incoming Webhooks docs]({{ link.integrations.stitch-incoming-webhooks | prepend: site.baseurl }}) for more info.
 

--- a/_troubleshooting/destinations/aws-io-errors.md
+++ b/_troubleshooting/destinations/aws-io-errors.md
@@ -6,6 +6,7 @@ tags: [troubleshooting_destinations, troubleshooting_errors]
 
 summary: "While typically transient, I/O errors arise from connection issues between Stitch and your data warehouse. If persistent, these errors may be indicative of a larger issue."
 type: "redshift-destination, error"
+category: "loading-errors"
 promote: "false"
 
 key: "aws-redshift-io-error"

--- a/_troubleshooting/destinations/panoply-issues.md
+++ b/_troubleshooting/destinations/panoply-issues.md
@@ -5,7 +5,8 @@ permalink: /troubleshooting/destinations/panoply-connection-issues
 tags: [troubleshooting_destinations, troubleshooting_errors]
 
 summary: "If you’re having trouble with setting up or connecting to your Panoply data warehouse in Stitch, try these troubleshooting steps before reaching out to support."
-type: "panoply-destination, connection"
+type: "panoply-destination, connection, error"
+category: "connection-errors"
 promote: "false"
 ---
 {% include misc/data-files.html %}
@@ -29,4 +30,4 @@ If you’ve recently reset your password in Panoply, you’ll also need to updat
 
 If you’re still running into problems with Panoply in Stitch, reach out to [Stitch support](mailto:{{ site.support }}).
 
-If you’re experiencing issues inside of Panoply, [reach out to Panoply support](https://panoply.io).
+If you’re experiencing issues inside of Panoply, [reach out to Panoply support](https://panoply.io){:target="new"}.

--- a/_troubleshooting/destinations/redshift-dependent-view-errors.md
+++ b/_troubleshooting/destinations/redshift-dependent-view-errors.md
@@ -6,6 +6,7 @@ tags: [troubleshooting_destinations, troubleshooting_errors]
 
 summary: "If you've received a 'Dependent Views' error for your Redshift or Panoply data warehouse, you may need to temporarily drop dependent objects."
 type: "redshift-destination, error, replication"
+category: "loading-errors"
 promote: "false"
 
 key: "redshift-view-dependencies"

--- a/_troubleshooting/destinations/redshift-vacuum-errors.md
+++ b/_troubleshooting/destinations/redshift-vacuum-errors.md
@@ -6,6 +6,7 @@ tags: [troubleshooting_destinations, troubleshooting_errors]
 
 summary: "If you received a `VACUUM` notification, it means that Stitch hasn't been able to successfully complete `VACUUM` some tables in your data warehouse for more than 10 days."
 type: "redshift-destination, error"
+category: "loading-errors"
 promote: "false"
 
 key: "redshift-vacuum-error"

--- a/_troubleshooting/error-notifications.md
+++ b/_troubleshooting/error-notifications.md
@@ -11,48 +11,99 @@ feedback: false
 
 intro: |
   {% include misc/data-files.html %}
-  {% assign sorted-docs = site.troubleshooting | sort_natural:'title' %}
+  {% assign all-errors = site.troubleshooting | where_exp:"page","page.type contains 'error'" | sort_natural: "title" %}
 
   {{ page.summary }}
 
   {% for section in page.sections %}
-  - [{{ section.title }}](#{{ section.anchor }})
+  - [{{ section.title }}](#{{ section.anchor }}) - {{ section.summary }}
   {% endfor %}
 
 sections:
   - title: "Account and billing errors"
     anchor: "account-billing-errors"
+    summary: "Errors related to billing and account management"
     content: |
-      {% for page in sorted-docs %}
-      {% if page.type contains "account" and page.type contains "error" %}
-      <span class="h4">
-      <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-      </span>
-      {{ page.summary }}
-      {% endif %}
-      {% endfor %}
+      {% assign account-errors = all-errors | where_exp:"page","page.type contains 'account'" %}
 
-  - title: "Destination errors"
-    anchor: "destination-errors"
-    content: |
-      {% for page in sorted-docs %}
-      {% if page.type contains "destination" and page.type contains "error" %}
+      {% for page in account-errors %}
       <span class="h4">
       <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
       </span>
       {{ page.summary }}
-      {% endif %}
       {% endfor %}
 
   - title: "Integration errors"
     anchor: "integration-errors"
+    summary: "Errors applicable to integrations"
     content: |
-      {% for page in sorted-docs %}
-      {% if page.type contains "integration" and page.type contains "error" %}
-      <span class="h4">
-      <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-      </span>
-      {{ page.summary }}
-      {% endif %}
+      {% assign integration-errors = all-errors | where_exp:"page","page.type contains 'integration'" %}
+
+      {% for subsection in section.subsections %}
+      - [{{ subsection.title }}](#{{ subsection.anchor }}) - {{ subsection.summary | flatify }}
       {% endfor %}
+
+    subsections:
+      - title: "Connection errors"
+        anchor: "integration-connection-errors"
+        summary: &connection-errors "Errors arising from insufficient permissions, incorrect configuration, etc."
+        content: |
+          {% assign connection-errors = integration-errors | where:"category","connection-errors" %}
+
+          {% for page in connection-errors %}
+          <span class="h4">
+          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          </span>
+          {{ page.summary }}
+          {% endfor %}
+
+      - title: "Extraction errors"
+        anchor: "integration-extraction-errors"
+        summary: "Errors that arise during Extraction. These will surface in an integration's Extraction Logs."
+        content: |
+          {% assign extraction-errors = integration-errors | where:"category","extraction-errors" %}
+
+          {% for page in extraction-errors %}
+          <span class="h4">
+          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          </span>
+          {{ page.summary }}
+          {% endfor %}
+
+  - title: "Destination errors"
+    anchor: "destination-errors"
+    summary: "Errors applicable to destinations"
+    content: |
+      {% assign destination-errors = all-errors | where_exp:"page","page.type contains 'destination'" %}
+
+      {% for subsection in section.subsections %}
+      - [{{ subsection.title }}](#{{ subsection.anchor }}) - {{ subsection.summary | flatify }}
+      {% endfor %}
+
+    subsections:
+      - title: "Connection errors"
+        anchor: "destination-connection-errors"
+        summary: *connection-errors
+        content: |
+          {% assign connection-errors = destination-errors | where:"category","connection-errors" %}
+
+          {% for page in connection-errors %}
+          <span class="h4">
+          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          </span>
+          {{ page.summary }}
+          {% endfor %}
+
+      - title: "Loading errors"
+        anchor: "destination-loading-errors"
+        summary: "Errors that arise during Loading. These will surface in the Notifications tab and in an integration's Loading Reports."
+        content: |
+          {% assign loading-errors = destination-errors | where:"category","loading-errors" %}
+
+          {% for page in loading-errors %}
+          <span class="h4">
+          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          </span>
+          {{ page.summary }}
+          {% endfor %}
 ---

--- a/_troubleshooting/errors/connection-errors/database-integration-connection-errors.md
+++ b/_troubleshooting/errors/connection-errors/database-integration-connection-errors.md
@@ -11,11 +11,10 @@ redirect_from:
 
 summary: "Resolve errors related to connecting to a database integration."
 type: "database-integration, error"
+category: "connection-errors"
 
 level: "guide"
 top-level: ""
-# category: "connection-errors"
-type: "integration, error"
 popular: true
 
 intro: |

--- a/_troubleshooting/errors/connection-errors/destination-connection-errors.md
+++ b/_troubleshooting/errors/connection-errors/destination-connection-errors.md
@@ -16,7 +16,7 @@ key: "destination-connection-errors"
 
 level: "guide"
 top-level: ""
-# category: "connection-errors"
+category: "connection-errors"
 type: "all-destinations, destination, error"
 popular: true
 

--- a/_troubleshooting/errors/destination-loading-errors.md
+++ b/_troubleshooting/errors/destination-loading-errors.md
@@ -11,13 +11,12 @@ redirect_from:
   - /troubleshooting/destinations/destination-data-loading-errors
 
 summary: "Resolve errors related to loading data into your Stitch destination."
-type: "all-destinations, error"
 
 key: "destination-loading-errors"
 
 level: "guide"
 top-level: ""
-# category: "connection-errors"
+category: "loading-errors"
 type: "all-destinations, destination, error"
 popular: true
 

--- a/_troubleshooting/errors/extraction-errors/database-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/database-extraction-errors.md
@@ -16,7 +16,7 @@ summary: "Extraction errors for database integrations and how to resolve them."
 
 level: "guide"
 top-level: "replication"
-# category: "extraction-errors"
+category: "extraction-errors"
 type: "database-integration, error, replication"
 popular: true
 
@@ -48,12 +48,17 @@ sections:
   - title: "Common extraction errors"
     anchor: "common-error-reference"
     content: |
+      {% capture notice %}
+      **Looking for SaaS integrations?** Refer to the [Common SaaS Extraction Error Reference]({{ link.troubleshooting.saas-extraction-errors | prepend: site.baseurl }}).
+      {% endcapture %}
+
+      {% include note.html type="single-line" content=notice %}
+
       {% assign errors = site.data.errors.extraction.common.databases | sort_natural:"message" %}
 
       The following errors are applicable to all database integrations that support Extraction Logs:
 
       {% include troubleshooting/error-messages.html display-name="Common" %}
-
 
   - title: "Amazon DynamoDB extraction errors"
     anchor: "amazon-dynamodb-server-error-reference"

--- a/_troubleshooting/errors/extraction-errors/saas-common-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/saas-common-extraction-errors.md
@@ -1,0 +1,53 @@
+---
+title: Common SaaS Integration Extraction Error Reference
+keywords: troubleshooting, integration, saas integration, extraction error, common errors, 6 hour limit, table limit
+layout: general
+
+permalink: /troubleshooting/integrations/common-saas-extraction-error-reference
+
+summary: "Extraction errors applicable to all SaaS integrations and how to resolve them."
+
+level: "guide"
+top-level: "replication"
+category: "extraction-errors"
+integration-type: "saas"
+
+type: "saas-integration, error, replication"
+popular: true
+
+intro: |
+  When Stitch replicates data from a SaaS integration, it will check for the required user permissions and account configuration. If permisisons are insufficient or the source isn't configured correctly, you may receive an error during the Extraction phase of the replication process. These errors will surface in the integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
+
+  **Note**: The errors in this reference are applicable to all SaaS integrations that support Extraction Logs. For integration-specific errors, refer to the [reference for that integration](#integration-specific-error-references).
+
+  {% for section in page.sections %}
+  - [{{ section.title | flatify }}](#{{ section.anchor }})
+  {% endfor %}
+
+sections:
+  - title: "Common extraction errors"
+    anchor: "common-extraction-errors"
+    content: |
+      {% assign errors = site.data.errors.extraction.common.saas | sort_natural:"message" %}
+
+      {% include troubleshooting/error-messages.html %}
+
+  - title: "Integration-specific error references"
+    anchor: "integration-specific-error-references"
+    content: |
+      {% capture notice %}
+      **Looking for database integrations?** Refer to the [Database Extraction Error Reference]({{ link.troubleshooting.database-extraction-errors | prepend: site.baseurl }}).
+      {% endcapture %}
+
+      {% include note.html type="single-line" content=notice %}
+
+      {% assign all-extraction-errors = site.troubleshooting | where:"category","extraction-errors" %}
+      {% assign saas-extraction-error-references = all-extraction-errors | where:"integration-type","saas" | sort_natural:"title" %}
+
+      {% for reference in saas-extraction-error-references %}
+      {% if reference.title != page.title %}
+      - [{{ reference.title | remove: " Extraction Error Reference" }}]({{ reference.url | prepend: site.baseurl }})
+      {% endif %}
+      {% endfor %}
+---
+{% include misc/data-files.html %}

--- a/_troubleshooting/errors/extraction-errors/saas/google-sheets-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/saas/google-sheets-extraction-errors.md
@@ -9,12 +9,16 @@ summary: "Extraction errors for Google Sheets integrations and how to resolve th
 
 level: "guide"
 top-level: "replication"
-# category: "extraction-errors"
+category: "extraction-errors"
+integration-type: "saas"
+
 type: "saas-integration, error, replication"
 
 sections:
   - content: |
-      These errors will surface in the Google Sheets integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
+      The errors in this guide are specific to Google Sheets integrations. Refer to the [Common SaaS extraction error reference]({{ link.troubleshooting.saas-extraction-errors | prepend: site.baseurl }}) for errors common to all SaaS integrations.
+
+      These errors will surface in the integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
 
       {% assign errors = site.data.errors.extraction.saas.google-sheets.all | sort_natural:"message" %}
 

--- a/_troubleshooting/errors/extraction-errors/saas/netsuite-suitetalk-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/saas/netsuite-suitetalk-extraction-errors.md
@@ -9,12 +9,16 @@ summary: "Extraction errors for NetSuite integrations and how to resolve them."
 
 level: "guide"
 top-level: "replication"
-# category: "extraction-errors"
+category: "extraction-errors"
+integration-type: "saas"
+
 type: "saas-integration, error, replication"
 
 sections:
   - content: |
-      These errors will surface in the NetSuite integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
+      The errors in this guide are specific to NetSuite integrations. Refer to the [Common SaaS extraction error reference]({{ link.troubleshooting.saas-extraction-errors | prepend: site.baseurl }}) for errors common to all SaaS integrations.
+
+      These errors will surface in the integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
 
       {% assign errors = site.data.errors.extraction.saas.netsuite.all | sort_natural:"message" %}
 

--- a/_troubleshooting/integrations/reauthorizing-integrations.md
+++ b/_troubleshooting/integrations/reauthorizing-integrations.md
@@ -6,6 +6,7 @@ tags: [troubleshooting_integrations, troubleshooting_errors]
 
 summary: "If you see a message that asks you to re-authorize an integration, it means that Stitch's permissions to that service have been revoked."
 type: "all-integrations, error"
+category: "connection-errors"
 ---
 {% include misc/data-files.html %}
 

--- a/_troubleshooting/integrations/saas-integration-connection-errors.md
+++ b/_troubleshooting/integrations/saas-integration-connection-errors.md
@@ -9,6 +9,7 @@ redirect_from: /troubleshooting/integrations/integration-connection-errors
 
 summary: "If Stitch is unable to connect to one of your SaaS integrations, the issue may be a security setting on the integration provider's side."
 type: "saas-integrations, connection, error"
+category: "connection-errors"
 ---
 {% include misc/data-files.html %}
 

--- a/_troubleshooting/integrations/salesforce-rest-api-too-many-columns.md
+++ b/_troubleshooting/integrations/salesforce-rest-api-too-many-columns.md
@@ -5,7 +5,8 @@ permalink: /troubleshooting/salesforce-replication-too-many-columns
 tags: [troubleshooting_integrations, saas_integrations, error_notifications]
 
 summary: "If a single Salesforce object has a large number of columns set to replicate, issues with replication may arise."
-type: "saas-integration, replication"
+type: "saas-integration, replication, error"
+category: "extraction-errors"
 ---
 {% include misc/data-files.html %}
 
@@ -24,9 +25,9 @@ This issue is applicable to:
 
 ## Extraction Log Error
 
-{% include note.html type="single-line" content="Extraction logs are unavailable for Salesforce integrations using version 15-10-2017." %}
+{% include note.html type="single-line" content="Extraction Logs are unavailable for Salesforce integrations using version 15-10-2017." %}
 
-If the version of your Salesforce integration supports [extraction logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}), this is the error message that will display in Stitch:
+If the version of your Salesforce integration supports [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}), this is the error message that will display in Stitch:
 
 ```shell
 Bad Message 431 reason: Request Header Fields Too Large

--- a/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
+++ b/_troubleshooting/integrations/unable-to-load-tables-too-many-tables.md
@@ -7,8 +7,8 @@ layout: general
 toc: false
 
 key: "source-database-access-level-issue"
-
-type: "database-integration, replication"
+type: "database-integration, replication, error"
+category: "extraction-errors"
 promote: "false"
 
 intro: |

--- a/_webhook-integrations/stitch-incoming-webhooks.md
+++ b/_webhook-integrations/stitch-incoming-webhooks.md
@@ -78,7 +78,7 @@ To use Stitch Incoming Webhooks:
 2. **The Webhook API you're integrating with meets the following requirements**:
    - The data sent by the webhook API must come to Stitch in **JSON format**. This is currently the only format Stitch supports.
    - The payload (or delivery) of the data must come via a `POST` request.
-   - Request bodies must be less than 4MB
+   - Request bodies must be less than {{ site.data.import-api.general.max-record-size }}
 
 You can determine if the webhook API you want to use meets the above criteria by checking out that provider's webhook API documentation.
 


### PR DESCRIPTION
This PR:

- Updates the max record size limit to 20MB
- Adds the extraction error for records exceeding this size to the docs
- Adds a **Common SaaS extraction errors reference** to the troubleshooting docs
- Single-sources the max record size limit and updates references (data lives in `_data/import-api/general.yml`)
- Re-vamps the **Troubleshooting > Error Notifications** page so it's not a total dump of pages