### PR TITLE
Add kramdown-parser-gfm to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'jekyll-redirect-from'  # https://github.com/jekyll/jekyll-redirect-from
 gem 'jekyll-contentblocks'
 gem 'jekyll-include-cache'
 gem 'jekyll-random'
+gem 'kramdown-parser-gfm'


### PR DESCRIPTION
This PR adds the `kramdown-parser-gfm` gem to the site's `Gemfile`.

Netlify doesn't seem to be respecting the `Gemfile`, and suddenly started using Jekyll `3.9.0` (and we use `4.1.1`, so ¯\_(ツ)_/¯), which caused problems with this gem. In the 3.9 release of Jekyll, they required that this be added to `Gemfile`s to continue using GitHub-flavored Markdown with Kramdown.