### PR TITLE
fix: Added missing `</li>` in the sidebar

### DIFF
--- a/_includes/layout/sidebars/on-page-sidebar.html
+++ b/_includes/layout/sidebars/on-page-sidebar.html
@@ -81,7 +81,7 @@
                     	{% endfor %}
                     {% endif %}
                 </ul>
-
+    	</li>
             {% else %}
             	<li>
             		<a href="#{{ section.anchor }}">
@@ -89,7 +89,6 @@
 		            </a>
 		        </li>
     		{% endif %}
-    	</li>
     {% endfor %}
 
     {% if page.related %}

--- a/_includes/layout/sidebars/on-page-sidebar.html
+++ b/_includes/layout/sidebars/on-page-sidebar.html
@@ -72,6 +72,7 @@
                                             </li>
                                         {% endfor %}
                                     </ul>
+				</li>
                             {% else %}
                         		<li>
                                     <a href="#{{ subsection.anchor }}">{{ subsection.title | flatify }}</a>


### PR DESCRIPTION
# Description of change
The HTML structure in the sidebar was missing a `</li>` in the lower levels of the list.

# Manual QA steps
Search for `#system-architecture--preparing--menu` in the HTML source of for instance the [Basic Concepts and System Overview](https://www.stitchdata.com/docs/getting-started/basic-concepts-system-overview) page – the parent `<li>` is not closed.
 
# Risks
 - Someone else has already found the problem and fixed it
 
# Rollback steps
 - revert this branch
