### PR TITLE
August 17 support fixes

### DIFF
--- a/_data/destinations/bigquery/loading-errors.yml
+++ b/_data/destinations/bigquery/loading-errors.yml
@@ -6,9 +6,12 @@
 
 # "Primary key change is not permitted"
 
+numeric-out-of-range: &numeric-out-of-range "Numeric out of range for BigQuery on [NUMERIC]"
+primary-key-change: &primary-key-change "Primary key change is not permitted"
+
 all:
 ## Primary Key change not allowed
-  - message: "Primary key change is not permitted"
+  - message: *primary-key-change
     id: "pk-change-not-permitted"
     applicable-to: "Google BigQuery v2 destinations"
     level: "critical"
@@ -25,7 +28,7 @@ all:
     fix-it: |
       Reset the table(s) mentioned in the error. This will queue a full re-replication of the table(s), which will ensure Primary Keys are correctly captured and used to de-dupe data when loading.
 
-  - message: "Numeric out of range for BigQuery on [NUMERIC]"
+  - message: *numeric-out-of-range
     id: "numeric-out-of-range"
     applicable-to: "All Google BigQuery destination versions"
     level: "warning"

--- a/_data/errors/extraction/databases/mongo.yml
+++ b/_data/errors/extraction/databases/mongo.yml
@@ -18,6 +18,11 @@ raw-error:
 
 # '[VALUE]' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string
 
+  oplog-age-out: &oplog-age-out |
+    Clearing state because Oplog has aged out
+    Must complete full table sync before starting oplog replication for [COLLECTION_NAME]
+
+
 documentation:
   projection-queries: &projection-queries
     category: "Projection queries"
@@ -148,3 +153,19 @@ all:
       {% for integration in applicable-integrations %}
       - [{{ integration.display_name }}]({{ integration.url | prepend: site.baseurl | append: "/v2" | append: "#create-a-database-user" }})
       {% endfor %}
+
+  - message: *oplog-age-out
+    id: "oplog-age-out-full-table-replication"
+    applicable-to: *all-mongo
+    level: "info"
+    category: "Log-based Incremental Replication"
+    category-doc: |
+      {{ link.replication.log-based-incremental | prepend: site.baseurl | append: "#limitation--log-retention" }}
+    version: "1,2"
+    summary: "Insufficient maximum OpLog size"
+    cause: |
+      The OpLog's maximum size is insufficient, causing log files to age out before Stitch can replicate them. When this occurs, Stitch will clear the saved log position ID for any affection collection(s) and re-replicate them in full.
+    fix-it: |
+      Increase the maximum size of the OpLog using the [replSetResizeOplog](https://docs.mongodb.com/v4.0/reference/command/replSetResizeOplog/#dbcmd.replSetResizeOplog){:target="new"} command.
+
+      **Note**: As the maximum size you need depends on your database, it may take some experimentation to identify the best setting. Mongo doesn't currently recommend an OpLog size.

--- a/_includes/integrations/databases/setup/binlog/mongodb-oplog.html
+++ b/_includes/integrations/databases/setup/binlog/mongodb-oplog.html
@@ -12,33 +12,52 @@ In this step, you'll edit the `/etc/mongod.conf` file to add a [replica set]({{ 
 
 1. Start the {{ integration.display_name }} instance:
 
-   ```shell
+   {% capture code %}
    mongod --port 27017
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
    ```
 
 2. Connect to the Mongo shell as a `root` user:
 
+   {% capture code %}
+   mongo --port 27017 -u <root_username> -p <password> --authenticationDatabase admin
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
    ```shell
-   mongo --port 27017
+{{ code | lstrip | rstrip }}
    ```
 
 3. Navigate to the `/etc/mongod.conf` file.
 
-4. In `/etc/mongod.conf`, uncomment `replication` and specify a name for the replica set (`replSetName`). 
+4. In `/etc/mongod.conf`, uncomment `replication` and define the following configuration options. **Note**: As `/etc/mongod.conf` is a protected file, you may need to assume `sudo` to edit it.
 
-   In this example, we're using `rs0` as the replica set name:
-
-   ```shell
+   {% capture code %}
    replication:
       replSetName: "rs0"
-	 ```
+      oplogSizeMB: <integer>
+   {% endcapture %}
 
-    Use the `rs.status()` command to return this replica set's name going forward.
+   {% include layout/code-snippet.html use-code-block=false code=code %}
 
-	 **Note**: As `/etc/mongod.conf` is a protected file, you may need to assume `sudo` to edit it.
+   ```shell
+{{ code | lstrip | rstrip }}
+   ```
+
+   - **replSetName**: The name for the replica set. In this example, we used `rs0`. Use the `rs.status()` command to return this replica set's name going forward.
+   - **oplogSizeMB**: The maximum size, in megabytes, for the oplog. If undefined, MongoDB will use the default size - refer to [MongoDB's docs for more info](https://docs.mongodb.com/v4.0/core/replica-set-oplog/#oplog-size){:target="new"}.
+
+      When the oplog reaches this size, MongoDB will automatically remove log entries to maintain the maximum oplog size. If Stitch is unable to replicate all of a table's log entries before they age out, Stitch will re-replicate the table in full to ensure records aren't missing. Refer to the [Log-based Incremental guide]({{ link.replication.log-based-incremental | prepend: site.baseurl | append: "#limitation--log-retention" }}) for more info and examples.
+
+      **Note**: If you're using an existing replica set and want to change its maximum size, use the [replSetResizeOplog](https://docs.mongodb.com/v4.0/reference/command/replSetResizeOplog/#dbcmd.replSetResizeOplog){:target="new"} command.
 
 5. Save the changes.
-
 
 
 <!-- INITIATE THE REPLICA SET -->
@@ -48,27 +67,51 @@ Next, you'll restart the instance and initiate the replica set.
 
 1. Restart `mongod` with the configuration file:
 
-   ```shell
+   {% capture code %}
    sudo mongod --auth --config /etc/mongod.conf
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
    ```
 
 2. Connect to the Mongo shell as a `root` user, replacing `<root_username>` and `<password>` with the `root` user's username and password:
 
-   ```shell
+   {% capture code %}
    mongo --port 27017 -u <root_username> -p <password> --authenticationDatabase admin
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
    ```
 
 3. Initiate the replica set, replacing `<host_address>` with the IP address or endpoint used by the `mongod` instance:
 
-   ```shell
+   {% capture code %}
    rs.initiate({_id: "rs0", members: [{_id: 0, host: "<host_address>:27017"}]})
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
    ```
 
-If successful, you'll receive a response similar to the following:
+   If successful, you'll receive a response similar to the following:
 
-```json
-{ "ok" : 1 }
-```
+   {% capture code %}
+   { "ok" : 1 }
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```json
+{{ code | lstrip | rstrip }}
+   ```
 
 
 <!-- VERIFY OPLOG ACCESS -->
@@ -80,27 +123,51 @@ Lastly, you'll verify that the Stitch user can read from the OpLog.
 
 2. Reconnect as the Stitch database user you created in [Step 2](##create-a-database-user). Replace `<stitch_username>` and `<password>` with the Stitch user's username and password, respectively:
 
-   ```shell
+   {% capture code %}
    mongo --port 27017 -u <stitch_username> -p <password> --authenticationDatabase admin
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
    ```
 
 3. Switch to the `local` database:
 
-   ```shell
+   {% capture code %}
    use local
-   ```
+   {% endcapture %}
 
-4. View OpLog rows:
+   {% include layout/code-snippet.html use-code-block=false code=code %}
 
    ```shell
-   db.oplog.rs.find()
+{{ code | lstrip | rstrip }}
    ```
 
-If successful, records from the OpLog similar to the following will be returned:
+4. View oplog rows:
 
-```json
-{ "ts" : Timestamp(1524038245, 63), "t" : NumberLong(1), "h" : NumberLong("-596019791399272412"), "v" : 2, "op" : "i", "ns" : "stitchTest.customers", "ui"
+   {% capture code %}
+   db.oplog.rs.find()
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```shell
+{{ code | lstrip | rstrip }}
+   ```
+
+   If successful, records from the oplog similar to the following will be returned:
+
+   {% capture code %}
+   { "ts" : Timestamp(1524038245, 63), "t" : NumberLong(1), "h" : NumberLong("-596019791399272412"), "v" : 2, "op" : "i", "ns" : "stitchTest.customers", "ui"
 : UUID("0e623d9c-722c-41d5-a5e6-83947cc2466e"), "wall" : ISODate("2018-04-18T07:57:25.065Z"), "o" : { "_id" : 100, "name" : "Finn" } }
-```
+   {% endcapture %}
+
+   {% include layout/code-snippet.html use-code-block=false code=code %}
+
+   ```json
+{{ code | lstrip | rstrip }}
+   ```
 
 {% endcase %}

--- a/_includes/integrations/databases/setup/db-users/mongo.html
+++ b/_includes/integrations/databases/setup/db-users/mongo.html
@@ -21,9 +21,11 @@ Select the version your {{ integration.display_name }} database is using to view
 {% capture mongo-create-user-below-v3 %}
 Create the user, using the `addUser` command for {{ integration.display_name }} versions 2.4 through 2.6. Replace `<password>` with a password:
 
-```javascript
+{% capture code %}
 {{ site.data.taps.extraction.database-setup.user-privileges.mongo.create-user-v2 | strip }}
-```
+{% endcapture %}
+
+{% include layout/code-snippet.html code=code language="javascript" %}
 {% endcapture %}
 
 {% include layout/expandable-heading.html title="I'm using a MongoDB version between 2.4 and 2.6." content=mongo-create-user-below-v3  anchor="mongo-create-user-below-v3" %}
@@ -32,9 +34,11 @@ Create the user, using the `addUser` command for {{ integration.display_name }} 
 {% capture mongo-create-user-v3-v3-2 %}
 Create the user, using the `createUser` command for {{ integration.display_name }} versions 3.0 through 3.2. Replace `<password>` with a password:
 
-```javascript
+{% capture code %}
 {{ site.data.taps.extraction.database-setup.user-privileges.mongo.create-user-v3-2 | strip }}
-```
+{% endcapture %}
+
+{% include layout/code-snippet.html code=code language="javascript" %}
 {% endcapture %}
 
 {% include layout/expandable-heading.html title="I'm using a MongoDB version between 3.0 and 3.2." content=mongo-create-user-v3-v3-2  anchor="mongo-create-user-v3-v3-2" %}
@@ -43,9 +47,11 @@ Create the user, using the `createUser` command for {{ integration.display_name 
 {% capture mongo-create-user-v3-4 %}
 [For versions 3.4 and above](https://docs.mongodb.com/v3.4/reference/built-in-roles/#readAnyDatabase){:target="new"}, the `readAnyDatabase` role doesn't include the `local` database. Create the user, granting the additional `read` role on the `local` database:
 
-```javascript
+{% capture code %}
 {{ site.data.taps.extraction.database-setup.user-privileges.mongo.create-user-v3-4 | strip }}
-```
+{% endcapture %}
+
+{% include layout/code-snippet.html code=code language="javascript" %}
 {% endcapture %}
 
 {% capture 3-4-title %}

--- a/_replication/replication-methods/log-based-incremental-replication.md
+++ b/_replication/replication-methods/log-based-incremental-replication.md
@@ -364,44 +364,79 @@ sections:
 
           {{ section.back-to-list | flatify }}
 
-## MYSQL/ORACLE RETENTION PERIOD
-      - title: "Limitation {{ forloop.index }}: Logs can age out and stop replication (Microsoft SQL Server, MySQL, and Oracle)"
+## LOG AGE OUT
+      - title: "Limitation {{ forloop.index }}: Logs can age out and impact replication (Microsoft SQL Server, MongoDB, MySQL, and Oracle)"
         anchor: "limitation--log-retention"
-        databases: "mssql, mysql, oracle"
+        databases: "mongo, mssql, mysql, oracle"
         content: |
-          {% include note.html type="single-line" content="**Note**: This section is applicable only to **Microsoft SQL Server, MySQL,** and **Oracle**-backed database integrations." %}
+          {% include note.html type="single-line" content="**Note**: This section is applicable only to **Microsoft SQL Server, MongoDB, MySQL,** and **Oracle**-backed database integrations." %}
 
-          Log files, by default, are not stored indefinitely on a database server. The amount of time a log file is stored depends on the database's log retention settings.
+          Log files, by default, aren't stored indefinitely on a database server. The amount of time a log file is stored depends on the database's log retention settings.
 
-          Log retention settings specify the amount of time before a log file is automatically removed from the database server. When a log file is removed from the server before Stitch can read from it, replication will be unable to proceed. 
+          Log retention settings when a log file is automatically removed from the database server. This can either be a set amount of time, or the maximum size of all the database's log files. When a log file is removed from the server before Stitch can read from it, one of two things will happen depending on the database type:
 
-          When this occurs, an extraction error similar to the following will surface in the [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}):
+          {% for sub-subsection in subsection.sub-subsections %}
+          - [{{ sub-subsection.summary }}](#{{ sub-subsection.anchor }})
+          {% endfor %}
 
-          - **For MySQL databases**:
-            ```
-            {{ site.data.errors.extraction.databases.mysql.raw-error.log-retention-purge | strip }}
-            ```
-
-          - **For Oracle databases**:
-            ```
-            {{ site.data.errors.extraction.databases.oracle.raw-error.missing-logfile | strip }}
-            ```
-
-          To resolve the error, you'll need to [reset the integration from the {{ app.page-names.int-settings }} page]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}). **Note**: This is different than resetting an individual table.
-
-          This error can be caused by a few things:
+          This can be caused by a few things:
 
           1. **The log file is purged before historical replication completes**. This is because the maximum [log position ID](#log-based-incremental-replication-terminology) is saved at the start of [historical replication jobs](#log-based-incremental-replication-terminology), so Stitch knows where to begin reading from the database logs after historical data is replicated.
-          2. **The log retention settings are set to too short of a time period**. Stitch recommends a minimum of **3 days**, but **7 days** is preferred to account for resolving potential issues without losing logs.
+          2. **For log retention settings that define a time period, the time period is too short.** Stitch recommends a minimum of **3 days**, but **7 days** is preferred to account for resolving potential issues without losing logs.
 
              - **For Microsoft SQL Server databases**, this is the `CHANGE_RETENTION` setting.
              - **For MysQL databases**, these are the `expire_logs_days` or `binlog_expire_logs_seconds` settings.
              - **For Oracle databases**:
                 - **For self-hosted Oracle databases**, this is the [RMAN retention policy setting]({{ site.baseurl }}/integrations/databases/oracle#configure-rman-backups).
                 - **For Oracle-RDS databases**, these are the [AWS automated backup]({{ site.baseurl }}/integrations/databases/amazon-oracle-rds#enable-aws-automated-backups) and [`archivelog retention hours`]({{ site.baseurl }}/integrations/databases/amazon-oracle-rds#define-archivelog-retention-hours) settings.
-          3. **Any critical error that prevents Stitch from replicating data**, such as a connection issue that prevents Stitch from connecting to the database or a [schema violation](#limitation-3--structural-changes). If the error persists past the log retention period, the log will be purged before Stitch can read it.
+          3. **For log retention settings that define a maximum size, the size is insufficient.** This is applicable to MongoDB integrations. When creating a replica set, this is defined using the replication `oplogSizeMB` configuration option. It can also be defined for an existing replica set using the [replSetResizeOplog](https://docs.mongodb.com/v4.0/reference/command/replSetResizeOplog/#dbcmd.replSetResizeOplog){:target="new"} command.
 
-          {{ section.back-to-list | flatify }}
+          4. **Any critical error that prevents Stitch from replicating data**, such as a connection issue that prevents Stitch from connecting to the database or a [schema violation](#limitation-3--structural-changes). If the error persists past the log retention period, the log will be purged before Stitch can read it.
+
+        sub-subsections:
+          - title: "MongoDB: Affected tables will be re-replicated in full"
+            anchor: "limitation--log-retention--full-re-replication"
+            summary: "**Affected collections will be re-replicated in full**. This is applicable to MongoDB database integrations."
+            content: |
+              When logs age out for a MongoDB database integration, the affected collections will be re-replicated in full and the following will surface in the [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}):
+
+              {% capture code %}{{ site.data.errors.extraction.databases.mongo.raw-error.oplog-age-out | strip }}
+              {% endcapture %}
+
+              {% include layout/code-snippet.html code=code language="shell"%}
+
+              To prevent collection re-replication, increase the maximum size of the OpLog with the [replSetResizeOplog](https://docs.mongodb.com/v4.0/reference/command/replSetResizeOplog/#dbcmd.replSetResizeOplog){:target="new"} command. **Note**: As the maximum size you need depends on your database, it may take some experimentation to identify the best setting. Mongo doesn't currently recommend an OpLog size.
+
+          - title: "MySQL and Oracle: Replication will stop"
+            anchor: "limitation--log-retention--stop-replication"
+            summary: "**Replication will stop**. This is applicable to MySQL and Oracle database integrations."
+            content: |
+              When logs age out for MySQL and Oracle database integrations, an extraction error similar to the following will surface in the [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}):
+
+              - **For MySQL databases**:
+                {% capture code %}{{ site.data.errors.extraction.databases.mysql.raw-error.log-retention-purge | strip }}
+                {% endcapture %}
+
+                {% include layout/code-snippet.html use-code-block=false code=code %}
+
+                ```shell
+              {{ code | lstrip | rstrip }}
+                ```
+
+              - **For Oracle databases**:
+                {% capture code %}{{ site.data.errors.extraction.databases.oracle.raw-error.missing-logfile | strip }}
+                {% endcapture %}
+
+                {% include layout/code-snippet.html use-code-block=false code=code %}
+
+                ```shell
+              {{ code | lstrip | rstrip }}
+                ```
+
+              To resolve the error, you'll need to [reset the integration from the {{ app.page-names.int-settings }} page]({{ link.replication.reset-rep-keys | prepend: site.baseurl }}). **Note**: This is different than resetting an individual table.
+
+              {{ section.back-to-list | flatify }}
+
 
 ## POSTGRES INCREASE DISK SPACE
       - title: "Limitation {{ forloop.index }}: Will increase source disk space usage (PostgreSQL)"


### PR DESCRIPTION
This PR addresses the following:

- DOC-1163: Fixes missing Primary Key error message in the Google BQ v2 loading reference
- DOC-1266: Adds info about MongoDD maximum oplog size to the MongoDB, Log-based Incremental Rep, and Database Extraction Errors pages.
- DOC-1317: Corrects SQL client to psql tool in the Amazon Redshift SORT/DIST keys tutorial 
