### PR TITLE
Pendo - update rep key

### DIFF
--- a/_integration-schemas/pendo/v1/visitor_history.md
+++ b/_integration-schemas/pendo/v1/visitor_history.md
@@ -1,8 +1,6 @@
 ---
-# 10/21/20: Commenting out as per Brian due to a bug. Team will address before initial beta.
-
-# tap: "pendo"
-# version: "1"
+tap: "pendo"
+version: "1"
 key: "visitor-history"
 
 name: "visitor_history"
@@ -27,7 +25,7 @@ attributes:
   - name: "modified_ts"
     type: "date-time"
     replication-key: true
-    description: ""
+    description: "The time the visitor was last modified."
 
   - name: "last_ts"
     type: "date-time"

--- a/_integration-schemas/pendo/v1/visitor_history.md
+++ b/_integration-schemas/pendo/v1/visitor_history.md
@@ -24,9 +24,13 @@ attributes:
     description: "The visitor ID."
     foreign-key-id: "visitor-id"
 
-  - name: "last_ts"
+  - name: "modified_ts"
     type: "date-time"
     replication-key: true
+    description: ""
+
+  - name: "last_ts"
+    type: "date-time"
     description: ""
 
   - name: "app_id"


### PR DESCRIPTION
This PR uncomments the `visitor_history` table and updates its Replication Key as per https://github.com/singer-io/tap-pendo/pull/17.