### PR TITLE
Release v1 of Intercom, Mixpanel, and Square

### DIFF
--- a/_data/taps/versions/intercom.yml
+++ b/_data/taps/versions/intercom.yml
@@ -15,15 +15,15 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
+    status: "released"
     date-released: "August 14, 2020"
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""
 
   - number: "02-02-2016" # not a singer tap
-    status: "released"
+    status: "deprecated"
     date-released: "February 2, 2016"
-    # date-last-connection:
+    date-last-connection: "October 1, 2020"
     deprecation-date: ""
     sunset-date: ""

--- a/_data/taps/versions/mixpanel.yml
+++ b/_data/taps/versions/mixpanel.yml
@@ -5,16 +5,16 @@
 latest-version: "1"
 
 released-versions:
-  - number: "23-12-2015"
-    status: "released"
-    date-released: "December 23, 2015"
-    # date-last-connection:
-    deprecation-date: ""
-    sunset-date: ""
-
   - number: "1"
-    status: "beta"
+    status: "released"
     date-released: "June 2, 2020"
     # date-last-connection:
     deprecation-date: ""
-    sunset-date: ""  
+    sunset-date: "" 
+
+  - number: "23-12-2015"
+    status: "deprecated"
+    date-released: "December 23, 2015"
+    date-last-connection: "October 1, 2020"
+    deprecation-date: ""
+    sunset-date: "" 

--- a/_data/taps/versions/square.yml
+++ b/_data/taps/versions/square.yml
@@ -5,16 +5,16 @@
 latest-version: "1"
 
 released-versions:
-  - number: "04-05-2016"
-    status: "released"
-    date-released: "May 4, 2016"
-    # date-last-connection:
-    deprecation-date: ""
-    sunset-date: ""
-
   - number: "1"
-    status: "beta"
+    status: "released"
     date-released: "August 27, 2020"
-    # date-last-connection:
+    # date-last-connection: 
     deprecation-date: ""
-    sunset-date: ""  
+    sunset-date: "" 
+
+  - number: "04-05-2016"
+    status: "deprecated"
+    date-released: "May 4, 2016"
+    date-last-connection: "October 1, 2020"
+    deprecation-date: ""
+    sunset-date: "" 


### PR DESCRIPTION
This PR releases v1 of Intercom, Mixpanel, and Square, and deprecates the sourcerer versions.