### PR TITLE
Change Log Entries - starting from 2021-03-09

### DIFF
--- a/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
+++ b/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
@@ -11,4 +11,4 @@ pull-request: "https://github.com/singer-io/tap-adwords/pull/77"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Logic was updated for {{ this-connection.display_name }} to be able to handle common errors. There are now custom messages on these errors to give more specific information about the error.
+We've updated the {{ this-connection.display_name }} integration to return actionable messages when Stitch encounters errors during Extraction. These messages now include the cause of the error, ensuring you can take action to resolve it.

--- a/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
+++ b/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
@@ -11,4 +11,4 @@ pull-request: "https://github.com/singer-io/tap-adwords/pull/77"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Logic was updated for {{ this-connection.display_name }} to be able to handle common error with custom messages.
+Logic was updated for {{ this-connection.display_name }} to be able to handle common errors. There are now custom messages on these errors to give more specific information about the error.

--- a/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
+++ b/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
@@ -1,0 +1,13 @@
+---
+title: "Google Analytics (AdWords) improvement: New custom messages for common errors"
+content-type: "changelog-entry"
+date: 2021-03-09
+entry-type: improvement
+entry-category: "integration"
+connection-id: "google-analytics-adwords"
+connection-version: "05-12-2017"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+Logic was updated for {{ this-connection.display_name }} to be able to handle common error with custom messages.

--- a/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
+++ b/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
@@ -1,5 +1,5 @@
 ---
-title: "Google Analytics (AdWords) improvement: New custom messages for common errors"
+title: "Google Ads (v1) improvement: New custom messages for common errors"
 content-type: "changelog-entry"
 date: 2021-03-09
 entry-type: improvement

--- a/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
+++ b/_changelog/entries/2021/2021-03-09-adwords-v05-02-2017-common-error-messages.md
@@ -4,8 +4,9 @@ content-type: "changelog-entry"
 date: 2021-03-09
 entry-type: improvement
 entry-category: "integration"
-connection-id: "google-analytics-adwords"
-connection-version: "05-12-2017"
+connection-id: "google-ads"
+connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-adwords/pull/77"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}

--- a/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
+++ b/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
@@ -1,0 +1,13 @@
+---
+title: Pendo (v1) bug fix: Custom fields error resolved
+content-type: "changelog-entry"
+date: 2021-03-10
+entry-type: bug-fix
+entry-category: "integration"
+connection-id: "pendo"
+connection-version: "1"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+Issues with custom field display and selection have been resolved for {{ this-connection.display_name }}'s `visitors` and `accounts` tables.

--- a/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
+++ b/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
@@ -1,5 +1,5 @@
 ---
-title: Pendo (v1) bug fix: Custom fields error resolved
+title: "Pendo (v1) bug fix: Custom fields error resolved"
 content-type: "changelog-entry"
 date: 2021-03-10
 entry-type: bug-fix
@@ -11,4 +11,7 @@ pull-request: "https://github.com/singer-io/tap-pendo/pull/27"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Issues with custom field display and selection have been resolved for {{ this-connection.display_name }}'s `visitors` and `accounts` tables.
+Fixes made to the `visitors` and `accounts` tables:
+
+1. Custom fields without defined types will no longer return a `null` value. 
+2. The last property on tables with multiple custom fields were being overwritten. New code was added to avoid this.

--- a/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
+++ b/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
@@ -1,5 +1,5 @@
 ---
-title: "Pendo (v1) bug fix: Custom fields error resolved"
+title: "Pendo (v1) bug fix: Custom field issues for visitors and accounts tables"
 content-type: "changelog-entry"
 date: 2021-03-10
 entry-type: bug-fix
@@ -11,7 +11,7 @@ pull-request: "https://github.com/singer-io/tap-pendo/pull/27"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Fixes made to the `visitors` and `accounts` tables:
+We've fixed a few issues with the {{ this-connection.display_name }} `visitors` and `accounts` tables:
 
-1. Custom fields without defined types will no longer return a `null` value. 
-2. The last property on tables with multiple custom fields were being overwritten. New code was added to avoid this.
+1. Custom fields without a defined data type will no longer return a `null` value.
+2. If a table had multiple custom fields, the last field on the table was being overwritten. We've updated the integration to address this.

--- a/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
+++ b/_changelog/entries/2021/2021-03-10-pendo-v1-accounts-visitors-custom-fields.md
@@ -6,6 +6,7 @@ entry-type: bug-fix
 entry-category: "integration"
 connection-id: "pendo"
 connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-pendo/pull/27"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}

--- a/_changelog/entries/2021/2021-03-11-salesforce-v1-error-message-formatting.md
+++ b/_changelog/entries/2021/2021-03-11-salesforce-v1-error-message-formatting.md
@@ -1,13 +1,14 @@
 ---
-title: Salesforce (v1) improvement: Error message formatting
+title: "Salesforce (v1) improvement: Error message formatting"
 content-type: "changelog-entry"
 date: 2021-03-11
 entry-type: improvement
 entry-category: "integration"
 connection-id: "salesforce"
 connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-salesforce/pull/96"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Improvements made the formatting of {{ this-connection.display_name }}'s error messages.
+There are now actionable error messages when `QUERY_TOO_COMPLICATED` errors are encountered for the {{ this-connection.display_name }} integration.

--- a/_changelog/entries/2021/2021-03-11-salesforce-v1-error-message-formatting.md
+++ b/_changelog/entries/2021/2021-03-11-salesforce-v1-error-message-formatting.md
@@ -1,0 +1,13 @@
+---
+title: Salesforce (v1) improvement: Error message formatting
+content-type: "changelog-entry"
+date: 2021-03-11
+entry-type: improvement
+entry-category: "integration"
+connection-id: "salesforce"
+connection-version: "1"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+Improvements made the formatting of {{ this-connection.display_name }}'s error messages.

--- a/_changelog/entries/2021/2021-03-11-zuora-v1-aqua-jobs-rate-limit.md
+++ b/_changelog/entries/2021/2021-03-11-zuora-v1-aqua-jobs-rate-limit.md
@@ -1,0 +1,14 @@
+
+---
+title: Zuora (v1) improvement: Updated discovery process for new enforced limit on AQuA jobs
+content-type: "changelog-entry"
+date: 2021-03-11
+entry-type: improvement, updated-feature
+entry-category: "integration"
+connection-id: "zuora"
+connection-version: "1"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+The new discovery process helps avoid {{ this-connection.display_name }} integration failures due to the new enforcement of limits on AQuA jobs. For more information on {{ this-connection.display_name }}'s AQuA API, click [here](https://knowledgecenter.zuora.com/Central_Platform/API/AB_Aggregate_Query_API/AA_AQuA_API_Introduction){:target="new"}.

--- a/_changelog/entries/2021/2021-03-11-zuora-v1-aqua-jobs-rate-limit.md
+++ b/_changelog/entries/2021/2021-03-11-zuora-v1-aqua-jobs-rate-limit.md
@@ -1,12 +1,12 @@
-
 ---
-title: Zuora (v1) improvement: Updated discovery process for new enforced limit on AQuA jobs
+title: "Zuora (v1) improvement: Updated discovery process for new enforced limit on AQuA jobs"
 content-type: "changelog-entry"
 date: 2021-03-11
-entry-type: improvement, updated-feature
+entry-type: updated-feature
 entry-category: "integration"
 connection-id: "zuora"
 connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-zuora/pull/53"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}

--- a/_changelog/entries/2021/2021-03-12-mongodb-v2-remove-duplicate-instances.md
+++ b/_changelog/entries/2021/2021-03-12-mongodb-v2-remove-duplicate-instances.md
@@ -1,11 +1,12 @@
 ---
-title: MongoDB (v2) improvement: Duplicate database instances removed
+title: "MongoDB (v2) bug fix: Duplicate database instances removed"
 content-type: "changelog-entry"
 date: 2021-03-12
-entry-type: improvement
+entry-type: bug-fix
 entry-category: "integration"
 connection-id: "mongodb"
 connection-version: "2"
+pull-request: "https://github.com/singer-io/tap-mongodb/pull/58"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}

--- a/_changelog/entries/2021/2021-03-12-mongodb-v2-remove-duplicate-instances.md
+++ b/_changelog/entries/2021/2021-03-12-mongodb-v2-remove-duplicate-instances.md
@@ -1,0 +1,13 @@
+---
+title: MongoDB (v2) improvement: Duplicate database instances removed
+content-type: "changelog-entry"
+date: 2021-03-12
+entry-type: improvement
+entry-category: "integration"
+connection-id: "mongodb"
+connection-version: "2"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+This improvement removes duplicate instances of databases from the list of discovered databases in the Stitch {{ this-connection.display_name }} inegration. 

--- a/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
+++ b/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
@@ -1,13 +1,14 @@
 ---
-title: Pendo (v1) improvement: using ijson to improve `visitors` and `events` replication
+title: "Pendo (v1) improvement: Improve performance for `visitors` and `events` tables"
 content-type: "changelog-entry"
 date: 2021-03-12
 entry-type: improvement
 entry-category: "integration"
 connection-id: "pendo"
 connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-pendo/pull/28"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-ijson is now being used for {{ this-connection.display_name }}'s `visitors` and `events` streams to improve performance. It reduces the amount of memory needed to replicate its potentially large amounts of data.
+We've implemented [ijson](https://github.com/ICRAR/ijson), which is used in other Singer taps, to streamline replication for {{ this-connection.display_name }}'s `visitors` and `events` tables. This improvement reduces the amount of memory needed to replicate large amounts of data, potentially leading to improved Extraction times.

--- a/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
+++ b/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
@@ -11,4 +11,4 @@ pull-request: "https://github.com/singer-io/tap-pendo/pull/28"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-We've implemented [ijson](https://github.com/ICRAR/ijson), which is used in other Singer taps, to streamline replication for {{ this-connection.display_name }}'s `visitors` and `events` tables. This improvement reduces the amount of memory needed to replicate large amounts of data, potentially leading to improved Extraction times.
+We've implemented [ijson](https://github.com/ICRAR/ijson){:target="new"}, which is used in other Singer taps, to streamline replication for {{ this-connection.display_name }}'s `visitors` and `events` tables. This improvement reduces the amount of memory needed to replicate large amounts of data, potentially leading to improved Extraction times.

--- a/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
+++ b/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
@@ -1,0 +1,13 @@
+---
+title: Pendo (v1) improvement: using ijson to improve `visitors` and `events` replication
+content-type: "changelog-entry"
+date: 2021-03-12
+entry-type: improvement
+entry-category: "integration"
+connection-id: "pendo"
+connection-version: "1"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+ijson is now being used for {{ this-connection.display_name }}'s `visitors` and `events` streams to improve performance. It reduces the amount of memory needed to replicate its potentially large amounts of data.

--- a/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
+++ b/_changelog/entries/2021/2021-03-12-pendo-v1-ijson-performance-enhancement.md
@@ -1,5 +1,5 @@
 ---
-title: "Pendo (v1) improvement: Improve performance for `visitors` and `events` tables"
+title: "Pendo (v1) improvement: Improve performance for visitors and events tables"
 content-type: "changelog-entry"
 date: 2021-03-12
 entry-type: improvement

--- a/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
+++ b/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
@@ -1,0 +1,13 @@
+---
+title: Zoom (v1) update: Fixed schema for `report_meetings` and `webinars`
+content-type: "changelog-entry"
+date: 2021-03-15
+entry-type: improvement
+entry-category: "integration"
+connection-id: "zoom"
+connection-version: "1"
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+Schema fixed for {{ this-connection.display_name }}'s `report_meetings` and `webinars`.

--- a/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
+++ b/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
@@ -1,5 +1,5 @@
 ---
-title: "Zoom (v1) update: Updated data for `report_meetings` and `report_webinars` tables"
+title: "Zoom (v1) update: Updated data for report_meetings and report_webinars tables"
 content-type: "changelog-entry"
 date: 2021-03-15
 entry-type: updated-feature

--- a/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
+++ b/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
@@ -1,13 +1,17 @@
 ---
-title: Zoom (v1) update: Fixed schema for `report_meetings` and `webinars`
+title: "Zoom (v1) update: Updated data for `report_meetings` and `report_webinars` tables"
 content-type: "changelog-entry"
 date: 2021-03-15
-entry-type: improvement
+entry-type: updated-feature
 entry-category: "integration"
 connection-id: "zoom"
 connection-version: "1"
+pull-request: "https://github.com/singer-io/tap-zoom/pull/4"
 ---
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
-Schema fixed for {{ this-connection.display_name }}'s `report_meetings` and `webinars`.
+
+1. The `dept` attribute was returning a `string` value instead of an `integer`. The update corrects that attribute for the `report_meetings` and `report_webinars` tables. 
+
+2. The following fields were added to the `report_webinars` table: `host_id`, `user_id`.

--- a/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
+++ b/_changelog/entries/2021/2021-03-15-zoom-v1-fixed-schema-report-meetings-webinars.md
@@ -11,7 +11,7 @@ pull-request: "https://github.com/singer-io/tap-zoom/pull/4"
 
 {{ site.data.changelog.metadata.single-integration | flatify }}
 
+We've made a few updates to the {{ this-connection.display_name }} `report_meetings` and `report_webinars` tables
 
-1. The `dept` attribute was returning a `string` value instead of an `integer`. The update corrects that attribute for the `report_meetings` and `report_webinars` tables. 
-
-2. The following fields were added to the `report_webinars` table: `host_id`, `user_id`.
+1. The `dept` attribute in both tables now correctly returns an `integer` instead of a `string`
+2. We've added the `host_id` and `user_id` fields to the `report_webinars` table


### PR DESCRIPTION
This PR adds changelog entries for these pull requests:

- https://github.com/singer-io/tap-adwords/pull/77
- https://github.com/singer-io/tap-mongodb/pull/58
- https://github.com/singer-io/tap-pendo/pull/27
- https://github.com/singer-io/tap-pendo/pull/28
- https://github.com/singer-io/tap-salesforce/pull/96
- https://github.com/singer-io/tap-zoom/pull/4
- https://github.com/singer-io/tap-zuora/pull/53