### PR TITLE
Support Issues: 10/26/2020

### DIFF
--- a/_data/destinations/databricks-delta/loading-errors.yml
+++ b/_data/destinations/databricks-delta/loading-errors.yml
@@ -17,3 +17,15 @@ float-out-of-range: "float ([float]) out of range for column [column_name]"
 decimal-out-of-range: "decimal ([decimal]) out of range for column [column_name]"
 
 long-out-of-range: "long ([long]) out of range for column [column_name]"
+
+all:
+  - message: |
+      The authorization header is malformed; the region '[STITCH_ACCOUNT_REGION]' is wrong; expecting '[S3_BUCKET_REGION]'
+    id: "s3-bucket-region-mismatch"
+    applicable-to: "Databricks Delta Lake destinations"
+    level: "critical"
+    category: "Amazon S3 bucket configuration"
+    summary: "Mismatched Amazon S3 and Stitch account regions"
+    cause: "The Amazon S3 bucket isn't in the same AWS region as your Stitch account."
+    fix-it: |
+      Use an Amazon S3 bucket that's in the same AWS region as your Stitch account. Currently, all Stitch accounts are in the `us-east-1` region. Your S3 bucket must be created in this region to use Databricks Delta Lake as your destination.

--- a/_data/errors/extraction/saas/pardot.yml
+++ b/_data/errors/extraction/saas/pardot.yml
@@ -1,0 +1,42 @@
+# -------------------------- #
+#    Pardot Errors    #
+# -------------------------- #
+
+## This file contains extraction errors and how to (potentially)
+## fix them for the Pardot integration.
+
+## An object containing raw error messages
+raw-error:
+  
+
+all:
+## OUT OF ORDER DATA
+  - message: "Detected out of order data. Current bookmark value [VALUE] is less than last bookmark value [VALUE]"
+    id: "out-of-order-data"
+    applicable-to: "Pardot v1 integrations"
+    level: "critical"
+    category: "Replication Keys"
+    version: "1" 
+    summary: "Replication Key values are out of order"
+    cause: |
+      The most current Replication Key value returned by the Pardot API is less than the value Stitch has saved.
+
+      Some of the fields Stitch uses as Replication Keys are reported in Pardot using the preferred timezone of the user who authorized the integration in Stitch. For example: If the authorizing user has their preferred timezone set to `EST`, affected fields will contain time data reported in that timezone.
+
+      During Daylight Savings Time, the authorizing user's preferred timezone can impact how time data is reported in Pardot and extracted by Stitch. 
+
+      For example:
+
+      ```
+      '2019-10-27 01:48:55',
+      '2019-10-27 01:54:08',
+      '2019-10-27 01:59:03',
+      '2019-10-27 01:00:17',  # Time reset back an hour for DST
+      '2019-10-27 01:03:53',
+      '2019-10-27 01:13:12'
+      ```
+
+      To prevent data discrepancies from occurring, Stitch's Pardot integration specifically checks for out of order data. When out of order data is detected, the Extraction will fail and result in this error in Stitch.
+      
+    fix-it: |
+      Re-authorize the integration in Stitch with a Pardot user who has their preferred timezone set to UTC. If possible, consider creating a dedicated API user with a UTC timezone for use in Stitch.

--- a/_data/urls.yaml
+++ b/_data/urls.yaml
@@ -344,6 +344,7 @@ troubleshooting:
 
 ## SaaS extraction errors
   google-sheets-extraction-errors: /troubleshooting/integrations/google-sheets-extraction-error-reference
+  pardot-extraction-errors: /troubleshooting/integrations/pardot-extraction-error-reference
 
 ## Connection Errors
   saas-connection-errors: /troubleshooting/integrations/saas-integration-connection-errors

--- a/_destinations/databricks-delta/guides/databricks-delta-destination-setup.md
+++ b/_destinations/databricks-delta/guides/databricks-delta-destination-setup.md
@@ -44,7 +44,10 @@ requirements:
   - item: |
       **An Amazon Web Services (AWS) account with a {{ destination.display_name }} deployment.** Instructions for configuring a {{ destination.display_name }} deployment are outside the scope of this tutorial; our instructions assume that you have {{ destination.display_name }} up and running. Refer to [Databricks' documentation]({{ site.data.destinations.databricks-delta.resource-links.configure-aws-account }}){:target="new"} for help configuring your AWS account with Databricks.
   - item: |
-      **An existing Amazon S3 bucket.** This bucket must be in the same AWS account as the Databricks deployment or have a cross-account bucket policy that allows access to the bucket from the AWS account with the Databricks deployment.
+      **An existing Amazon S3 bucket that must be:** 
+
+      - In the `us-east-1` region. Other regions aren't currently supported.
+      - In the same AWS account as the Databricks deployment or have a cross-account bucket policy that allows access to the bucket from the AWS account with the Databricks deployment.
   - item: |
       **Permissions to manage S3 buckets in AWS**. Your AWS user must be able to add and modify bucket policies in the AWS account or accounts where the S3 bucket and Databricks deployment reside.
   
@@ -57,6 +60,12 @@ steps:
   - title: "Configure S3 bucket access in AWS"
     anchor: "configure-s3-bucket-access-in-aws"
     content: |
+      {% capture s3-region-note %}
+      The S3 bucket you use must be in the `us-east-1` region in AWS. Using a bucket in another region isn't currently supported and will result [in errors in Stitch]({{ link.troubleshooting.dw-loading-errors | prepend: site.baseurl | append: "#s3-bucket-region-mismatch" }}).
+      {% endcapture %}
+
+      {% include important.html type="single-line" content=s3-region-note %}
+
       {% for substep in step.substeps %}
       - [Step 1.{{ forloop.index }}: {{ substep.title }}](#{{ substep.anchor }})
       {% endfor %}

--- a/_integration-schemas/marketo/activities.md
+++ b/_integration-schemas/marketo/activities.md
@@ -14,7 +14,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: "getLeadActivities"
+  name: "Get lead activities"
   doc-link: "http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Activities/getLeadActivitiesUsingGET"
 
 attributes:

--- a/_integration-schemas/marketo/activity_types.md
+++ b/_integration-schemas/marketo/activity_types.md
@@ -18,7 +18,7 @@ description: |
 
 replication-method: "Full Table"
 api-method:
-  name: "getAllActivityTypes"
+  name: "Get all activity types"
   doc-link: "http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Activities/getAllActivityTypesUsingGET"
 
 attributes:

--- a/_integration-schemas/marketo/campaigns.md
+++ b/_integration-schemas/marketo/campaigns.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: "getCampaigns"
+  name: "Get campaigns"
   doc-link: http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Campaigns/getCampaignsUsingGET
 
 attributes:

--- a/_integration-schemas/marketo/leads.md
+++ b/_integration-schemas/marketo/leads.md
@@ -8,21 +8,19 @@ singer-schema:
 description: |
   The `{{ table.name }}` table contains info about your {{ integration.display_name }} leads.
 
-  #### {{ integration.display_name }} Corona and Replication Method for Leads
+  Stitch replicates leads from {{ integration.display_name }} using the Bulk API. The Replication Key for this table varies depending on your {{ integration.display_name }} account setup:
 
-  Stitch replicates leads from {{ integration.display_name }} using the Bulk API. The replication method for this table will vary depending on your {{ integration.display_name }} account setup:
+  - **If updatedAt filtering is enabled**, this table will use `updatedAt` as the Replication Key
+  - **If updatedAt filtering isn't enabled,** this table will use `createdAt` as the Replication Key. Additionally, data will be loaded using [Append-Only loading]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}).
 
-  - **If Corona is enabled**, this table will use Incremental Replication based on an `updatedAt` timestamp included in the API query. 
-  - **If Corona isn't enabled**, this table will use Full Table Replication.
-
-  [Read more about Corona](#corona-replication).
+  [Read more about replicating this table](#leads-replication).
 
 replication-method: "Key-based Incremental"
 replication-key:
-  name: "updatedAt"
+  name: "updatedAt or createdAt"
 
 api-method:
-  name: "getLeads"
+  name: "Get leads"
   doc-link: "http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/getLeadsByFilterUsingGET"
 
 attributes:

--- a/_integration-schemas/marketo/lists.md
+++ b/_integration-schemas/marketo/lists.md
@@ -12,7 +12,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: "getLists"
+  name: "Get lists"
   doc-link: "http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Static_Lists/getListsUsingGET"
 
 attributes:

--- a/_integration-schemas/marketo/programs.md
+++ b/_integration-schemas/marketo/programs.md
@@ -10,7 +10,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 api-method:
-  name: "getPrograms"
+  name: "Get programs"
   doc-link: https://developers.marketo.com/rest-api/endpoint-reference/asset-endpoint-reference/#!/Programs/browseProgramsUsingGET
 
 attributes:

--- a/_integration-schemas/square/v1/customers.md
+++ b/_integration-schemas/square/v1/customers.md
@@ -1,0 +1,101 @@
+---
+tap: "square"
+version: "1"
+key: "square"
+
+name: "customers"
+doc-link: "https://developer.squareup.com/reference/square/customers-api/list-customers"
+singer-schema: "https://github.com/singer-io/tap-square/blob/master/tap_square/schemas/customers.json"
+description: |
+  The `{{ table.name }}` contains information about customer profiles associated with your {{ integration.display_name }} account.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: "List customers (v2)"
+  doc-link: "https://developer.squareup.com/reference/square/customers-api/list-customers"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The customer ID."
+    foreign-key-id: "customer-id"
+
+  - name: "updated_at"
+    type: "date-time"
+    replication-key: true
+    description: ""
+
+  - name: "address"
+    type: "object"
+    description: ""
+    subattributes:
+      - name: "locality"
+        type: "string"
+        description: ""
+
+      - name: "administrative_district_level_1"
+        type: "string"
+        description: ""
+
+      - name: "country"
+        type: "string" 
+        description: ""
+
+      - name: "address_line_1"
+        type: "string"
+        description: ""
+
+      - name: "postal_code"
+        type: "string"
+        description: ""
+
+  - name: "birthday"
+    type: "date-time"
+    description: ""
+
+  - name: "company_name"
+    type: "string"
+    description: ""
+
+  - name: "created_at"
+    type: "date-time"
+    description: ""
+
+  - name: "creation_source"
+    type: "string"
+    description: ""
+
+  - name: "email_address"
+    type: "string"
+    description: ""
+
+  - name: "family_name"
+    type: "string"
+    description: ""
+
+  - name: "given_name"
+    type: "string"
+    description: ""
+
+  - name: "nickname"
+    type: "string"
+    description: ""
+
+  - name: "note"
+    type: "string"
+    description: ""
+
+  - name: "phone_number"
+    type: "string"
+    description: ""
+
+  - name: "preferences"
+    type: "object"
+    description: ""
+    subattributes:
+      - name: "email_unsubscribed"
+        type: "boolean"
+        description: ""
+---

--- a/_saas-integrations/marketo/marketo-latest.md
+++ b/_saas-integrations/marketo/marketo-latest.md
@@ -165,40 +165,43 @@ setup-steps:
 
 
 replication-sections:
-  - title: "Stitch & Marketo Daily REST API Call Limits"
+  - content: |
+      {% for section in page.replication-sections %}
+      {% if section.title %}
+      - [{{ section.title }}](#{{ section.anchor }})
+      {% endif %}
+      {% endfor %}
+
+  - title: "Marketo Daily REST API call limits"
     anchor: "marketo-daily-api-call-limits"
     content: |
-      By default, all Marketo accounts have a maximum number of 50,000 daily account calls.
+      By default, all {{ integration.display_name }} accounts have a maximum number of 50,000 daily account calls.
        
-      The integration's **Max Daily API Calls** field dictates the quantity of your total API quota Stitch is allowed to use per 24 hour period. **Note**: This includes API usage from other apps. By default, Stitch's Marketo integration will use up to 40,000 of these calls per day, which can be increased or reduced by setting a **Max Daily API Calls** value.
+      The integration's **Max Daily API Calls** field dictates the quantity of your total API quota Stitch is allowed to use per 24 hour period. **Note**: This includes API usage from other apps. By default, Stitch's {{ integration.display_name }} integration will use up to 40,000 of these calls per day, which can be increased or reduced by setting a **Max Daily API Calls** value.
        
-      When the integration detects that the source account's quota usage has exceeded the specified **Max Daily API Calls** limit, Stitch will be unable to replicate any Marketo data until more API quota is available. If you find that the 50,000 total call limit isn't enough, contact Marketo support to inquire about raising your limit.
+      When the integration detects that the source account's quota usage has exceeded the specified **Max Daily API Calls** limit, Stitch will be unable to replicate any {{ integration.display_name }} data until more API quota is available. If you find that the 50,000 total call limit isn't enough, contact {{ integration.display_name }} support to inquire about raising your limit.
 
-  - title: "Activities and Leads Replication"
+  - title: "Activities and Leads replication"
     anchor: "activities-leads-replication"
     content: |
+      To efficiently replicate activity and lead data, Stitch's {{ integration.display_name }} integration uses the Bulk API to extract data. While this approach is more efficient than the REST API, it may also impact your overall row count and frequency with which data is replicated.
 
-      To efficiently replicate activity and lead data, Stitch's Marketo integration uses the Bulk API to extract data. While this approach is more efficient than the REST API, it may also impact your overall row count and frequency with which data is replicated.
+    subsections:
+      - title: "Leads replication"
+        anchor: "leads-replication"
+        content: |
+          To incrementally replicate `leads` data, Marketo requires the authorizing account to have the ability to filter using the `updatedAt` field. This allows Stitch to use an `updatedAt` query parameter to extract only new and updated data from the `leads` endpoint.
 
-      #### Leads Replication and Marketo Corona {#corona-replication}
+          If your account doesn't have this filter enabled, Stitch will use the `createdAt` field to incrementally replicate `leads` data. **Note**: This will result in data for this table using [Append-Only loading]({{ link.destinations.storage.loading-behavior | prepend: site.baseurl }}).
 
-      To incrementally replicate `leads` data, Marketo requires the authorizing account to have a feature called Corona. Corona allows Stitch to use an `updatedAt` query parameter to extract only new and updated data from the `leads` endpoint.
+      - title: "Bulk API limits"
+        anchor: "bulk-api-limits"
+        content: |
+          {% include note.html type="single-line" content="**Note**: This section applies to the `activity_[activity_types]` and `leads` tables. Bulk API call limits are a separate quota from REST API call limits." %}
 
-      If your account doesn't have Corona enabled, the `leads` table will use Full Table Replication. 
+          Part of the extraction process using the Bulk API involves writing and downloading a file of the extracted data. Stitch then pushes the data from this file into your destination.
 
-      Additionally, the following message will surface in the extraction logs:
-
-      ```
-      Your account does not have Corona support enabled. Without Corona, each sync of the Leads table requires a full export which can lead to lower data freshness. Please contact Marketo to request Corona support be added to your account.
-      ```
-
-      #### Bulk API Limits
-
-      Part of the extraction process using the Bulk API involves writing and downloading a file of the extracted data. Stitch then pushes the data from this file into your destination.
-
-      Marketo currently [limits the amount of data pulled on a daily basis to 500MB](http://developers.marketo.com/rest-api/bulk-extract/#limits). Exceeding the limit will pause replication until midnight CT, when it will be possible to resume.
-
-      **Note**: This applies to the `activity_[activity_types]` and `leads` tables and is a separate quota from the REST API call limits mentioned previously.
+          {{ integration.display_name }} currently [limits the amount of data pulled on a daily basis to 500MB](http://developers.marketo.com/rest-api/bulk-extract/#limits){:target="new"}. Exceeding the limit will pause replication until midnight CT, when it will be possible to resume.
 
 
 # -------------------------- #

--- a/_saas-integrations/pardot/v1/pardot-v1.md
+++ b/_saas-integrations/pardot/v1/pardot-v1.md
@@ -90,8 +90,12 @@ feature-summary: |
 #      Setup Instructions    #
 # -------------------------- #
 
+requirements-list:
+  - item: |
+      **A user with a preferred timezone of UTC.** This is required to ensure you don't encounter Extraction errors during Daylight Savings Time, as some Replication Key fields used by Stitch are reported in {{ integration.display_name }} using the user's preferred timezone. By using UTC, this ensures that time data is accurately reported during extraction. Otherwise, you might encounter [Extraction errors during Daylight Savings Time]({{ link.troubleshooting.pardot-extraction-errors | prepend: site.baseurl | append: "#out-of-order-data" }}).
+
 setup-steps:
-  - title: "Retrieve your {{ integration.display_name }} user key."
+  - title: "Retrieve your {{ integration.display_name }} user key"
     anchor: "retrieve-user-key"
     content: |
       1. Sign into your {{ integration.display_name }} account.
@@ -105,6 +109,7 @@ setup-steps:
       {% include integrations/shared-setup/connection-setup.html %}
       4. In the **Email** and **Password** fields, enter the email and password you use to access your {{ integration.display_name }} account.
       5. In the **User Key** field, enter the **API User Key** you retrieved in [step 1](#retrieve-user-key).
+
   - title: "Define the historical replication start date"
     anchor: "define-historical-sync"
     content: |

--- a/_troubleshooting/errors/destination-loading-errors.md
+++ b/_troubleshooting/errors/destination-loading-errors.md
@@ -50,6 +50,13 @@ sections:
 
       {% include troubleshooting/error-messages.html top-anchor="amazon-redshift-error-reference" display-name="Amazon Redshift" %}
 
+  - title: "Databricks Delta Lake loading errors"
+    anchor: "databricks-delta-lake-error-reference"
+    content: |
+      {% assign errors = site.data.destinations.databricks-delta.loading-errors.all | sort_natural:"message" %}
+
+      {% include troubleshooting/error-messages.html top-anchor="databricks-delta-lake-error-reference" display-name="Databricks Delta Lake" %}
+
   - title: "Google BigQuery loading errors"
     anchor: "google-bigquery-error-reference"
     content: |

--- a/_troubleshooting/errors/extraction-errors/saas/pardot-extraction-errors.md
+++ b/_troubleshooting/errors/extraction-errors/saas/pardot-extraction-errors.md
@@ -1,0 +1,36 @@
+---
+# -------------------------- #
+#      Page & Formatting     #
+# -------------------------- #
+
+title: Pardot Extraction Error Reference
+keywords: troubleshooting, integration, extraction error
+layout: general
+
+permalink: /troubleshooting/integrations/pardot-extraction-error-reference
+
+summary: "Extraction errors for Pardot integrations and how to resolve them."
+
+level: "guide"
+top-level: "replication"
+category: "extraction-errors"
+integration-type: "saas"
+
+type: "saas-integration, error, replication"
+
+
+# -------------------------- #
+#           Content          #
+# -------------------------- #
+
+sections:
+  - content: |
+      The errors in this guide are specific to Pardot integrations. Refer to the [Common SaaS extraction error reference]({{ link.troubleshooting.saas-extraction-errors | prepend: site.baseurl }}) for errors common to all SaaS integrations.
+
+      These errors will surface in the integration's [Extraction Logs]({{ link.replication.extraction-logs | prepend: site.baseurl }}).
+
+      {% assign errors = site.data.errors.extraction.saas.pardot.all | sort_natural:"message" %}
+
+      {% include troubleshooting/error-messages.html display-name="Pardot" %}
+---
+{% include misc/data-files.html %}


### PR DESCRIPTION
This PR:

- Adds a note about specific AWS region requirements for S3 bucket setup for Databricks Delta Lake destinations
- Adds a requirement to the Pardot docs to use a user with a UTC preferred timezone to auth the integration
- Removes Marketo Corona from the docs and clarifies how replicating the `leads` table works
- Adds the `customers` table to the Square integration docs