### PR TITLE
Update test script to work with `Clojure CLI version 1.11.1.1252`

### DIFF
--- a/scripts/tap-generate-docs/bin/test
+++ b/scripts/tap-generate-docs/bin/test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -C:test -m runner
+clj -A:test -M -m runner

--- a/scripts/tap-generate-docs/bin/test
+++ b/scripts/tap-generate-docs/bin/test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clj -A:test -M -m runner
+clojure -A:test -M -m runner


### PR DESCRIPTION
# Description of change
This PR fixes the following error

```shell
#!/bin/bash -eo pipefail cd scripts/tap-generate-docs/ bin/test
-C is no longer supported, use -A with repl, -M for main, -X for exec, -T for tool
```

I originally thought this was broken because the Docker image we use was updated recently. But just judging by the version numbers, I would've expected this to break a long time ago
- [Docker File History](https://github.com/Quantisan/docker-clojure/commits/6a44a1a9f0343fcd60cae124b92ff0041e479f96/target/eclipse-temurin-17-jdk-jammy/tools-deps/Dockerfile)

Not really worth digging into.

# Manual QA steps
 - Ran the failing command and the new command
 
# Risks
 - Low. It can't get more broken than it already is
 
# Rollback steps
 - revert this branch
