### PR TITLE
Support updates: 5/11/2021

### DIFF
--- a/_data/connect/api.yml
+++ b/_data/connect/api.yml
@@ -518,14 +518,14 @@ data-structures:
 #       FORM PROPERTIES      #
 # -------------------------- #
 form-properties:
-  section: "#form-properties"
+  section: &form-properties "#form-properties"
 
 # -------------------------- #
 #     Destination Forms      #
 # -------------------------- #
 
   destination-forms:
-    section: "#destination-form-properties"
+    section: *form-properties
 
     postgresql:
       title: "PostgreSQL"
@@ -546,4 +546,4 @@ form-properties:
 #        Source Forms        #
 # -------------------------- #
   source-forms:
-    section: "#source-form-properties"
+    section: *form-properties

--- a/_data/connect/code-examples/streams.yml
+++ b/_data/connect/code-examples/streams.yml
@@ -55,7 +55,7 @@ request-bodies:
              {
                "breadcrumb": [],
                "metadata": {
-                 "selected": "true"
+                 "selected": true
                }
              }
            ]

--- a/_data/stitch/notifications/replication.yml
+++ b/_data/stitch/notifications/replication.yml
@@ -52,7 +52,6 @@ warning:
     opt-out: true
     content:
       - "A brief explanation of the issue"
-      - "The HTTP status code Stitch received"
       - "The webhook URL Stitch is attempting to deliver to"
     potential-causes:
       - "Issues with the webhook service Stitch is attempting to deliver to"
@@ -156,7 +155,7 @@ critical:
 
 
 # -------------------------- #
-#   JAMMED READ HEAD ERRORS  #
+#      SSH TUNNEL ERROR      #
 # -------------------------- #
   - id: "loader-tunnel-error"
     name: "SSH tunnel connection error"

--- a/_data/taps/extraction/data-types/postgres/v1.yml
+++ b/_data/taps/extraction/data-types/postgres/v1.yml
@@ -28,6 +28,9 @@ array:
 bigint:
   stitch-type: "integer"
 
+bigserial:
+  stitch-type: "integer"
+
 bit:
   stitch-type: "boolean"
 
@@ -100,7 +103,13 @@ nvarchar:
 real:
   stitch-type: "number"
 
+serial:
+  stitch-type: "integer"
+
 smallint:
+  stitch-type: "integer"
+
+smallserial:
   stitch-type: "integer"
 
 time:

--- a/_developer-content/connect/guides/api/select-tables-and-fields.md
+++ b/_developer-content/connect/guides/api/select-tables-and-fields.md
@@ -252,7 +252,7 @@ steps:
         anchor: "create-the-request-body"
         content: |
           {% capture quote %}'{% endcapture %}
-          To select a stream, you'll make a request to [POST {{ site.data.connect.core-objects.streams.update.name | flatify }}]({{ link.connect.api | append: site.data.connect.core-objects.streams.update.anchor | prepend: site.baseurl }}) with a request body that contains:
+          To select a stream, you'll make a request to [PUT {{ site.data.connect.core-objects.streams.update.name | flatify }}]({{ link.connect.api | append: site.data.connect.core-objects.streams.update.anchor | prepend: site.baseurl }}) with a request body that contains:
 
           1. The stream's `tap_stream_id`. **Note** This is different than the `stream_id`, which is always numeric.
 

--- a/_developer-files/connect/api/objects/destinations/v3/create-a-destination-v3.md
+++ b/_developer-files/connect/api/objects/destinations/v3/create-a-destination-v3.md
@@ -37,7 +37,7 @@ arguments:
   - name: "connection"
     required: true
     type: "object"
-    description: "A [Destination Form Properties object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_developer-files/connect/api/objects/destinations/v3/destination-object-v3.md
+++ b/_developer-files/connect/api/objects/destinations/v3/destination-object-v3.md
@@ -20,7 +20,7 @@ version: "3"
 object-attributes:
   - name: "connection"
     type: "object"
-    sub-type: "destination form properties"
+    sub-type: "connection property"
     url: "{{ api.form-properties.destination-forms.section }}"
     description: |
       Parameters for connecting to the destination, excluding any sensitive credentials.

--- a/_developer-files/connect/api/objects/destinations/v3/update-a-destination-v3.md
+++ b/_developer-files/connect/api/objects/destinations/v3/update-a-destination-v3.md
@@ -42,7 +42,7 @@ arguments:
   - name: "connection"
     required: true
     type: "object"
-    description: "A [Destination Form Properties object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_developer-files/connect/api/objects/destinations/v4/create-a-destination-v4.md
+++ b/_developer-files/connect/api/objects/destinations/v4/create-a-destination-v4.md
@@ -40,7 +40,7 @@ arguments:
   - name: "properties"
     required: true
     type: "object"
-    description: "A [Destination Form Property object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_developer-files/connect/api/objects/destinations/v4/destination-object-v4.md
+++ b/_developer-files/connect/api/objects/destinations/v4/destination-object-v4.md
@@ -44,7 +44,7 @@ object-attributes:
 
   - name: "properties"
     type: "object"
-    sub-type: "destination form properties"
+    sub-type: "connection property"
     url: "{{ api.form-properties.destination-forms.section }}"
     description: |
       Parameters for connecting to the destination, excluding any sensitive credentials. The parameters must adhere to the `type` of destination.

--- a/_developer-files/connect/api/objects/destinations/v4/update-a-destination-v4.md
+++ b/_developer-files/connect/api/objects/destinations/v4/update-a-destination-v4.md
@@ -37,7 +37,7 @@ arguments:
   - name: "properties"
     required: true
     type: "object"
-    description: "A [Destination Form Properties object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.destination-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_developer-files/connect/api/objects/notifications/custom-emails/create-custom-email-recipient.md
+++ b/_developer-files/connect/api/objects/notifications/custom-emails/create-custom-email-recipient.md
@@ -52,7 +52,7 @@ returns: |
 examples:
   - type: "Request"
     request-url: "{{ endpoint.short-url | flatify | strip_newlines }}"
-    header: "{{ site.data.connect.request-headers.put.with-body | flatify }}"
+    header: "{{ site.data.connect.request-headers.post.with-body | flatify }}"
     code: |
       '{
          "email_address": "stitch-custom-notification@yourdomain.com"

--- a/_developer-files/connect/api/objects/notifications/post-load-hooks/create-hook-notification.md
+++ b/_developer-files/connect/api/objects/notifications/post-load-hooks/create-hook-notification.md
@@ -67,7 +67,7 @@ returns: |
 examples:
   - type: "Request"
     request-url: "{{ endpoint.short-url | flatify | strip_newlines }}"
-    header: "{{ site.data.connect.request-headers.put.with-body | flatify }}"
+    header: "{{ site.data.connect.request-headers.post.with-body | flatify }}"
     code: |
       '{
          "type":"post_load",

--- a/_developer-files/connect/api/objects/sources/create-a-source.md
+++ b/_developer-files/connect/api/objects/sources/create-a-source.md
@@ -53,7 +53,7 @@ arguments:
   - name: "properties"
     required: false
     type: "object"
-    description: "A [Source Form Property object]({{ api.form-properties.source-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.source-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_developer-files/connect/api/objects/sources/sources-object.md
+++ b/_developer-files/connect/api/objects/sources/sources-object.md
@@ -96,7 +96,7 @@ object-attributes:
 
   - name: "properties"
     type: "object"
-    sub-type: " source form properties"
+    sub-type: "connection property"
     url: "{{ api.form-properties.source-forms.section }}"
     description: |
       Parameters for connecting to the source, excluding any sensitive credentials. The parameters must adhere to the `type` of source.

--- a/_developer-files/connect/api/objects/sources/update-a-source.md
+++ b/_developer-files/connect/api/objects/sources/update-a-source.md
@@ -58,7 +58,7 @@ arguments:
   - name: "properties"
     required: false
     type: "object"
-    description: "A [Source Form Property object]({{ api.form-properties.source-forms.section }}) corresponding to the value of `type`."
+    description: "A [Connection property object]({{ api.form-properties.source-forms.section }}) corresponding to the value of `type`."
 
 
 # -------------------------- #

--- a/_includes/integrations/shared-setup/aws-s3-iam-setup.html
+++ b/_includes/integrations/shared-setup/aws-s3-iam-setup.html
@@ -150,7 +150,7 @@ To create the IAM policy:
 4. Click **Create Policy**.
 5. In the **Create Policy** page, click the **JSON** tab.
 6. Select everything currently in the text field and delete it.
-7. In the text field, paste the Stitch IAM policy.
+7. In the text field, paste the IAM policy from the **{{ page-name }}** page in Stitch.
 8. Click **Review policy**.
 9. On the **Review Policy** page, give the policy a name. For example: `stitch_{{ integration.name | replace:"-","_" }}`
 10. Click **Create policy**.

--- a/_includes/integrations/shared-setup/configure-table-settings-file-server.html
+++ b/_includes/integrations/shared-setup/configure-table-settings-file-server.html
@@ -95,9 +95,9 @@ customers\.csv
 {% when 'define-search-directory' %}
 {% include note.html type="single-line" content="**This step is optional.** However, limiting the search to a single location can potentially reduce extraction time, especially if the server contains a large number of files." %}
 
-The **Directory** field limits the location of the file search Stitch performs during replication jobs. When defined, Stitch will only search for files in this location and select those that match the [search pattern](#define-search-pattern).
+The **Directory** field limits the location of the file search Stitch performs during replication jobs. When defined, Stitch will only search for files in this location and select those that match the [search pattern](#define-search-pattern). **Note**: This field is not a regular expression.
 
-To define a specific location in the {{ include.location }}, enter the directory path into the **Directory** field. For example: `data-exports/lists`. **Note**: This field is not a regular expression.
+To define a specific location in the {{ include.location }}, enter the directory path into the **Directory** field. For example: `data-exports/lists/` will exactly match `data-exports/lists/`.
 
 
 <!-- DEFINE TABLE NAME -->

--- a/_integration-schemas/braintree/transactions.yml
+++ b/_integration-schemas/braintree/transactions.yml
@@ -58,6 +58,58 @@ attributes:
     type: "string"
     description: "The order ID of the transaction."
 
+  - name: "paypal_details"
+    type: "array"
+    description: ""
+    subattributes:
+      - name: "authorization_id"
+        type: "string"
+        description: ""
+
+      - name: "capture_id"
+        type: "string"
+        description: ""
+
+      - name: "payer_email"
+        type: "string"
+        description: ""
+
+      - name: "payer_id"
+        type: "string"
+        description: ""
+
+      - name: "payer_status"
+        type: "string"
+        description: ""
+
+      - name: "payment_id"
+        type: "string"
+        description: ""
+
+      - name: "refund_id"
+        type: "string"
+        description: ""
+
+      - name: "seller_protection_status"
+        type: "string"
+        description: ""
+
+      - name: "tax_id"
+        type: "string"
+        description: ""
+
+      - name: "tax_id_type"
+        type: "string"
+        description: ""
+
+      - name: "transaction_fee_amount"
+        type: "string"
+        description: ""
+
+      - name: "transaction_fee_iso_code"
+        type: "string"
+        description: ""
+
   - name: "plan_id"
     type: "string"
     description: "The plan ID."

--- a/_integration-schemas/jira/v2/changelogs.md
+++ b/_integration-schemas/jira/v2/changelogs.md
@@ -9,11 +9,13 @@ singer-schema: "https://github.com/singer-io/tap-jira/blob/master/tap_jira/schem
 description: |
   The `{{ table.name }}` table contains info about the changelogs associated with an issue.
 
+  **Note**: Due to a {{ integration.display_name }} limitation in the endpoint Stitch uses to replicate changelogs, only the 100 most recent changelogs for any individual issue can be replicated. Refer to [{{ integration.display_name }}'s documentation](https://confluence.atlassian.com/jirakb/jira-cloud-rest-api-limits-the-number-of-changelogs-returned-938840277.html){:target="new"} for more info.
+
   #### Replication requirements {#replication-requirements-changelogs}
 
   To replicate this data:
 
-  1. The [`issues`](#issues) table must also be set to replicate. **Note**: When an issue is updated, all the changelogs for that issue will also be replicated.
+  1. The [`issues`](#issues) table must also be set to replicate. **Note**: When an issue is updated, all available changelogs for that issue will also be replicated.
 
   2. The `Browse Projects` [project {{ integration.display_name }} permission]({{ integration.project-permissions-doc }}){:target="new"} is required. Refer to [{{ integration.display_name }}'s API documentation]({{ table.doc-link }}){:target="new"} for more info.
 

--- a/_integration-schemas/linkedin-ads/v1/ad_analytics_by_campaign.md
+++ b/_integration-schemas/linkedin-ads/v1/ad_analytics_by_campaign.md
@@ -9,7 +9,10 @@ singer-schema: "https://github.com/singer-io/tap-linkedin-ads/blob/master/tap_li
 description: |
   The `{{ table.name }}` table contains analytics data for ads, segmented by campaign.
 
+  **Note**: This table is replicated using an attribution window of {{ integration.attribution-window }}. Refer to the [Replication](#replication) section for more info.
+
 replication-method: "Key-based Incremental"
+attribution-window: true
 
 api-method:
   name: "Analytics Finder; Creative"

--- a/_integration-schemas/linkedin-ads/v1/ad_analytics_by_creative.md
+++ b/_integration-schemas/linkedin-ads/v1/ad_analytics_by_creative.md
@@ -9,7 +9,10 @@ singer-schema: "https://github.com/singer-io/tap-linkedin-ads/blob/master/tap_li
 description: |
   The `{{ table.name }}` table contains info about ad analytics, segmented by creative.
 
+  **Note**: This table is replicated using an attribution window of {{ integration.attribution-window }}. Refer to the [Replication](#replication) section for more info.
+
 replication-method: "Key-based Incremental"
+attribution-window: true
 
 api-method:
   name: "Analytics Finder; Creative"

--- a/_integration-schemas/netsuite-suite-analytics/v1/budget.md
+++ b/_integration-schemas/netsuite-suite-analytics/v1/budget.md
@@ -20,23 +20,23 @@ attributes:
       {{ integration.netsuite-primary-keys | flatify }}
 
   - name: "budget_id"
-    type: "integer"
+    type: "number"
     netsuite-primary-key: true
     description: "The budget ID. {{ integration.netsuite-primary-key-description | flatify }}"
     # foreign-key-id: "budget-id"
 
   - name: "account_id"
-    type: "integer"
+    type: "number"
     description: "The account ID."
     foreign-key-id: "account-id"
 
   - name: "accounting_book_id"
-    type: "integer"
+    type: "number"
     description: "The accounting book ID."
     foreign-key-id: "accounting-book-id"
 
   - name: "accounting_period_id"
-    type: "integer"
+    type: "number"
     description: "The accounting period."
     foreign-key-id: "accounting-period-id"
 
@@ -49,37 +49,37 @@ attributes:
     description: "The date of the budget."
 
   - name: "category_id"
-    type: "integer"
+    type: "number"
     description: "The budget category ID."
     foreign-key-id: "budget-category-id"
 
   - name: "class_id"
-    type: "integer"
+    type: "number"
     description: "The class of the budget."
     foreign-key-id: "class-id"
 
   - name: "customer_id"
-    type: "integer"
+    type: "number"
     description: "The customer associated with the budget."
     foreign-key-id: "customer-id"
 
   - name: "department_id"
-    type: "integer"
+    type: "number"
     description: "The department associated with the budget."
     foreign-key-id: "department-id"
 
   - name: "item_id"
-    type: "integer"
+    type: "number"
     description: "The item associated with the budget."
     foreign-key-id: "item-id"
 
   - name: "location_id"
-    type: "integer"
+    type: "number"
     description: "The location associated with the budget."
     foreign-key-id: "location-id"
 
   - name: "subsidiary_id"
-    type: "integer"
+    type: "number"
     description: "The subsidiary associated with the budget."
     foreign-key-id: "subsidiary-id"
 ---

--- a/_replication/selecting-data/syncing-new-additional-columns.md
+++ b/_replication/selecting-data/syncing-new-additional-columns.md
@@ -47,7 +47,7 @@ For tables using Full Table Replication, data in the newly-synced column will be
 
 For tables using Incremental Replication, data in the newly-synced column will be available **only for rows added AFTER the column is synced. Existing rows must be backfilled to make the data available.**
 
-Getting newly-synced column data into existing rows requires a full re-ync of the table. Because this can significantly impact your row count and we don't want to re-replicate data without your say-so, we leave inserting newly-synced column data into existing rows up to you.
+Getting newly-synced column data into existing rows requires a full re-replication of the table. Because this can significantly impact your row count and we don't want to re-replicate data without your say-so, we leave inserting newly-synced column data into existing rows up to you.
 
 ---
 

--- a/_saas-integrations/linkedin-ads/v1/linkedin-ads-v1.md
+++ b/_saas-integrations/linkedin-ads/v1/linkedin-ads-v1.md
@@ -56,6 +56,13 @@ column-selection: true
 
 
 # -------------------------- #
+#        API Details         #
+# -------------------------- #
+
+attribution-window: "7 days"
+
+
+# -------------------------- #
 #      Setup Instructions    #
 # -------------------------- #
 
@@ -95,6 +102,31 @@ setup-steps:
     anchor: "setting-data-to-replicate"
     content: |
       {% include integrations/shared-setup/data-selection/object-selection.html %}
+
+
+# -------------------------- #
+#      Replication Info      #
+# -------------------------- #
+
+replication-sections:
+  - content: |
+      {% assign window = "Attribution Window" %}
+      {% assign table = "ad_analytics_by_campaign" %}
+      {% assign replication-key = "end_at" %}
+      {% assign start-date ="06/03/2017" %}
+      {% assign start-date-value = "June 3, 2017" %}
+      {% assign replication-key-historical = "2017-06-03 00:00:00" %}
+      {% assign replication-key-ongoing = "2017-09-24 00:00:00" %}
+
+      {% include integrations/saas/attribution-windows.html %}
+
+      Refer to the documentation for each of these tables in the next section for more info.
+
+      ### Attribution window examples
+
+      In the tabs below are examples of attribution windows behave during historical (initial) and ongoing replication jobs.
+
+      {% include integrations/saas/attribution-window-examples.html %}
 
 # -------------------------- #
 #     Integration Tables     #

--- a/_saas-integrations/yotpo/yotpo-v1.md
+++ b/_saas-integrations/yotpo/yotpo-v1.md
@@ -117,6 +117,7 @@ replication-sections:
       {% assign table = "reviews" %}
       {% assign replication-key = "created_at" %}
       {% assign start-date ="06/03/2017" %}
+      {% assign start-date-value = "June 3, 2017" %}
       {% assign replication-key-historical = "2017-06-03 00:00:00" %}
       {% assign replication-key-ongoing = "2017-09-01 00:00:00" %}
 

--- a/_webhook-integrations/branch.md
+++ b/_webhook-integrations/branch.md
@@ -59,13 +59,11 @@ tables:
 {% include misc/data-files.html %}
 
 {% contentfor setup %}
-{% include integrations/webhooks/webhook-setup.html %}
+{% include integrations/webhooks/webhook-setup.html %} For additional info on Branch webhooks, check out [Branch's webhooks documentation](https://dev.branch.io/getting-started/webhooks/guide/).
 
-For additional info on Branch webhooks, check out [Branch's webhooks documentation](https://dev.branch.io/getting-started/webhooks/guide/).
-
-1. Sign into your Branch account.
-2. In the side nav, click the [webhooks](https://dashboard.branch.io/webhook) option.
-3. Click **Add a new webhook**. 
+1. Sign into your {{ integration.display_name }} account.
+2. Open the [webhooks](https://dashboard.branch.io/data-import-export/webhooks){:target="new"} page on the {{ integration.display_name }} dashboard.
+3. Click **+ Add a new webhook**. 
 4. In the window that displays:
    - Paste your Stitch-generated webhook URL in the URL field.
    - Leave the method (`POST`) as-is.


### PR DESCRIPTION
This PR:

- Corrects cURL examples using the incorrect HTTP methods
- Clarifies behavior of the **Directory** field for file system-based database integrations
- Adds info about API limitations for `changelogs` in the JIRA integration
- Adds info about attribution windows for LinkedIn Ads integrations
- Fixes broken anchor links for connection property objects in the API docs
- Adds the `paypal_details` object to Braintree's `transactions` schema documentation
- Updates the setup instructions for Branch integrations based on their UI updates
- Fixes a few typos