### PR TITLE
update wording to enable hubspot certification

### DIFF
--- a/_includes/notifications/status-support/support.html
+++ b/_includes/notifications/status-support/support.html
@@ -15,7 +15,7 @@
     <i class="fa fa-life-ring"></i>
     {% if integration.certified == true %}
         <strong>
-            {{ integration.display_name }} is supported by Stitch
+            {{ integration.display_name }} extraction is supported by Stitch
         </strong><br>
 
         {% if integration.singer == true %}


### PR DESCRIPTION
# Description of change
Feedback from HubSpot regarding out setup instructions for HubSpot:
>Please update the [setup guide](https://www.stitchdata.com/docs/integrations/saas/hubspot) to further distinguish your brand. For example, the portion “ HubSpot is supported by Stitch” may imply to customers that Stitch supports HubSpot. I recommend this to be updated to “ Stitch integration with HubSpot is supported by Stitch” or “Connection with HubSpot in Stitch is supported by Stitch.”

I have updated the text to indicate what we are supporting is the integration, not HubSpot themselves.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
