### PR TITLE
Shopify - Add attribute to customers table

### DIFF
--- a/_integration-schemas/shopify/customers.md
+++ b/_integration-schemas/shopify/customers.md
@@ -38,6 +38,10 @@ attributes:
     type: "boolean"
     description: "Indicates if the customer has consented to receive marketing emails."
 
+  - name: "accepts_marketing_updated_at"
+    type: "date-time"
+    description: "An ISO 8601-formated date of when the customer consented to receive marketing emails."
+
   - name: "addresses"
     type: "array"
     description: "A list of the 10 most recently updated addresses for the customer."


### PR DESCRIPTION
Adds `accepts_marketing_updated_at` field to the customer table.

Context: This is the Sources' PR for this update: https://github.com/singer-io/tap-shopify/pull/69/files
It says that they added this as an `anyOf` field, but the Shopify docs says that this is a date-time field. I put in in the docs as a date-time field too.