### PR TITLE
Typeform/v1 - Add forms table

### DIFF
--- a/_changelog-files/2021/2021-05-21-typeform-v1-forms-table.md
+++ b/_changelog-files/2021/2021-05-21-typeform-v1-forms-table.md
@@ -1,0 +1,17 @@
+---
+title: "Typeform (v1) update: New forms table!"
+content-type: "changelog-entry"
+date: 2021-05-21
+entry-type: updated-feature
+entry-category: integration
+connection-id: typeform
+connection-version: 1
+pull-request: "https://github.com/singer-io/tap-typeform/pull/29"
+---
+{{ site.data.changelog.metadata.single-integration | flatify }}
+
+We've added a new table to our {{ this-connection.display_name }} (v{{ this-connection.this-version }}) integration!
+
+The new `forms` table contains info about the forms accesible to the user who authorized the {{ this-connection.display_name }} integration in Stitch.
+
+Learn more in [our documentation]({{ this-connection.url | prepend: site.baseurl | prepend: site.home | append: "#forms" }}).

--- a/_integration-schemas/typeform/foreign-keys.md
+++ b/_integration-schemas/typeform/foreign-keys.md
@@ -12,19 +12,19 @@ tap-reference: "typeform"
 version: "1"
 
 foreign-keys:
-# Forms doesn't currently have its own table, but it might some day
-  # - id: "form-id"
-  #   table: ""
-  #   attribute: "form_id"
-  #   all-foreign-keys:
-  #     - table: "forms"
+  - id: "form-id"
+    table: "forms"
+    attribute: "form_id"
+    all-foreign-keys:
+      - table: "forms"
+      - table: "questions"
 
   - id: "landing-id"
     table: "landings"
     attribute: "landing_id"
     all-foreign-keys:
-      - table: "landings"
       - table: "answers"
+      - table: "landings"
 
   - id: "question-id"
     table: "questions"

--- a/_integration-schemas/typeform/forms.md
+++ b/_integration-schemas/typeform/forms.md
@@ -1,0 +1,70 @@
+---
+tap: "typeform"
+version: "1"
+key: "form"
+
+name: "forms"
+doc-link: "https://developer.typeform.com/responses/"
+singer-schema: "https://github.com/singer-io/tap-typeform/blob/master/tap_typeform/schemas/forms.json"
+description: |
+  The `{{ table.name }}` table contains info about the forms (public and private) that are accesible by the user who authorized the integration in Stitch.
+
+replication-method: "Key-based Incremental"
+
+api-method:
+  name: "Retrieve forms"
+  doc-link: "https://developer.typeform.com/create/reference/retrieve-forms/"
+
+attributes:
+  - name: "id"
+    type: "string"
+    primary-key: true
+    description: "The form ID."
+    foreign-key-id: "form-id"
+
+  - name: "last_updated_at"
+    type: "string"
+    replication-key: true
+    description: "The time of the last update in the form."
+
+  - name: "self"
+    type: "object"
+    description: "The URL for the typeform."
+    subattributes: &href
+      - name: "href"
+        type: "string"
+        description: ""
+
+  - name: "settings"
+    type: "object"
+    description: ""
+    subattributes:
+      - name: "is_public"
+        type: "boolean"
+        description: ""
+
+      - name: "is_trial"
+        type: "boolean"
+        description: ""
+
+  - name: "theme"
+    type: "object"
+    description: "The URL for the theme the typeform uses."
+    subattributes: *href
+
+  - name: "title"
+    type: "string"
+    description: "The title of the form."
+
+  - name: "type"
+    type: "string"
+    description: ""
+
+  - name: "_links"
+    type: "object"
+    description: ""
+    subattributes:
+      - name: "type"
+        type: "string"
+        description: ""
+---

--- a/_integration-schemas/typeform/questions.md
+++ b/_integration-schemas/typeform/questions.md
@@ -19,7 +19,7 @@ attributes:
     type: "string"
     primary-key: true
     description: "The form ID."
-    # foreign-key-id: "form-id"
+    foreign-key-id: "form-id"
     
   - name: "question_id"
     type: "string"

--- a/_saas-integrations/typeform/v1/typeform-v1.md
+++ b/_saas-integrations/typeform/v1/typeform-v1.md
@@ -35,7 +35,7 @@ repo-url: https://github.com/singer-io/tap-typeform
 this-version: "1"
 
 api: |
-  [{{ integration.display_name }} Responses API](https://developer.typeform.com/responses/){:target="new"}
+  [{{ integration.display_name }} Create](https://developer.typeform.com/create/){:target="new"} and [Responses](https://developer.typeform.com/responses/){:target="new"} APIs
 
 # -------------------------- #
 #       Stitch Details       #


### PR DESCRIPTION
This PR updates the Typeform (v1) docs to include the new `forms` table. (https://github.com/singer-io/tap-typeform/pull/29)