### PR TITLE
PostgreSQL/v1 - Remove date-time formats from data typing

### DIFF
--- a/_data/taps/extraction/data-types/postgres/v1.yml
+++ b/_data/taps/extraction/data-types/postgres/v1.yml
@@ -109,7 +109,6 @@ smallint:
 
 time:
   stitch-type: "string"
-  format: "date-time"
 
 timestamp:
   stitch-type: "string"


### PR DESCRIPTION
Removes the `format: "date-time" ` line to more accurately represent the tap's functionality