### PR TITLE
GCP MySQL and Postgres - Add setup requirements for log-based rep

### DIFF
--- a/_database-integrations/mysql/cloudsql/google-cloudsql-mysql.md
+++ b/_database-integrations/mysql/cloudsql/google-cloudsql-mysql.md
@@ -83,10 +83,16 @@ notice: |
   If you want to connect a **PostgreSQL-based** CloudSQL instance, use [these instructions]({{ link.integrations.database-integration | prepend: site.baseurl | replace: "INTEGRATION","google-cloudsql-postgresql" }}).
 
 requirements-list:
+  - item: "**Permissions in Google Cloud that allow you to modify the database's connection settings.** This is required to whitelist Stitch's IP addresses."
   - item: |
       **The `CREATE USER` or `INSERT` privilege (for the `mysql` database).** The [`CREATE USER` privilege](https://dev.mysql.com/doc/refman/8.0/en/create-user.html){:target="new"} is required to create a database user for Stitch.
   - item: |
-      **The `GRANT OPTION` privilege in {{ integration.display_name }}.** The [`GRANT OPTION` privilege](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_grant-option){:target="new"} is required to grant the necessary privileges to the Stitch database user.
+      **The `GRANT OPTION` privilege.** The [`GRANT OPTION` privilege](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_grant-option){:target="new"} is required to grant the necessary privileges to the Stitch database user.
+  - item: |
+      **If using Log-based Replication**, you'll need:
+
+      - **A database running MySQL {{ integration.log-based-replication-minimum-version }} or greater** Earlier versions of MySQL do not include binlog replication functionality, which is required for Log-based Replication.
+      - **To connect to the master instance.** [Google doesn't currently support binlog replication on read replicas](https://cloud.google.com/sql/docs/mysql/replication/create-replica){:target="new"}.
 
 # -------------------------- #
 #     Setup Instructions     #

--- a/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
+++ b/_database-integrations/postgres/cloudsql/v1/google-cloudsql-postgresql-v1.md
@@ -87,8 +87,10 @@ notice-copy: |
   If you want to connect a {{ integration.display_name }} instance as a **destination**, refer to the [Connecting a Self-Hosted {{ integration.display_name }} Destination guide]({{ link.destinations.setup.cloudsql-postgres | prepend: site.baseurl }}).
 
 requirements-list:
+  - item: "**A database running PostgreSQL 9.3.x or greater.** PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations."
+  - item: "**Permissions in Google Cloud that allow you to modify the database's connection settings.** This is required to whitelist Stitch's IP addresses."
   - item: "**Permissions in PostgreSQL that allow you to create users.** This is required to create a database user for Stitch."
-  - item: "**To be running PostgeSQL 9.3+ or greater**. PostgreSQL 9.3.x is the minimum version Stitch supports for PostgreSQL integrations."
+  
 
 # -------------------------- #
 #     Setup Instructions     #


### PR DESCRIPTION
This PR adds setup requirements for enabling log-based rep for GCP MySQL-based databases. It also clarifies some requirements for GCP Postgres.