### PR TITLE
Campaign Manager (v1) - Update API from 3.2 to 3.5

### DIFF
--- a/_saas-integrations/campaign-manager/campaign-manager-v1.md
+++ b/_saas-integrations/campaign-manager/campaign-manager-v1.md
@@ -29,7 +29,7 @@ repo-url: https://github.com/singer-io/tap-doubleclick-campaign-manager
 this-version: "1"
 
 api: |
-  [DCM/DFA Reporting and Trafficking API](https://developers.google.com/doubleclick-advertisers/getting_started){:target="new"}
+  [Campaign Manager 360 API](https://developers.google.com/doubleclick-advertisers/getting_started){:target="new"}
 
 # -------------------------- #
 #       Stitch Details       #


### PR DESCRIPTION
The API has a new name, but the link is still the same.