### PR TITLE
Shopify - Shopify Plus permissions

### DIFF
--- a/_changelog/entries/2021/2021-06-24-shopify-v1-plus-permissions.md
+++ b/_changelog/entries/2021/2021-06-24-shopify-v1-plus-permissions.md
@@ -1,0 +1,15 @@
+---
+title: "Shopify (v1) update: Updated setup requirements for Shopify Plus plans"
+content-type: "changelog-entry"
+date: 2021-06-24
+entry-type: updated-feature
+entry-category: "integration, documentation"
+connection-id: "shopify"
+connection-version: "1"
+pull-request: "https://github.com/stitchdata/docs/pull/644"
+---
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+We've updated our [{{ this-connection.display_name }} documentation]({{ this-connection.url | prepend: site.baseurl | prepend: site.home }}#setup-requirements) to include info about the required permissions for users on {{ this-connection.display_name }} Plus plans.
+
+In general, **view-level** permissions should be sufficient to allow Stitch to replciate data. We recommend checking out [{{ this-connection.display_name }}'s Staff Permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for details on the permissions available in{{ this-connection.display_name }}.

--- a/_integration-schemas/shopify/customers.md
+++ b/_integration-schemas/shopify/customers.md
@@ -6,7 +6,7 @@ name: "customers"
 doc-link: "https://shopify.dev/docs/admin-api/rest/reference/customers"
 singer-schema: "https://github.com/singer-io/tap-shopify/blob/master/tap_shopify/schemas/customers.json"
 description: |
-  The `{{ table.name }}` table contains info about the shop's customers. This includes their contact details, order history, and email marketing preferences. Null values are now accepted for replication.
+  The `{{ table.name }}` table contains info about the shop's customers. This includes their contact details, order history, and email marketing preferences.
 
   #### Customer metafield data
 

--- a/_integration-schemas/shopify/customers.md
+++ b/_integration-schemas/shopify/customers.md
@@ -6,7 +6,7 @@ name: "customers"
 doc-link: "https://shopify.dev/docs/admin-api/rest/reference/customers"
 singer-schema: "https://github.com/singer-io/tap-shopify/blob/master/tap_shopify/schemas/customers.json"
 description: |
-  The `{{ table.name }}` table contains info about the shop's customers. This includes their contact details, order history, and email marketing preferences.
+  The `{{ table.name }}` table contains info about the shop's customers. This includes their contact details, order history, and email marketing preferences. Null values are now accepted for replication.
 
   #### Customer metafield data
 

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -68,10 +68,11 @@ feature-summary: |
 
 requirements-list:
   - item: |
-      **Admin Access**. Only {{ integration.display_name }} admin accounts can export data.
+      **Admin access in {{ integration.display_name }}**. This is required to allow Stitch to replicate data.
 
-requirements-info: |
-  **If you're on a {{ integration.display_name }} Plus plan**, Store owners can give staff members permissions to export orders, draft orders, products, inventory, and customer data. Read the [{{ integration.display_name }} Staff permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for more information.
+      **Note: If you're on a {{ integration.display_name }} Plus plan**, the permissions required may differ. Store owners can grant users permissions to export orders, draft orders, products, inventory, and customer data. In general, **view-level** permissions should be sufficient.
+      
+      Refer to the [{{ integration.display_name }} Staff permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for more information.
   
 setup-steps:
   - title: "Add {{ integration.display_name }} as a Stitch data source"
@@ -79,6 +80,7 @@ setup-steps:
     content: |
       {% include integrations/shared-setup/connection-setup.html %}
       4. In the **Shopify Shop** field, enter the name of the shop you want to connect to Stitch. For example: If the shop URL was `stitch-data.shopify.com`, you'd enter `stitch-data` into this field. 
+
   - title: "Define the historical replication start date"
     anchor: "define-historical-sync"
     content: |
@@ -96,6 +98,7 @@ setup-steps:
       2. Click **Log in**.
       3. After the authorization process is successfully completed, you'll be directed back to Stitch.
       4. Click {{ app.buttons.finish-int-setup }}.
+
   - title: "Set objects to replicate"
     anchor: "setting-data-to-replicate"
     content: |

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -66,8 +66,12 @@ feature-summary: |
 #      Setup Instructions    #
 # -------------------------- #
 
+requirements-list:
+  - item: |
+      **Admin Access**. Only {{ integration.display_name }} admin accounts can export data.
+
 requirements-info: |
-  Staff members on a {{ integration.display_name }} Plus plan cannot export data by default. Store owners can give staff members permissions export orders, draft orders, products, inventory, and customer data. Read the [{{ integration.display_name }} Staff permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for more information.
+  **If you're on a {{ integration.display_name }} Plus plan**, Store owners can give staff members permissions to export orders, draft orders, products, inventory, and customer data. Read the [{{ integration.display_name }} Staff permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for more information.
   
 setup-steps:
   - title: "Add {{ integration.display_name }} as a Stitch data source"

--- a/_saas-integrations/shopify/v1/shopify-v1.md
+++ b/_saas-integrations/shopify/v1/shopify-v1.md
@@ -57,7 +57,7 @@ row-usage-hog-reasons:
 # -------------------------- #
 #      Feature Summary       #
 # -------------------------- #
-
+ 
 feature-summary: |
   Stitch's {{ integration.display_name }} integration replicates data using the {{ integration.api | flatify | strip }}. Refer to the [Schema](#schema) section for a list of objects available for replication.
 
@@ -66,6 +66,9 @@ feature-summary: |
 #      Setup Instructions    #
 # -------------------------- #
 
+requirements-info: |
+  Staff members on a {{ integration.display_name }} Plus plan cannot export data by default. Store owners can give staff members permissions export orders, draft orders, products, inventory, and customer data. Read the [{{ integration.display_name }} Staff permissions documentation](https://help.shopify.com/en/manual/your-account/staff-accounts/staff-permissions#store-owner-permissions){:target="new"} for more information.
+  
 setup-steps:
   - title: "Add {{ integration.display_name }} as a Stitch data source"
     anchor: "add-stitch-data-source"


### PR DESCRIPTION
This PR adds info about possible permission requirements for Shopify Plus plan users to the Shopify docs.