### PR TITLE
PostgreSQL/v2 - Add Key-based Incremental support

### DIFF
--- a/_changelog/entries/2021/2021-03-30-postgres-v2-key-incremental-support.md
+++ b/_changelog/entries/2021/2021-03-30-postgres-v2-key-incremental-support.md
@@ -1,0 +1,16 @@
+---
+title: "PostgreSQL (v2) integrations: Key-based Incremental Replication now available!"
+content-type: "changelog-entry"
+date: 2021-03-30
+entry-type: updated-feature
+entry-category: integration
+connection-id: postgres
+connection-version: 2
+---
+
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+{% assign all-postgres = site.database-integrations | where:"key","postgres-integration" %}
+{% assign postgres-overview = all-postgres | where:"content-type","database-category" | first %}
+
+The (v{{ this-connection.this-version }}) of our {{ this-connection.display_name }} integration, which is currently in open beta, now supports Key-based Incremental Replication. All of Stitch's supported Replication Methods are now available for this version - go try it out!

--- a/_database-integrations/postgres/vanilla/v2/postgres-v2.md
+++ b/_database-integrations/postgres/vanilla/v2/postgres-v2.md
@@ -77,7 +77,7 @@ log-based-replication-read-replica-doc-link: |
 
 ## Other Replication Methods
 
-key-based-incremental-replication: false
+key-based-incremental-replication: true
 full-table-replication: true
 
 view-replication: true
@@ -116,7 +116,6 @@ feature-summary: |
   
   **Note**: The following features aren't currently supported, but will be before the integration leaves beta:
 
-  - Key-based Incremental Replication
   - `ARRAY` data type
 
   To get a look at how this version compares to the previous version of {{ integration.display_name }}, refer to the [{{ integration.display_name }} version comparison documentation]({{ postgres-overview.url | prepend: site.baseurl | append: "#supported-features" }}).


### PR DESCRIPTION
This PR updates the docs to reflect support for Key-based Incremental Replication for the PostgreSQL v2 integration.