### PR TITLE
Outreach/v1 - Add `name` to `events` table

### DIFF
--- a/_integration-schemas/outreach/v1/events.md
+++ b/_integration-schemas/outreach/v1/events.md
@@ -44,6 +44,10 @@ attributes:
     description: ""
     foreign-key-id: "mailing-id"
 
+  - name: "name"
+    type: "string"
+    description: ""
+
   - name: "payload"
     type: "object"
     description: ""


### PR DESCRIPTION
This PR adds the `name` field to the `events` table (https://github.com/singer-io/tap-outreach/pull/10)