### PR TITLE
Release Trello and Adroll

### DIFF
--- a/_data/taps/versions/adroll.yml
+++ b/_data/taps/versions/adroll.yml
@@ -6,15 +6,15 @@ latest-version: "1"
 
 released-versions:
   - number: "1"
-    status: "beta"
-    date-released: ""
+    status: "released"
+    date-released: "July 24, 2020"
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""
     
   - number: "20-07-2017" # not a singer tap
-    status: "released"
+    status: "deprecated"
     date-released: "July 20, 2017"
-    # date-last-connection:
+    date-last-connection: "September 16, 2020"
     deprecation-date: ""
     sunset-date: ""  

--- a/_data/taps/versions/trello.yml
+++ b/_data/taps/versions/trello.yml
@@ -5,16 +5,16 @@
 latest-version: "1"
 
 released-versions:
-  - number: "15-12-2015"
-    status: "deprecated"
-    date-released: "December 21, 2015"
-    # date-last-connection:
-    deprecation-date: ""
-    sunset-date: ""
-
   - number: "1"
     status: "released"
     date-released: "June 10, 2020"
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""  
+    
+  - number: "15-12-2015"
+    status: "deprecated"
+    date-released: "December 21, 2015"
+    date-last-connection: "September 16, 2020"
+    deprecation-date: ""
+    sunset-date: ""

--- a/_data/taps/versions/trello.yml
+++ b/_data/taps/versions/trello.yml
@@ -6,14 +6,14 @@ latest-version: "1"
 
 released-versions:
   - number: "15-12-2015"
-    status: "released"
+    status: "deprecated"
     date-released: "December 21, 2015"
     # date-last-connection:
     deprecation-date: ""
     sunset-date: ""
 
   - number: "1"
-    status: "beta"
+    status: "released"
     date-released: "June 10, 2020"
     # date-last-connection:
     deprecation-date: ""


### PR DESCRIPTION
This PR releases v1 of Adroll and Trello and deprecates the sourcerer versions.