### PR TITLE
Bigquery V2 now uses our static IP addresses

### DIFF
--- a/_data/destinations/bigquery/v2/stitch-details.yml
+++ b/_data/destinations/bigquery/v2/stitch-details.yml
@@ -39,7 +39,7 @@ ssh: false
 
 vpn: false
 
-static-ip: false
+static-ip: true
 
 
 # ------------------------------ #


### PR DESCRIPTION
Last week I made a change, enabled by some recent infrastructure work, to enable the static IP addresses for BigQuery V2. That has been confirmed to be working, so this PR is to propagate that change to the documentation!