### PR TITLE
PostgreSQL/v15-10-2015 - Update time format for data typing

### DIFF
--- a/_data/taps/extraction/data-types/postgres/v15-10-2015.yml
+++ b/_data/taps/extraction/data-types/postgres/v15-10-2015.yml
@@ -97,7 +97,6 @@ smallint:
 
 time:
   stitch-type: "string"
-  format: "date-time"
 
 timestamp:
   stitch-type: "string"


### PR DESCRIPTION
Removes the `format: "date-time" from the time type to more accurately represent the previous integration's functionality