### PR TITLE
Pendo - update rep keys

### DIFF
--- a/_integration-schemas/pendo/v1/guide_events.md
+++ b/_integration-schemas/pendo/v1/guide_events.md
@@ -12,8 +12,6 @@ description: |
   {{ event-replication-note }}
 
 replication-method: "Key-based Incremental"
-replication-key:
-  name: "day or hour"
 
 attribution-window: true
 
@@ -38,6 +36,11 @@ attributes:
     primary-key: true
     description: ""
 
+  - name: "browser_time"
+    type: "date-time"
+    description: ""
+    replication-key: true  
+
   - name: "visitor_id"
     type: "string"
     description: ""
@@ -56,10 +59,6 @@ attributes:
     type: "string"
     description: ""
     foreign-key-id: "app-id"
-
-  - name: "browser_time"
-    type: "date-time"
-    description: ""
 
   - name: "country"
     type: "string"

--- a/_integration-schemas/pendo/v1/guides.md
+++ b/_integration-schemas/pendo/v1/guides.md
@@ -10,8 +10,6 @@ description: |
   The `{{ table.name }}` table contains info about the guides in your {{ integration.display_name }} account.
 
 replication-method: "Key-based Incremental"
-replication-key:
-  name: "browserTime"
 
 api-method:
   name: "Aggregation"
@@ -27,6 +25,7 @@ attributes:
   - name: "last_updated_at"
     type: "date-time"
     description: ""
+    replication-key: true
 
   - name: "attributes"
     type: "object"

--- a/_integration-schemas/pendo/v1/guides.md
+++ b/_integration-schemas/pendo/v1/guides.md
@@ -10,6 +10,8 @@ description: |
   The `{{ table.name }}` table contains info about the guides in your {{ integration.display_name }} account.
 
 replication-method: "Key-based Incremental"
+replication-key:
+  name: "browserTime"
 
 api-method:
   name: "Aggregation"
@@ -24,7 +26,6 @@ attributes:
 
   - name: "last_updated_at"
     type: "date-time"
-    replication-key: true
     description: ""
 
   - name: "attributes"

--- a/_integration-schemas/pendo/v1/poll_events.md
+++ b/_integration-schemas/pendo/v1/poll_events.md
@@ -12,8 +12,6 @@ description: |
   {{ event-replication-note }}
 
 replication-method: "Key-based Incremental"
-replication-key:
-  name: "browserTime"
 
 attribution-window: true
 
@@ -39,6 +37,11 @@ attributes:
     description: ""
     foreign-key-id: "visitor-id"
 
+  - name: "browser_time"
+    type: "date-time"
+    description: ""
+    replication-key: true  
+
   - name: "account_ids"
     type: "array"
     description: "A list of accounts the visitor (`visitor_id`) belongs to."
@@ -47,10 +50,6 @@ attributes:
         type: "string"
         description: "The account ID."
         foreign-key-id: "account-id"
-
-  - name: "browser_time"
-    type: "date-time"
-    description: ""
 
   - name: "country"
     type: "string"

--- a/_integration-schemas/pendo/v1/poll_events.md
+++ b/_integration-schemas/pendo/v1/poll_events.md
@@ -13,7 +13,7 @@ description: |
 
 replication-method: "Key-based Incremental"
 replication-key:
-  name: "day or hour"
+  name: "browserTime"
 
 attribution-window: true
 


### PR DESCRIPTION
change `guides` and `poll_events` tables' replication keys to `browserTime` (source: https://github.com/singer-io/tap-pendo/pull/21)