### PR TITLE
Amazon S3 CSV/v1 - Add .gz compression + .jsonl file support

### DIFF
--- a/_data/taps/extraction/file-systems/file-requirements.yml
+++ b/_data/taps/extraction/file-systems/file-requirements.yml
@@ -7,23 +7,6 @@
 
 ## Ex: Amazon S3 CSV, SFTP, etc.
 
-file-types: &file-types |
-  - CSV (`.csv`)
-  - Text (`.txt`)
-  - gzip (`.gz`)
-
-compression-types: &compression-types "None"
-
-delimiters: &delimiters |
-  - Comma (`,`)
-  - Tab (`/t`)
-  - Pipe (`|`)
-
-encodings: &encodings |
-  UTF-8
-
-
-
 attributes:
   - name: "First-row header"
     all: |
@@ -33,24 +16,34 @@ attributes:
 
       2. **Files with the same first-row header values, if including multiple files in a table.** Stitch's {{ integration.display_name }} integration allows you to map several files to a single destination table. Header row values are used to determine a table's schema. For the best results, each file should have the same header row values.
 
-         **Note**: This is not the same as configuring multiple tables. See the [Search pattern](#define-table-search-pattern-and-name) section for examples.
+         **Note**: This isn't the same as configuring multiple tables. See the [Search pattern](#define-table-search-pattern-and-name) section for examples.
+  
   - name: "File types"
     all: |
       - CSV (`.csv`)
       - Text (`.txt`)
+      {% if integration.name == "amazon-s3-csv" %}
+      - JSONL (`.jsonl`)
+      {% endif %}
 
   - name: "Compression types"
     all: |
       These files must be correctly compressed or errors will surface during Extraction.
 
-      - gzip compressed files (`.gz`)
       - zip compressed archive (`.zip`)
+      - gzip compressed files (`.gz`)
+
+         **Note**: `.tar.gz` files aren't currently supported.
 
   - name: "Delimiters"
-    all: *delimiters
+    all: |
+      - Comma (`,`)
+      - Tab (`/t`)
+      - Pipe (`|`)
 
   - name: "Character encoding"
-    all: *encodings
+    all: |
+      UTF-8
 
 
 # ------------------------------- #

--- a/_data/taps/extraction/file-systems/file-requirements.yml
+++ b/_data/taps/extraction/file-systems/file-requirements.yml
@@ -40,8 +40,7 @@ attributes:
       - Text (`.txt`)
 
   - name: "Compression types"
-    amazon-s3-csv: "None"
-    sftp: |
+    all: |
       These files must be correctly compressed or errors will surface during Extraction.
 
       - gzip compressed files (`.gz`)


### PR DESCRIPTION
This PR adds `.gz` compression and `.jsonl` file type support for the Amazon S3 CSV integration.

Documents these PRs:

- https://github.com/singer-io/tap-s3-csv/pull/31
- https://github.com/singer-io/tap-s3-csv/pull/32