### PR TITLE
Multiple sources: GA release

### DIFF
--- a/_data/taps/versions/impact.yml
+++ b/_data/taps/versions/impact.yml
@@ -15,8 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
-    date-released: "July 1, 2020"
+    status: "released"
+    date-released: "July 1, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/kustomer.yml
+++ b/_data/taps/versions/kustomer.yml
@@ -15,8 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
-    date-released: "March 26, 2020"
+    status: "released" ## beta, released, deprecated
+    date-released: "March 26, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/lever.yml
+++ b/_data/taps/versions/lever.yml
@@ -8,15 +8,15 @@
 
 
 # -------------------------- #
-#   [INTEGRATION] VERSIONS   #
+#        LEVER VERSIONS      #
 # -------------------------- #
 
 latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
-    date-released: "June 1, 2020"
+    status: "released" ## beta, released, deprecated
+    date-released: "June 1, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/netsuite-suite-analytics.yml
+++ b/_data/taps/versions/netsuite-suite-analytics.yml
@@ -6,8 +6,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
-    date-released: "May XX, 2020"
+    status: "released"
+    date-released: "June 4, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/surveymonkey.yml
+++ b/_data/taps/versions/surveymonkey.yml
@@ -15,8 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
-    date-released: "February 26, 2020"
+    status: "released" ## beta, released, deprecated
+    date-released: "February 26, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/ujet.yml
+++ b/_data/taps/versions/ujet.yml
@@ -15,8 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
-    date-released: "March 4, 2020"
+    status: "released" ## beta, released, deprecated
+    date-released: "March 4, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/workday-raas.yml
+++ b/_data/taps/versions/workday-raas.yml
@@ -15,8 +15,8 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta" ## beta, released, deprecated
-    date-released: "March 9, 2020"
+    status: "released" ## beta, released, deprecated
+    date-released: "March 9, 2020" # Full release: September 2, 2020
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""


### PR DESCRIPTION
This PR moves the following integrations to `released` status:

- Kustomer
- Impact
- Lever
- Netsuite Suite Analytics
- Ujet
- Survey Monkey
- Workday RaaS