### PR TITLE
Fix tap generate docs

### DIFF
--- a/scripts/tap-generate-docs/src/tap_generate_docs.clj
+++ b/scripts/tap-generate-docs/src/tap_generate_docs.clj
@@ -268,7 +268,7 @@
   {:pre [(tap-fs? tap-fs)]}
   (let [schema-path        (.relativize (.toPath tap-directory)
                                         (.toPath input-json-schema-file))
-        tap-version        (string/replace (string/trim (:out (sh "python" "setup.py" "--version" :dir tap-directory)))
+        tap-version (string/replace (string/trim (:out (sh "python3" "setup.py" "--version" :dir tap-directory)))
                                            #"^([0-9]+)\..+"
                                            "$1.x")
         stream-name        (string/replace (.getName input-json-schema-file) #".json$" "")
@@ -379,7 +379,7 @@
   [tap-directory]
   {:pre [(.exists tap-directory)]
    :post [(tap-fs? %)]}
-  (let [tap-name             (string/trim (:out (sh "python" "setup.py" "--name" :dir tap-directory)))
+  (let [tap-name             (string/trim (:out (sh "python3" "setup.py" "--name" :dir tap-directory)))
         tap-code-package-dir (io/file tap-directory (string/replace tap-name "-" "_"))
         tap-schema-dir       (let [tap-schema-dir (io/file tap-code-package-dir "schemas")]
                                (if (.exists tap-schema-dir)

--- a/scripts/tap-generate-docs/src/tap_generate_docs.clj
+++ b/scripts/tap-generate-docs/src/tap_generate_docs.clj
@@ -430,8 +430,10 @@
     (if (or (get-in parsed-args [:options :help])
             (not= 1 (count (parsed-args :arguments)))
             (not (try (cli-arg->tap-fs (first (parsed-args :arguments)))
-                      (catch Exception e)
-                      (catch Error e))))
+                      (catch Exception e
+                        (println e))
+                      (catch Error e
+                        (println e)))))
       (show-help parsed-args)
       (let [tap-fs       (cli-arg->tap-fs (first (parsed-args :arguments)))
             schema-files (:tap-schemas tap-fs)]

--- a/scripts/tap-generate-docs/src/tap_generate_docs.clj
+++ b/scripts/tap-generate-docs/src/tap_generate_docs.clj
@@ -323,7 +323,7 @@
                              1)))
                    "tap"                (string/replace tap-name "tap-" "")
                    "version"            tap-version
-                   "key"																""
+                   "key"                ""
                    "name"               stream-name
                    "doc-link"           ""
                    "singer-schema"      (format "https://github.com/singer-io/%s/blob/master/%s"


### PR DESCRIPTION
### Additions
- Print stack traces when the CLI arg parser fails

### Changes
- Uses `python3` instead of `python`
-  A previous commit added non-space whitespace characters to a line, so this changes those characters back to spaces

## QA Steps

### Error Logging
Before
```shell
2022-03-02T12:47:58
alu@biscuits
~/git/docs/scripts/tap-generate-docs (fix-tap-generate-docs *$%)
$ clojure -Sdeps "$(< deps.edn)" -m tap-generate-docs sailthru
tap-generate-docs   -h, --help  Show help  [<tap-name> | <tap-directory>]
```

After
```shell
2022-03-02T12:41:35
alu@biscuits
~/git/docs/scripts/tap-generate-docs (master *$%=)
$ clojure -Sdeps "$(< deps.edn)" -m tap-generate-docs sailthru
#error {
 :cause Schema directory does not exist
 :data {:tap-schema-dir #object[java.io.File 0x21090c88 /opt/code/tap-sailthru/schemas]}
 :via
 [{:type clojure.lang.ExceptionInfo
   :message Schema directory does not exist
   :data {:tap-schema-dir #object[java.io.File 0x21090c88 /opt/code/tap-sailthru/schemas]}
   :at [tap_generate_docs$tap_directory__GT_tap_fs invokeStatic tap_generate_docs.clj 382]}]
 :trace
 [[tap_generate_docs$tap_directory__GT_tap_fs invokeStatic tap_generate_docs.clj 382]
  [tap_generate_docs$tap_directory__GT_tap_fs invoke tap_generate_docs.clj 373]
  [tap_generate_docs$tap_name__GT_tap_fs invokeStatic tap_generate_docs.clj 395]
  [tap_generate_docs$tap_name__GT_tap_fs invoke tap_generate_docs.clj 391]
  [tap_generate_docs$cli_arg__GT_tap_fs$fn__1991 invoke tap_generate_docs.clj 401]
  [tap_generate_docs$cli_arg__GT_tap_fs invokeStatic tap_generate_docs.clj 401]
  [tap_generate_docs$cli_arg__GT_tap_fs invoke tap_generate_docs.clj 397]
  [tap_generate_docs$_main$fn__1998 invoke tap_generate_docs.clj 427]
  [tap_generate_docs$_main invokeStatic tap_generate_docs.clj 427]
  [tap_generate_docs$_main doInvoke tap_generate_docs.clj 423]
  [clojure.lang.RestFn applyTo RestFn.java 137]
  [clojure.lang.Var applyTo Var.java 705]
  [clojure.core$apply invokeStatic core.clj 665]
  [clojure.main$main_opt invokeStatic main.clj 514]
  [clojure.main$main_opt invoke main.clj 510]
  [clojure.main$main invokeStatic main.clj 664]
  [clojure.main$main doInvoke main.clj 616]
  [clojure.lang.RestFn applyTo RestFn.java 137]
  [clojure.lang.Var applyTo Var.java 705]
  [clojure.main main main.java 40]]}
tap-generate-docs   -h, --help  Show help  [<tap-name> | <tap-directory>]
```

### `python` vs `python3`

Python versions used
```shell
2022-03-02T12:49:00
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python -V
Python 2.7.18

2022-03-02T12:55:20
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python3 -V
Python 3.8.10
```

Before
```shell
2022-03-02T12:48:48
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python setup.py --name
Traceback (most recent call last):
  File "setup.py", line 1, in <module>
    from setuptools import find_packages, setup
ImportError: No module named setuptools

2022-03-02T12:48:53
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python setup.py --version
Traceback (most recent call last):
  File "setup.py", line 1, in <module>
    from setuptools import find_packages, setup
ImportError: No module named setuptools
```

After
```shell
2022-03-02T12:48:50
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python3 setup.py --name
tap-sailthru

2022-03-02T12:48:58
alu@biscuits
/opt/code/tap-sailthru (main=)
$ python3 setup.py --version
0.1.3
```

# Overall Changes
```sh