### PR TITLE
Add debug logging

### DIFF
--- a/scripts/tap-generate-docs/src/tap_generate_docs.clj
+++ b/scripts/tap-generate-docs/src/tap_generate_docs.clj
@@ -211,8 +211,13 @@
                   :as property]]
   (let [property (if (contains? property-json-schema-partial "$ref")
                    (let [{:keys [file json-pointer]}
-                         (parse-json-schema-reference
-                          (property-json-schema-partial "$ref"))
+
+                         (try
+                           (parse-json-schema-reference
+                            (property-json-schema-partial "$ref"))
+                           (catch Exception err
+                             (println (str "Got an error processing " property))
+                             (throw err)))
 
                          _
                          (when (and (nil? file)


### PR DESCRIPTION
Log the bad field in the file we are currently processing

The old logs
```
vagrant@vagrant:/opt/code/docs$ ./bin/tap-generate-docs facebook
WARNING: Use of -A with clojure.main is deprecated, use -M instead
Processing file: /opt/code/tap-facebook/tap_facebook/schemas/campaigns.json
Writing converted /opt/code/tap-facebook/tap_facebook/schemas/campaigns.json to campaigns.md
Processing file: /opt/code/tap-facebook/tap_facebook/schemas/ads_insights.json
Execution error (ExceptionInfo) at tap-generate-docs/parse-json-schema-reference (tap_generate_docs.clj:176).
Malformed json-schema-reference

Full report at:
/tmp/clojure-15093173328980073991.edn
```

The new logs
```
vagrant@vagrant:/opt/code/docs$ ./bin/tap-generate-docs facebook
WARNING: Use of -A with clojure.main is deprecated, use -M instead
Processing file: /opt/code/tap-facebook/tap_facebook/schemas/campaigns.json
Writing converted /opt/code/tap-facebook/tap_facebook/schemas/campaigns.json to campaigns.md
Processing file: /opt/code/tap-facebook/tap_facebook/schemas/ads_insights.json
Got an error processing ["video_play_curve_actions" {"$ref" "ads_histogram_stats.json"}]
Execution error (ExceptionInfo) at tap-generate-docs/parse-json-schema-reference (tap_generate_docs.clj:176).
Malformed json-schema-reference

Full report at:
/tmp/clojure-3044349314439070184.edn
```

My goal is that you can quickly see that `ads_insights.json` has a field `"video_play_curve_actions"` that is causing us to error with `Malformed json-schema-reference`