### PR TITLE
TDL-16557 updated doc for filter_dbs

### DIFF
--- a/_data/connect/common/database-sources.yml
+++ b/_data/connect/common/database-sources.yml
@@ -57,14 +57,6 @@ mysql:
     description: &database-description "The name of the logical database to connect to."
     value: "<DATABASE_NAME>"
 
-  - name: &filterdbs-name "filter_dbs"
-    required: false
-    read-only: false
-    internal: true
-    type: "string"
-    description: &internal-field "**This is an internal field and is for Stitch use only.**"
-    value: ""
-
 
 # -------------------------- #
 #    POSTGRESQL DATABASES    #
@@ -79,12 +71,12 @@ postgres:
     description: *database-description
     value: "<DATABASE_NAME>"
 
-  - name: *filterdbs-name
+  - name: &filterdbs-name "filter_dbs"
     required: true
     read-only: false
     internal: true
     type: "string"
-    description: *internal-field
+    description: &internal-field "**This is an internal field and is for Stitch use only.**"
     value: ""
 
   - name: "include_schemas_in_destination_stream_name"

--- a/_database-integrations/mysql/vanilla/mysql-v2.md
+++ b/_database-integrations/mysql/vanilla/mysql-v2.md
@@ -209,6 +209,15 @@ setup-steps:
         anchor: "define-default-replication-method"
         content: |
           {% include integrations/databases/setup/binlog/log-based-replication-default-setting.html %}
+      
+      - title: "Select databases to discover"
+        anchor: "filter-databases"
+        content: |
+          {% include note.html type="single-line" content="**Note**: Skip this step if you don't need to filter databases." %}
+
+          Enter database names under **Limit to the following databases** to select the databases that Stitch can discover.
+
+          If no database is specified, Stitch will discover all databases on the host.
 
       - title: "Create a replication schedule"
         anchor: "create-replication-schedule"

--- a/_database-integrations/mysql/vanilla/mysql-v2.md
+++ b/_database-integrations/mysql/vanilla/mysql-v2.md
@@ -210,7 +210,7 @@ setup-steps:
         content: |
           {% include note.html type="single-line" content="**Note**: Skip this step if you don't need to filter databases." %}
 
-          Enter a database name in the field under **Limit to the following databases** to select the database that Stitch can discover. You can add multiple database names by clicking **Add another database**.
+          Enter a database name in the field under **Filter databases in the source** to select the database that Stitch can discover. You can add multiple database names by clicking **Add another database**.
 
           If no database is specified, Stitch will discover all databases on the host.
 

--- a/_database-integrations/mysql/vanilla/mysql-v2.md
+++ b/_database-integrations/mysql/vanilla/mysql-v2.md
@@ -204,20 +204,20 @@ setup-steps:
         anchor: "ssl-connection-details"
         content: |
           {% include shared/database-connection-settings.html type="ssl" ssl-fields=true %}
-
-      - title: "Define the Log-based Replication setting"
-        anchor: "define-default-replication-method"
-        content: |
-          {% include integrations/databases/setup/binlog/log-based-replication-default-setting.html %}
       
       - title: "Select databases to discover"
         anchor: "filter-databases"
         content: |
           {% include note.html type="single-line" content="**Note**: Skip this step if you don't need to filter databases." %}
 
-          Enter database names under **Limit to the following databases** to select the databases that Stitch can discover.
+          Enter a database name in the field under **Limit to the following databases** to select the database that Stitch can discover. You can add multiple database names by clicking **Add another database**.
 
           If no database is specified, Stitch will discover all databases on the host.
+
+      - title: "Define the Log-based Replication setting"
+        anchor: "define-default-replication-method"
+        content: |
+          {% include integrations/databases/setup/binlog/log-based-replication-default-setting.html %}
 
       - title: "Create a replication schedule"
         anchor: "create-replication-schedule"

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/amazon-aurora-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/amazon-aurora-object.md
@@ -43,4 +43,12 @@ object-attributes:
 
       Unless set, this property will default to `true`.
     value: "true"
+  
+  - name: "filter_dbs"
+    required: false
+    read-only: false
+    internal: true
+    type: "string"
+    description: "**This is an internal field and is for Stitch use only.**"
+    value: ""
 ---

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/google-cloudsql-mysql.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/google-cloudsql-mysql.md
@@ -43,4 +43,12 @@ object-attributes:
 
       Unless set, this property will default to `true`.
     value: "true"
+  
+  - name: "filter_dbs"
+    required: false
+    read-only: false
+    internal: true
+    type: "string"
+    description: "**This is an internal field and is for Stitch use only.**"
+    value: ""
 ---

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/hp-mysql-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/hp-mysql-object.md
@@ -59,7 +59,7 @@ object-attributes:
     type: "string"
     required: false
     description: |
-      **Optional**: If `ssl_client_auth_enabled: true`, the SSL client authentication cerficiate stitch should use. The `ssl_key` property must also be provided to ensure the connection is successful.
+      **Optional**: If `ssl_client_auth_enabled: true`, the SSL client authentication cerficiate Stitch should use. The `ssl_key` property must also be provided to ensure the connection is successful.
     value: "<CA_CERTIFICATE>"
 
   - name: "ssl_key"
@@ -79,5 +79,17 @@ object-attributes:
       - `false'
 
       **Note**: If you don't want to use a custom CA, this property and the `check_hostname` property should both be enabled (`true`).
-    value: "true"        
+    value: "true"   
+    
+  - name: "filter_dbs"
+    required: false
+    read-only: false
+    internal: false
+    type: "string"
+    description: |
+      **Optional**: If you want to Stitch to discover specific databases, specify their names with this property. You can add a comma-separated list of databases in the string to filter on multiple databases.
+
+      If no value is specified, Stitch will discover all databases on the host.
+    value: "<DATABASE_NAME>,<OTHER_DATABASE_NAME>"
+     
 ---

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/hp-mysql-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/hp-mysql-object.md
@@ -85,11 +85,12 @@ object-attributes:
     required: false
     read-only: false
     internal: false
-    type: "string"
+    type: "array"
     description: |
-      **Optional**: If you want to Stitch to discover specific databases, specify their names with this property. You can add a comma-separated list of databases in the string to filter on multiple databases.
+      **Optional**: An array of strings that specifies the name of the databases that can be discovered by Stitch.
 
       If no value is specified, Stitch will discover all databases on the host.
-    value: "<DATABASE_NAME>,<OTHER_DATABASE_NAME>"
+    value: |
+      ["<DATABASE_NAME>", "<OTHER_DATABASE_NAME>"]
      
 ---

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/mariadb-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/mariadb-object.md
@@ -44,4 +44,13 @@ object-attributes:
 
       Unless set, this property will default to `true`.
     value: "true"
+    
+  - name: "filter_dbs"
+    required: false
+    read-only: false
+    internal: true
+    type: "string"
+    description: "**This is an internal field and is for Stitch use only.**"
+    value: ""
+
 ---

--- a/_developer-files/connect/api/objects/form-properties/sources/databases/mysql-object.md
+++ b/_developer-files/connect/api/objects/form-properties/sources/databases/mysql-object.md
@@ -100,4 +100,12 @@ object-attributes:
 
       **Note**: If you don't want to use a custom CA, this property and the `check_hostname` property should both be enabled (`true`).
     value: "true"
+  
+  - name: "filter_dbs"
+    required: false
+    read-only: false
+    internal: true
+    type: "string"
+    description: "**This is an internal field and is for Stitch use only.**"
+    value: ""
 ---


### PR DESCRIPTION
The `filter_dbs` field is now user-provided in hpt-mysql, so I removed this field from the common mysql fields, added it to all other mysql sources with the previous values and added it with the new values for hp-mysql.