### PR TITLE
Free Trial Page & Top Nav update (v1)

### DIFF
--- a/_getting-started/free-trial.md
+++ b/_getting-started/free-trial.md
@@ -1,0 +1,47 @@
+---
+# -------------------------- #
+#          PAGE INFO         #
+# -------------------------- #
+
+title: Free Trial
+permalink: /getting-started/free-trial
+keywords: free trial, trial, test, talk to sales, demo, sales, signup, sign up,
+summary: "Are you interested in trying out Stitch for yourself? Do you have any sales-related questions? [Sign up for your free trial or talk to an expert](https://www.stitchdata.com/signup/)!"
+feedback: false
+
+layout: general
+sidebar: stitch
+toc: false
+
+key: "free-trial"
+weight: 5
+type: "all"
+
+# -------------------------- #
+#         PAGE  INTRO        #
+# -------------------------- #
+
+intro: |
+  Are you interested in giving Stitch a try? Do you have any sales-related questions? [Sign up for your free trial or talk to an expert](https://www.stitchdata.com/signup)!
+
+
+# -------------------------- #
+#      CONTENT SECTIONS      #
+# -------------------------- #
+
+sections:
+  - title: "Specified actions"
+    anchor: "action-steps"
+    content: ""
+    
+    subsections:
+      - title: "Ready to sign up?"
+        anchor: "sign-up"
+        content: |
+          Create your Stitch account and start your free trial [here](https://app.stitchdata.com/signup).
+
+      - title: "Have some more questions you need answered?"
+        anchor: "ask-expert"
+        content: |
+          Request to talk to an expert [here](https://www.app.stitchdata.com/signup/) to get your product and pricing questions answered.  
+---

--- a/_getting-started/free-trial.md
+++ b/_getting-started/free-trial.md
@@ -5,7 +5,7 @@
 
 title: Free Trial
 permalink: /getting-started/free-trial
-keywords: free trial, trial, test, talk to sales, demo, sales, signup, sign up,
+keywords: free trial, trial, test, talk to sales, demo, sales, signup, sign up
 summary: "Are you interested in trying out Stitch for yourself? Do you have any sales-related questions? [Sign up for your free trial or talk to an expert](https://www.stitchdata.com/signup/)!"
 feedback: false
 
@@ -13,7 +13,7 @@ layout: general
 sidebar: stitch
 toc: false
 
-key: "free-trial"
+key: "trial"
 weight: 5
 type: "all"
 

--- a/_includes/layout/topnav.html
+++ b/_includes/layout/topnav.html
@@ -33,7 +33,7 @@
                     {% endif %}
                 {% endfor %}
             {% endfor %}
-            <li class="sign-up"><a href="https://stitchdata.com/signup">Sign up</a></li>
+            <li class="sign-up"><a href="https://app.stitchdata.com/signup">Sign up</a></li>
             <li>
                 <!--start search-->
                 <div id="search-demo-container">


### PR DESCRIPTION
This PR includes:
- Updates the Stitch docs top navigation 'Sign Up' link to take you directly to the web app sign up page
- Create a 'Free Trial' page so that it comes up in the Intercom search results

There may be several launches/versions of this so that Marketing can test an analyze the effectiveness of the changes.