### PR TITLE
Table Reset Support for additional SaaS/file integrations

### DIFF
--- a/_database-integrations/amazon-s3/amazon-s3-csv-latest.md
+++ b/_database-integrations/amazon-s3/amazon-s3-csv-latest.md
@@ -59,7 +59,7 @@ loading-reports: true
 
 table-selection: true
 column-selection: true
-table-level-reset: false
+table-level-reset: true
 
 append-only-tables: true
 append-only-tables-description: "Unless Primary Keys are defined for the table, Append-Only loading will be used."

--- a/_saas-integrations/facebook-ads/facebook-ads-latest.md
+++ b/_saas-integrations/facebook-ads/facebook-ads-latest.md
@@ -40,6 +40,7 @@ cron-scheduling: false
 
 table-selection: true
 column-selection: true
+table-level-reset: true
 
 extraction-logs: true
 loading-reports: true

--- a/_saas-integrations/hubspot/v2/hubspot-v2.md
+++ b/_saas-integrations/hubspot/v2/hubspot-v2.md
@@ -40,6 +40,7 @@ cron-scheduling: true
 
 table-selection: true
 column-selection: true
+table-level-reset: true
 
 extraction-logs: true
 loading-reports: true

--- a/_saas-integrations/jira/v2/jira-v2.md
+++ b/_saas-integrations/jira/v2/jira-v2.md
@@ -42,6 +42,7 @@ cron-scheduling: true
 
 table-selection: true
 column-selection: true
+table-level-reset: true
 
 extraction-logs: true
 loading-reports: true


### PR DESCRIPTION
This PR updates the docs for the following integrations, which now have table-level reset support:

- Facebook Ads
- JIRA
- Amazon S3 CSV
- HubSpot